### PR TITLE
LtoWarnings: Fix some warnings that appear when trying to use lto

### DIFF
--- a/Source/Lib/Encoder/Codec/EbCodingLoop.h
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.h
@@ -353,6 +353,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     PictureControlSet *pcs_ptr,
     ModeDecisionContext *context_ptr,
     EbEncMode mode_offset);
+
+void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
+                        EbPictureBufferDesc *input_picture_ptr);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.h
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.h
@@ -356,6 +356,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                         EbPictureBufferDesc *input_picture_ptr);
+void perform_md_reference_pruning(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
+                                  EbPictureBufferDesc *input_picture_ptr);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.h
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.h
@@ -140,6 +140,9 @@ const uint8_t *eb_av1_get_obmc_mask(int length);
 
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 
+void model_rd_from_sse(BlockSize bsize, int16_t quantizer, uint8_t bit_depth, uint64_t sse,
+                       uint32_t *rate, uint64_t *dist);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -525,7 +525,7 @@ void choose_best_av1_mv_pred(ModeDecisionContext *           context_ptr,
         return;
     }
     uint8_t  drli, max_drl_index;
-    IntMv    nearestmv[2];
+    IntMv    nearestmv[2] = {{0}};
     IntMv    nearmv[2];
     IntMv    ref_mv[2];
     uint32_t best_mv_cost = 0xFFFFFFFF;

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -17,6 +17,7 @@
 #include "EbCommonUtils.h"
 #include "aom_dsp_rtcd.h"
 #include "EbLog.h"
+#include "EbEncInterPrediction.h"
 
 #include <assert.h>
 #define FIRST_PASS_COST_PENALTY 20 // The penalty is added in cost calculation of the first pass.
@@ -545,13 +546,6 @@ int av1_filter_intra_allowed_bsize(uint8_t enable_filter_intra, BlockSize bs);
 int av1_filter_intra_allowed(uint8_t enable_filter_intra, BlockSize bsize, uint8_t palette_size,
                              uint32_t mode);
 
-/*static*/ void model_rd_from_sse(BlockSize bsize, int16_t quantizer,
-                                  //const Av1Comp *const cpi,
-                                  //const MacroBlockD *const xd,
-                                  //BlockSize bsize,
-                                  //int32_t plane,
-                                  uint64_t sse, uint32_t *rate, uint64_t *dist);
-
 uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
                              uint64_t luma_distortion, uint64_t chroma_distortion, uint64_t lambda,
                              EbBool use_ssd, PictureControlSet *pcs_ptr, CandidateMv *ref_mv_stack,
@@ -769,13 +763,23 @@ uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
             Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq_bd;
             int16_t quantizer = dequants->y_dequant_q3[current_q_index][1];
             rate              = 0;
-            model_rd_from_sse(blk_geom->bsize, quantizer, luma_distortion, &rate, &luma_sad);
+
+            model_rd_from_sse(blk_geom->bsize,
+                              quantizer,
+                              scs_ptr->encoder_bit_depth,
+                              luma_distortion,
+                              &rate,
+                              &luma_sad);
             luma_rate += rate;
             total_distortion = luma_sad;
 
             rate = 0;
-            model_rd_from_sse(
-                blk_geom->bsize_uv, quantizer, chroma_distortion, &chroma_rate, &chromasad_);
+            model_rd_from_sse(blk_geom->bsize_uv,
+                              quantizer,
+                              scs_ptr->encoder_bit_depth,
+                              chroma_distortion,
+                              &chroma_rate,
+                              &chromasad_);
             chroma_rate += rate;
             total_distortion += chromasad_;
 
@@ -1615,13 +1619,22 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
 
         int16_t quantizer = dequants->y_dequant_q3[current_q_index][1];
         rate              = 0;
-        model_rd_from_sse(blk_geom->bsize, quantizer, luma_distortion, &rate, &luma_sad);
+        model_rd_from_sse(blk_geom->bsize,
+                          quantizer,
+                          pcs_ptr->parent_pcs_ptr->scs_ptr->encoder_bit_depth,
+                          luma_distortion,
+                          &rate,
+                          &luma_sad);
         luma_rate += rate;
         total_distortion = luma_sad;
 
         rate = 0;
-        model_rd_from_sse(
-            blk_geom->bsize_uv, quantizer, chroma_distortion, &chroma_rate, &chromasad_);
+        model_rd_from_sse(blk_geom->bsize_uv,
+                          quantizer,
+                          pcs_ptr->parent_pcs_ptr->scs_ptr->encoder_bit_depth,
+                          chroma_distortion,
+                          &chroma_rate,
+                          &chromasad_);
         chroma_rate += rate;
         total_distortion += chromasad_;
 

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -929,9 +929,6 @@ void product_coding_loop_init_fast_loop(ModeDecisionContext *context_ptr,
                                         NeighborArrayUnit *  mode_type_neighbor_array,
                                         NeighborArrayUnit *  leaf_depth_neighbor_array,
                                         NeighborArrayUnit *  leaf_partition_neighbor_array);
-void perform_md_reference_pruning(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
-                         EbPictureBufferDesc *input_picture_ptr, uint32_t blk_origin_index);
-
 // inject intra candidates for first pass
 void  first_pass_inject_intra_candidates(
     ModeDecisionContext          *context_ptr,
@@ -1369,7 +1366,7 @@ extern void first_pass_md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionC
         read_refine_me_mvs(pcs_ptr, context_ptr, input_picture_ptr);
     if (context_ptr->ref_pruning_ctrls.enabled)
         // Perform md reference pruning
-        perform_md_reference_pruning(pcs_ptr, context_ptr, input_picture_ptr, blk_origin_index);
+        perform_md_reference_pruning(pcs_ptr, context_ptr, input_picture_ptr);
     context_ptr->inject_inter_candidates = 1;
     first_pass_generate_md_stage_0_cand(
      context_ptr, &fast_candidate_total_count, pcs_ptr);

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -929,9 +929,6 @@ void product_coding_loop_init_fast_loop(ModeDecisionContext *context_ptr,
                                         NeighborArrayUnit *  mode_type_neighbor_array,
                                         NeighborArrayUnit *  leaf_depth_neighbor_array,
                                         NeighborArrayUnit *  leaf_partition_neighbor_array);
-void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
-    EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
-    uint32_t blk_origin_index);
 void perform_md_reference_pruning(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                          EbPictureBufferDesc *input_picture_ptr, uint32_t blk_origin_index);
 
@@ -1369,11 +1366,10 @@ extern void first_pass_md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionC
     }
     // Read and (if needed) perform 1/8 Pel ME MVs refinement
     if (pcs_ptr->slice_type != I_SLICE)
-        read_refine_me_mvs(
-            pcs_ptr, context_ptr, input_picture_ptr, input_origin_index, blk_origin_index);
+        read_refine_me_mvs(pcs_ptr, context_ptr, input_picture_ptr);
     if (context_ptr->ref_pruning_ctrls.enabled)
-    // Perform md reference pruning
-    perform_md_reference_pruning(pcs_ptr, context_ptr, input_picture_ptr, blk_origin_index);
+        // Perform md reference pruning
+        perform_md_reference_pruning(pcs_ptr, context_ptr, input_picture_ptr, blk_origin_index);
     context_ptr->inject_inter_candidates = 1;
     first_pass_generate_md_stage_0_cand(
      context_ptr, &fast_candidate_total_count, pcs_ptr);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3630,6 +3630,7 @@ static EbErrorType allocate_frame_buffer(
     input_pic_buf_desc_init_data.split_mode = is_16bit ? EB_TRUE : EB_FALSE;
 
     input_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+    input_pic_buf_desc_init_data.is_16bit_pipeline = 0;
 
     if (is_16bit && config->compressed_ten_bit_format == 1)
         //do special allocation for 2bit data down below.

--- a/third_party/fastfeat/fast.c
+++ b/third_party/fastfeat/fast.c
@@ -6,7 +6,7 @@
 xy* svt_aom_fast9_detect_nonmax(const byte* im, int xsize, int ysize, int stride, int b, int* ret_num_corners)
 {
     xy* corners;
-    int num_corners;
+    int num_corners = 0;
     int* scores;
     xy* nonmax;
 


### PR DESCRIPTION
# Description

Fixes warnings such as:

```c
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c:548:17: warning: type of ‘model_rd_from_sse’ does not match original declaration [-Wlto-type-mismatch]
  548 | /*static*/ void model_rd_from_sse(BlockSize bsize, int16_t quantizer,
      |                 ^
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2977:6: note: type mismatch in parameter 3
 2977 | void model_rd_from_sse(BlockSize bsize, int16_t quantizer, uint8_t bit_depth, uint64_t sse,
      |      ^
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2977:6: note: type ‘uint8_t’ should match type ‘uint64_t’
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2977:6: note: ‘model_rd_from_sse’ was previously declared here
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2977:6: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
../Source/Lib/Encoder/Codec/firstpass.c:932:6: warning: type of ‘read_refine_me_mvs’ does not match original declaration [-Wlto-type-mismatch]
  932 | void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
      |      ^
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2422:6: note: type mismatch in parameter 4
 2422 | void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
      |      ^
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2422:6: note: type ‘void’ should match type ‘uint32_t’
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2422:6: note: ‘read_refine_me_mvs’ was previously declared here
../Source/Lib/Encoder/Codec/firstpass.c:935:6: warning: type of ‘perform_md_reference_pruning’ does not match original declaration [-Wlto-type-mismatch]
  935 | void perform_md_reference_pruning(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
      |      ^
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2548:6: note: type mismatch in parameter 4
 2548 | void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
      |      ^
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2548:6: note: type ‘void’ should match type ‘uint32_t’
../Source/Lib/Encoder/Codec/EbProductCodingLoop.c:2548:6: note: ‘perform_md_reference_pruning’ was previously declared here
../Source/Lib/Encoder/Codec/EbModeDecision.c: In function ‘choose_best_av1_mv_pred.constprop’:
../Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1283:15: warning: ‘MEM[(union IntMv *)&nearestmv + 4B]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1283 |     ref_mv[1] = nearestmv[1];
      |               ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c: In function ‘av1_intra_fast_cost’:
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2993:9: warning: ‘dist’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2993 |         eb_av1_model_rd_from_var_lapndz((uint64_t)sse,
      |         ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c:555:10: note: ‘dist’ was declared here
  555 | uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
      |          ^
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2993:9: warning: ‘dist’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2993 |         eb_av1_model_rd_from_var_lapndz((uint64_t)sse,
      |         ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c:555:10: note: ‘dist’ was declared here
  555 | uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
      |          ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c: In function ‘av1_inter_fast_cost’:
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2993:9: warning: ‘dist’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2993 |         eb_av1_model_rd_from_var_lapndz((uint64_t)sse,
      |         ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c:1330:10: note: ‘dist’ was declared here
 1330 | uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
      |          ^
../Source/Lib/Encoder/Codec/EbEncInterPrediction.c:2993:9: warning: ‘dist’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2993 |         eb_av1_model_rd_from_var_lapndz((uint64_t)sse,
      |         ^
../Source/Lib/Encoder/Codec/EbRateDistortionCost.c:1330:10: note: ‘dist’ was declared here
 1330 | uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
      |          ^
```

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
