### PR TITLE
Fix mismatch C/AVX2 kernel svt_av1_apply_temporal_filter_planewise()

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
@@ -142,11 +142,11 @@ static void apply_temporal_filter_planewise(
 
     uint32_t acc_5x5_sse[BH][BW];
     // Larger noise -> larger filtering weight.
-    const float n_decay           = (float)decay_control * (0.7f + logf((float)sigma + 1.0f));
-    const float n_decay_qr_inv    = 1.0f / (2 * n_decay * n_decay);
-    const float block_balacne_inv = 1.0f / (TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1);
-    const float distance_threshold_inv =
-        1.0f / (float)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
+    const double n_decay                = (double)decay_control * (0.7 + log1p(sigma));
+    const double n_decay_qr_inv         = 1.0 / (2 * n_decay * n_decay);
+    const double block_balacne_inv      = 1.0 / (TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1);
+    const double distance_threshold_inv = 1.0 /
+        (double)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
 
     uint16_t *frame_sse =
         (plane == PLANE_TYPE_Y) ? luma_sq_error : chroma_sq_error;
@@ -228,19 +228,19 @@ static void apply_temporal_filter_planewise(
                 }
             }
             // Combine window error and block error, and normalize it.
-            float     window_error = (float)diff_sse / num_ref_pixels;
+            double    window_error = (double)diff_sse / num_ref_pixels;
             const int subblock_idx = (i >= block_height / 2) * 2 + (j >= block_width / 2);
-            float     block_error;
+            double    block_error;
             int       idx_32x32 = context_ptr->tf_block_col + context_ptr->tf_block_row * 2;
             if (context_ptr->tf_32x32_block_split_flag[idx_32x32])
                 // 16x16
                 block_error =
-                    (float)context_ptr->tf_16x16_block_error[idx_32x32 * 4 + subblock_idx] / 256.0f;
+                    (double)context_ptr->tf_16x16_block_error[idx_32x32 * 4 + subblock_idx] / 256.0;
             else
                 //32x32
-                block_error = (float)context_ptr->tf_32x32_block_error[idx_32x32] / 1024.0f;
+                block_error = (double)context_ptr->tf_32x32_block_error[idx_32x32] / 1024.0;
 
-            float combined_error =
+            double combined_error =
                 (TF_WINDOW_BLOCK_BALANCE_WEIGHT * window_error + block_error) * block_balacne_inv;
 
             // Decay factors for non-local mean approach.
@@ -260,12 +260,12 @@ static void apply_temporal_filter_planewise(
                 mv.col = context_ptr->tf_32x32_mv_x[idx_32x32];
                 mv.row = context_ptr->tf_32x32_mv_y[idx_32x32];
             }
-            const float distance = sqrtf(powf(mv.row, 2) + powf(mv.col, 2));
-            const float d_factor = AOMMAX(distance * distance_threshold_inv, 1);
+            const float distance = sqrtf((float)(mv.row * mv.row + mv.col * mv.col));
+            const double d_factor = AOMMAX(distance * distance_threshold_inv, 1);
 
             // Compute filter weight.
-            float scaled_diff     = AOMMIN(combined_error * d_factor * n_decay_qr_inv, 7);
-            int   adjusted_weight = (int)(expf(-scaled_diff) * TF_WEIGHT_SCALE);
+            double scaled_diff     = AOMMIN(combined_error * d_factor * n_decay_qr_inv, 7);
+            int    adjusted_weight = (int)(expf((float)(-scaled_diff)) * TF_WEIGHT_SCALE);
             // updated the index
             count[i * stride2 + j] += adjusted_weight;
             accumulator[i * stride2 + j] += adjusted_weight * pixel_value;
@@ -427,11 +427,11 @@ static void apply_temporal_filter_planewise_hbd(
 
     uint32_t     acc_5x5_sse[BH][BW];
     // Larger noise -> larger filtering weight.
-    const float n_decay           = (float)decay_control * (0.7f + logf((float)sigma + 1.0f));
-    const float n_decay_qr_inv    = 1.0f / (2 * n_decay * n_decay);
-    const float block_balacne_inv = 1.0f / (TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1);
-    const float distance_threshold_inv =
-        1.0f / (float)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
+    const double n_decay                = (double)decay_control * (0.7 + log1p((double)sigma));
+    const double n_decay_qr_inv         = 1.0 / (2 * n_decay * n_decay);
+    const double block_balacne_inv      = 1.0 / (TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1);
+    const double distance_threshold_inv = 1.0 /
+        (double)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
     uint32_t *   frame_sse = (plane == PLANE_TYPE_Y) ? luma_sq_error : chroma_sq_error;
 
     if (block_width == 32) {
@@ -504,20 +504,21 @@ static void apply_temporal_filter_planewise_hbd(
             }
             diff_sse >>= 4;
             // Combine window error and block error, and normalize it.
-            float     window_error = (float)diff_sse / num_ref_pixels;
+            double    window_error = (double)diff_sse / num_ref_pixels;
             const int subblock_idx = (i >= block_height / 2) * 2 + (j >= block_width / 2);
-            float     block_error;
+            double    block_error;
             int       idx_32x32 = context_ptr->tf_block_col + context_ptr->tf_block_row * 2;
             if (context_ptr->tf_32x32_block_split_flag[idx_32x32])
                 // 16x16
                 block_error =
-                    (float)(context_ptr->tf_16x16_block_error[idx_32x32 * 4 + subblock_idx] >> 4) /
-                    256.0f;
+                    (double)(context_ptr->tf_16x16_block_error[idx_32x32 * 4 + subblock_idx] >> 4) /
+                    256.0;
             else
                 //32x32
-                block_error = (float)(context_ptr->tf_32x32_block_error[idx_32x32] >> 4) / 1024.0f;
+                block_error = (double)(context_ptr->tf_32x32_block_error[idx_32x32] >> 4) /
+                    1024.0;
 
-            float combined_error =
+            double combined_error =
                 (TF_WINDOW_BLOCK_BALANCE_WEIGHT * window_error + block_error) * block_balacne_inv;
 
             // Decay factors for non-local mean approach.
@@ -537,12 +538,12 @@ static void apply_temporal_filter_planewise_hbd(
                 mv.col = context_ptr->tf_32x32_mv_x[idx_32x32];
                 mv.row = context_ptr->tf_32x32_mv_y[idx_32x32];
             }
-            const float distance = sqrtf(powf(mv.row, 2) + powf(mv.col, 2));
-            const float d_factor = AOMMAX(distance * distance_threshold_inv, 1);
+            const float distance = sqrtf((float)(mv.row * mv.row + mv.col * mv.col));
+            const double d_factor = AOMMAX(distance * distance_threshold_inv, 1);
 
             // Compute filter weight.
-            float scaled_diff     = AOMMIN(combined_error * d_factor * n_decay_qr_inv, 7.0f);
-            int   adjusted_weight = (int)(expf(-scaled_diff) * TF_WEIGHT_SCALE);
+            double scaled_diff     = AOMMIN(combined_error * d_factor * n_decay_qr_inv, 7.0);
+            int    adjusted_weight = (int)(expf((float)-scaled_diff) * TF_WEIGHT_SCALE);
             // updated the index
             count[i * stride2 + j] += adjusted_weight;
             accumulator[i * stride2 + j] += adjusted_weight * pixel_value;

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -1036,7 +1036,7 @@ void svt_av1_apply_temporal_filter_planewise_c(
                 mv.col = context_ptr->tf_32x32_mv_x[idx_32x32];
                 mv.row = context_ptr->tf_32x32_mv_y[idx_32x32];
             }
-            const double distance = sqrt(pow(mv.row, 2) + pow(mv.col, 2));
+            const float distance = sqrtf(powf(mv.row, 2) + powf(mv.col, 2));
             const double distance_threshold =
                 (double)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
             const double d_factor = AOMMAX(distance / distance_threshold, 1);
@@ -1044,7 +1044,7 @@ void svt_av1_apply_temporal_filter_planewise_c(
             // Compute filter weight.
             double scaled_diff =
                 AOMMIN(combined_error * d_factor / (2*n_decay*n_decay) / q_decay / s_decay, 7);
-            int adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+            int adjusted_weight = (int)(expf((float)(-scaled_diff)) * TF_WEIGHT_SCALE);
             k = i * y_pre_stride + j;
             y_count[k] += adjusted_weight;
             y_accum[k] += adjusted_weight * pixel_value;
@@ -1094,7 +1094,7 @@ void svt_av1_apply_temporal_filter_planewise_c(
                 // Compute filter weight.
                 scaled_diff =
                     AOMMIN(combined_error * d_factor / (2*n_decay*n_decay) / q_decay / s_decay, 7);
-                adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+                adjusted_weight = (int)(expf((float)(-scaled_diff)) * TF_WEIGHT_SCALE);
                 u_count[m] += adjusted_weight;
                 u_accum[m] += adjusted_weight * u_pixel_value;
 
@@ -1111,13 +1111,14 @@ void svt_av1_apply_temporal_filter_planewise_c(
                 // Compute filter weight.
                 scaled_diff =
                 AOMMIN(combined_error * d_factor / (2 * n_decay*n_decay) / q_decay / s_decay, 7);
-                adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+                adjusted_weight = (int)(expf((float)(-scaled_diff)) * TF_WEIGHT_SCALE);
                 v_count[m] += adjusted_weight;
                 v_accum[m] += adjusted_weight * v_pixel_value;
             }
         }
     }
 }
+
 /***************************************************************************************************
 * Applies temporal filter plane by plane for hbd
 * Inputs:
@@ -1225,7 +1226,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_c(
                 mv.col = context_ptr->tf_32x32_mv_x[idx_32x32];
                 mv.row = context_ptr->tf_32x32_mv_y[idx_32x32];
             }
-            const double distance = sqrt(pow(mv.row, 2) + pow(mv.col, 2));
+            const float  distance = sqrtf(powf(mv.row, 2) + powf(mv.col, 2));
             const double distance_threshold =
                 (double)AOMMAX(context_ptr->min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
             const double d_factor = AOMMAX(distance / distance_threshold, 1);
@@ -1233,7 +1234,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_c(
             // Compute filter weight.
             double scaled_diff =
                 AOMMIN(combined_error * d_factor / (2 * n_decay*n_decay) / q_decay / s_decay, 7);
-            int adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+            int adjusted_weight = (int)(expf((float)-scaled_diff) * TF_WEIGHT_SCALE);
             k = i * y_pre_stride + j;
             y_count[k] += adjusted_weight;
             y_accum[k] += adjusted_weight * pixel_value;
@@ -1286,7 +1287,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_c(
                 // Compute filter weight.
                 scaled_diff =
                     AOMMIN(combined_error * d_factor / (2 * n_decay*n_decay) / q_decay / s_decay, 7);
-                adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+                adjusted_weight = (int)(expf((float)-scaled_diff) * TF_WEIGHT_SCALE);
                 u_count[m] += adjusted_weight;
                 u_accum[m] += adjusted_weight * u_pixel_value;
 
@@ -1303,7 +1304,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_c(
                 // Compute filter weight.
                 scaled_diff =
                     AOMMIN(combined_error * d_factor / (2 * n_decay*n_decay) / q_decay / s_decay, 7);
-                adjusted_weight = (int)(exp(-scaled_diff) * TF_WEIGHT_SCALE);
+                adjusted_weight = (int)(expf((float)-scaled_diff) * TF_WEIGHT_SCALE);
                 v_count[m] += adjusted_weight;
                 v_accum[m] += adjusted_weight * v_pixel_value;
             }


### PR DESCRIPTION


# Description
Calculation double/float in some cases can return different value.

# Issue
#1428 

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Slawomir Pawlowski

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
