### PR TITLE
Fix memory leaks from valgrind

### DIFF
--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
@@ -46,8 +46,8 @@ static void mode_decision_context_dctor(EbPtr p) {
     EB_FREE_ARRAY(obj->candidate_buffer_tx_depth_2->candidate_ptr);
     EB_DELETE(obj->candidate_buffer_tx_depth_2);
     EB_DELETE(obj->trans_quant_buffers_ptr);
-    if (obj->hbd_mode_decision > EB_8_BIT_MD) EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon16bit);
-    if (obj->hbd_mode_decision != EB_10_BIT_MD) EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon);
+    EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon16bit);
+    EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon);
     if (obj->is_md_rate_estimation_ptr_owner) EB_FREE_ARRAY(obj->md_rate_estimation_ptr);
     EB_FREE_ARRAY(obj->fast_candidate_array);
     EB_FREE_ARRAY(obj->fast_candidate_ptr_array);
@@ -56,14 +56,10 @@ static void mode_decision_context_dctor(EbPtr p) {
     EB_FREE_ARRAY(obj->full_cost_skip_ptr);
     EB_FREE_ARRAY(obj->full_cost_merge_ptr);
     if (obj->md_local_blk_unit) {
-        if (obj->hbd_mode_decision > EB_8_BIT_MD) {
-            EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_left_recon_16bit[0]);
-            EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_top_recon_16bit[0]);
-        }
-        if (obj->hbd_mode_decision != EB_10_BIT_MD) {
-            EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_left_recon[0]);
-            EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_top_recon[0]);
-        }
+        EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_left_recon_16bit[0]);
+        EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_top_recon_16bit[0]);
+        EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_left_recon[0]);
+        EB_FREE_ARRAY(obj->md_local_blk_unit[0].neigh_top_recon[0]);
     }
     if (obj->md_blk_arr_nsq) {
         EB_FREE_ARRAY(obj->md_blk_arr_nsq[0].av1xd);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -144,20 +144,17 @@ void picture_control_set_dctor(EbPtr p) {
         EB_DELETE_PTR_ARRAY(obj->md_leaf_depth_neighbor_array[depth], tile_cnt);
         EB_DELETE_PTR_ARRAY(obj->mdleaf_partition_neighbor_array[depth], tile_cnt);
 
-        if (obj->hbd_mode_decision > EB_8_BIT_MD) {
-            EB_DELETE_PTR_ARRAY(obj->md_luma_recon_neighbor_array16bit[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_tx_depth_1_luma_recon_neighbor_array16bit[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_tx_depth_2_luma_recon_neighbor_array16bit[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_cb_recon_neighbor_array16bit[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_cr_recon_neighbor_array16bit[depth], tile_cnt);
-        }
-        if (obj->hbd_mode_decision != EB_10_BIT_MD) {
-            EB_DELETE_PTR_ARRAY(obj->md_luma_recon_neighbor_array[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_tx_depth_1_luma_recon_neighbor_array[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_tx_depth_2_luma_recon_neighbor_array[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_cb_recon_neighbor_array[depth], tile_cnt);
-            EB_DELETE_PTR_ARRAY(obj->md_cr_recon_neighbor_array[depth], tile_cnt);
-        }
+        EB_DELETE_PTR_ARRAY(obj->md_luma_recon_neighbor_array16bit[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_tx_depth_1_luma_recon_neighbor_array16bit[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_tx_depth_2_luma_recon_neighbor_array16bit[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_cb_recon_neighbor_array16bit[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_cr_recon_neighbor_array16bit[depth], tile_cnt);
+
+        EB_DELETE_PTR_ARRAY(obj->md_luma_recon_neighbor_array[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_tx_depth_1_luma_recon_neighbor_array[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_tx_depth_2_luma_recon_neighbor_array[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_cb_recon_neighbor_array[depth], tile_cnt);
+        EB_DELETE_PTR_ARRAY(obj->md_cr_recon_neighbor_array[depth], tile_cnt);
 
         EB_DELETE_PTR_ARRAY(obj->md_skip_coeff_neighbor_array[depth], tile_cnt);
         EB_DELETE_PTR_ARRAY(obj->md_luma_dc_sign_level_coeff_neighbor_array[depth], tile_cnt);


### PR DESCRIPTION
# Description
When FrameHeader::is_motion_mode_switchable is true then
obj->hbd_mode_decision can be changes during encoder work,
and then between alloc and free encoder the decision about alloc and free
was made on the basis of a different value.


# Issue
Valgrind memleaks

Cmd:  ./SvtAv1EncApp --lp 8 -i LG_Cymatic_Jazz_HDR_003_864x480_10bit_60Hz_P420_300frames.yuv -w 864 -h 480 --preset 0 -n 5 -b jazz0.ivf --input-depth 10 --lp 2

Valgrind output:
==296430== 560 bytes in 1 blocks are possibly lost in loss record 4 of 32
==296430==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==296430==    by 0x4012774: _dl_allocate_tls (in /usr/lib64/ld-2.17.so)
==296430==    by 0x5E4487B: pthread_create@@GLIBC_2.2.5 (in /usr/lib64/libpthread-2.17.so)
==296430==    by 0x4E85CA0: eb_create_thread (EbThreads.c:93)
==296430==    by 0x4F688B6: svt_av1_enc_init (EbEncHandle.c:1678)
==296430==    by 0x1130C4: init_encoder (EbAppContext.c:445)
==296430==    by 0x114A7D: encode (EbAppMain.c:180)
==296430==    by 0x10DEEA: main (EbAppMain.c:492)
==296430==
==296430== 560 bytes in 1 blocks are possibly lost in loss record 5 of 32
==296430==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==296430==    by 0x4012774: _dl_allocate_tls (in /usr/lib64/ld-2.17.so)
==296430==    by 0x5E4487B: pthread_create@@GLIBC_2.2.5 (in /usr/lib64/libpthread-2.17.so)
==296430==    by 0x4E85CA0: eb_create_thread (EbThreads.c:93)
==296430==    by 0x4F6892D: svt_av1_enc_init (EbEncHandle.c:1679)
==296430==    by 0x1130C4: init_encoder (EbAppContext.c:445)
==296430==    by 0x114A7D: encode (EbAppMain.c:180)
==296430==    by 0x10DEEA: main (EbAppMain.c:492)
==296430==
==296430== 560 bytes in 1 blocks are possibly lost in loss record 6 of 32
==296430==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==296430==    by 0x4012774: _dl_allocate_tls (in /usr/lib64/ld-2.17.so)
==296430==    by 0x5E4487B: pthread_create@@GLIBC_2.2.5 (in /usr/lib64/libpthread-2.17.so)
==296430==    by 0x4E85CA0: eb_create_thread (EbThreads.c:93)
==296430==    by 0x4F689AF: svt_av1_enc_init (EbEncHandle.c:1684)
==296430==    by 0x1130C4: init_encoder (EbAppContext.c:445)
==296430==    by 0x114A7D: encode (EbAppMain.c:180)
==296430==    by 0x10DEEA: main (EbAppMain.c:492)
[....]

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [X] memory
- [ ] speed
- [ ] 8 bit
- [X] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [X] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
