### PR TITLE
avx2: eb_av1_haar_ac_sad_8x8_uint8_input_avx2, fix unaligned mov for transpose_32bit_8x8_avx2

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
@@ -12,7 +12,7 @@
 #include "transpose_avx2.h"
 
 int eb_av1_haar_ac_sad_8x8_uint8_input_avx2(uint8_t *input, int stride, int hbd) {
-    int32_t output[64];
+    DECLARE_ALIGNED(32, int32_t, output[64]);
 
     int32_t *out_ptr = output;
     int      i;


### PR DESCRIPTION

# Description
steps to reproduce:
1. build with debug. "mkdir build && cd build && cmake ..  -DCMAKE_BUILD_TYPE=Debug && make install"
2. run "SvtAv1EncApp -lp 4 -lad 0 -q 20 -n 3 -intra-period 119 -i ~/bits/SVT/vidyo_720p.y4m -b two_passes.ivf --passes 2 --preset 3"
3. you will see a core dump.

details:
We need declare the output as 32 bytes aligned since transpose_32bit_8x8_avx2 will unref it as __m256i*


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
