### PR TITLE
Block 2-pass VBR when used with --rc 2 / 3

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1393,20 +1393,6 @@ ConfigEntry config_entry[] = {
 /**********************************
  * Constructor
  **********************************/
-void eb_2pass_config_update(EbConfig *config_ptr) {
-    if (config_ptr->pass == ENCODE_FIRST_PASS || config_ptr->output_stat_file) {
-        config_ptr->enc_mode = MAX_ENC_PRESET;
-        config_ptr->look_ahead_distance = 1;
-        config_ptr->enable_tpl_la = 0;
-        config_ptr->intra_refresh_type     = 2;
-    }
-    else if (config_ptr->pass == ENCODE_LAST_PASS || config_ptr->input_stat_file) {
-        config_ptr->look_ahead_distance = 16;
-        config_ptr->enable_tpl_la = 1;
-        config_ptr->intra_refresh_type     = 2;
-    }
-    return;
-}
 EbConfig * eb_config_ctor(EncodePass pass) {
     EbConfig *config_ptr = (EbConfig *)calloc(1, sizeof(EbConfig));
     if (!config_ptr)

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1402,7 +1402,6 @@ EbConfig * eb_config_ctor(EncodePass pass) {
         config_ptr->pass = 1;
     else if (pass == ENCODE_LAST_PASS)
         config_ptr->pass = 2;
-    eb_2pass_config_update(config_ptr);
 
     config_ptr->error_log_file         = stderr;
     config_ptr->frame_rate             = 30 << 16;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1398,7 +1398,6 @@ void eb_2pass_config_update(EbConfig *config_ptr) {
         config_ptr->enc_mode = MAX_ENC_PRESET;
         config_ptr->look_ahead_distance = 1;
         config_ptr->enable_tpl_la = 0;
-        config_ptr->rate_control_mode = 0;
         config_ptr->intra_refresh_type     = 2;
     }
     else if (config_ptr->pass == ENCODE_LAST_PASS || config_ptr->input_stat_file) {

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -507,7 +507,6 @@ typedef struct EncApp {
 
 EbConfig * eb_config_ctor(EncodePass pass);
 void eb_config_dtor(EbConfig *config_ptr);
-void eb_2pass_config_update(EbConfig *config_ptr);
 
 EbErrorType enc_channel_ctor(EncChannel* c, EncodePass pass);
 void enc_channel_dctor(EncChannel* c);

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -79,7 +79,6 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
 
     // Assign Instance index to the library
     callback_data->instance_idx = (uint8_t)instance_idx;
-     eb_2pass_config_update(config);
     // Initialize Port Activity Flags
     callback_data->output_stream_port_active                = APP_PortActive;
     callback_data->eb_enc_parameters.source_width           = config->source_width;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -135,13 +135,6 @@ static EbErrorType enc_context_ctor(EncApp* enc_app, EncContext* enc_context, in
             start_time((uint64_t *)&config->performance_context.lib_start_time[0],
                         (uint64_t *)&config->performance_context.lib_start_time[1]);
 
-            if (pass == ENCODE_FIRST_PASS) {
-                //TODO: remove this if we can use a quick first pass in svt av1 library.
-                config->enc_mode = MAX_ENC_PRESET;
-                config->look_ahead_distance = 1;
-                config->enable_tpl_la = 0;
-                config->rate_control_mode = 0;
-            }
             c->return_error = set_two_passes_stats(config, pass,
                 &enc_app->rc_twopasses_stats, num_channels);
             if (c->return_error == EB_ErrorNone) {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2443,7 +2443,7 @@ static EbErrorType verify_settings(
     }
 
     if (config->rate_control_mode > 1 && (config->rc_firstpass_stats_out || config->rc_twopass_stats_in.buf)) {
-        SVT_LOG("Error Instance %u: Only rate control mode 0 and 1 is supported for 2-pass \n", channel_number + 1);
+        SVT_LOG("Error Instance %u: Only rate control mode 0 and 1 are supported for 2-pass \n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2429,6 +2429,11 @@ static EbErrorType verify_settings(
         return_error = EB_ErrorBadParameter;
     }
 
+    if (config->rate_control_mode > 1 && (config->rc_firstpass_stats_out || config->rc_twopass_stats_in.buf)) {
+        SVT_LOG("Error Instance %u: Only rate control mode 0 and 1 is supported for 2-pass \n", channel_number + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
     if (config->enable_hme_flag) {
         if ((config->number_hme_search_region_in_width > (uint32_t)EB_HME_SEARCH_AREA_COLUMN_MAX_COUNT) || (config->number_hme_search_region_in_width == 0)) {
             SVT_LOG("Error Instance %u: Invalid number_hme_search_region_in_width. number_hme_search_region_in_width must be [1 - %d]\n", channel_number + 1, EB_HME_SEARCH_AREA_COLUMN_MAX_COUNT);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -1950,6 +1950,19 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     scs_ptr->static_config.source_width = scs_ptr->max_input_luma_width;
     scs_ptr->static_config.source_height = scs_ptr->max_input_luma_height;
 
+    if (use_output_stat(scs_ptr)) {
+        scs_ptr->static_config.enc_mode = MAX_ENC_PRESET;
+        scs_ptr->static_config.look_ahead_distance = 1;
+        scs_ptr->static_config.enable_tpl_la = 0;
+        scs_ptr->static_config.rate_control_mode = 0;
+        scs_ptr->static_config.intra_refresh_type     = 2;
+    }
+    else if (use_input_stat(scs_ptr)) {
+        scs_ptr->static_config.look_ahead_distance = 16;
+        scs_ptr->static_config.enable_tpl_la = 1;
+        scs_ptr->static_config.intra_refresh_type     = 2;
+    }
+
     derive_input_resolution(
         &scs_ptr->input_resolution,
         scs_ptr->seq_header.max_frame_width*scs_ptr->seq_header.max_frame_height);


### PR DESCRIPTION
# Description
 At this point 2-pass only works when used with --rc 0 / 1.
- added check to handle the case where 2-pass is used with rc > 1
- removed code that manually overrides what rc was set to on the command line for first pass

# Issue
Fixes #1483

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@paulsgh
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
