### PR TITLE
fix typo in build.sh example

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -82,7 +82,7 @@ Usage: $0 [OPTION] ... -- [OPTIONS FOR CMAKE]
 
 Example usage:
     build.sh -xi debug test
-    build.sh jobs=8 all cc=clang cpp=clang++
+    build.sh jobs=8 all cc=clang cxx=clang++
     build.sh -j 4 all -t "https://gist.githubusercontent.com/peterspackman/8cf73f7f12ba270aa8192d6911972fe8/raw/mingw-w64-x86_64.cmake"
     build.sh generator=Xcode cc=clang
 EOF


### PR DESCRIPTION
# Description
a compilation example in `build.sh` didn't work, because it referenced a non-existing flag - `cpp`.
I changed the flag to `cxx` which does work, and is documented in the usage message.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
nodeav

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
