### PR TITLE
Documentation: Fix inaccurate default --keyint value

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -189,7 +189,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 #### Keyframe Placement Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |
 | --- | --- | --- | --- | --- |
-| **IntraPeriod** | --keyint | [-2 - 255] | -1 | Intra period interval(frames) -2: default intra period , -1: No intra update or [0-255] |
+| **IntraPeriod** | --keyint | [-2 - 255] | -2 | Intra period interval(frames) -2: default intra period , -1: No intra update or [0-255] |
 | **IntraRefreshType** | --irefresh-type | [1 - 2] | 1 | 1: CRA (Open GOP)2: IDR (Closed GOP) |
 
 #### AV1 Specific Options


### PR DESCRIPTION
# Description

Fix inaccurate documentation re: default --keyint value. The default value is -2; the docs say it is -1.

To confirm, simply run:
`SvtAv1EncApp.exe -i in.y4m --lp 1 --rc 0 -q 50 --keyint -2 -b keyint-2.ivf`
`SvtAv1EncApp.exe -i in.y4m --lp 1 --rc 0 -q 50 --keyint -1 -b keyint-1.ivf`
`SvtAv1EncApp.exe -i in.y4m --lp 1 --rc 0 -q 50 -b keyint-default.ivf`

and compare results/filesizes. Also, see https://github.com/AOMediaCodec/SVT-AV1/blob/master/Source/App/EncApp/EbAppConfig.c#L1430

# Author(s)

motbob

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [ ] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [X] N/A

# Merge method
- [X] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch