### PR TITLE
EncApp: Refact, split encode function to smaller functions.

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1407,8 +1407,17 @@ void eb_2pass_config_update(EbConfig *config_ptr) {
     }
     return;
 }
-void eb_config_ctor(EbConfig *config_ptr) {
-    memset(config_ptr, 0, sizeof(*config_ptr));
+EbConfig * eb_config_ctor(EncodePass pass) {
+    EbConfig *config_ptr = (EbConfig *)calloc(1, sizeof(EbConfig));
+    if (!config_ptr)
+        return NULL;
+
+    if (pass == ENCODE_FIRST_PASS)
+        config_ptr->pass = 1;
+    else if (pass == ENCODE_LAST_PASS)
+        config_ptr->pass = 2;
+    eb_2pass_config_update(config_ptr);
+
     config_ptr->error_log_file         = stderr;
     config_ptr->frame_rate             = 30 << 16;
     config_ptr->encoder_bit_depth      = 8;
@@ -1513,13 +1522,15 @@ void eb_config_ctor(EbConfig *config_ptr) {
 
     config_ptr->pass = DEFAULT;
 
-    return;
+    return config_ptr;
 }
 
 /**********************************
  * Destructor
  **********************************/
 void eb_config_dtor(EbConfig *config_ptr) {
+    if (!config_ptr)
+        return;
     // Close any files that are open
     if (config_ptr->config_file) {
         fclose(config_ptr->config_file);
@@ -1566,6 +1577,7 @@ void eb_config_dtor(EbConfig *config_ptr) {
         config_ptr->stat_file = (FILE *)NULL;
     }
     free((void*)config_ptr->stats);
+    free(config_ptr);
     return;
 }
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1589,6 +1589,11 @@ EbErrorType enc_channel_ctor(EncChannel* c, EncodePass pass) {
     c->app_callback = (EbAppContext *)malloc(sizeof(EbAppContext));
     if (!c->app_callback)
         return EB_ErrorInsufficientResources;
+    c->exit_cond        = APP_ExitConditionError;
+    c->exit_cond_output = APP_ExitConditionError;
+    c->exit_cond_recon  = APP_ExitConditionError;
+    c->exit_cond_input  = APP_ExitConditionError;
+    c->active = EB_FALSE;
     return EB_ErrorNone;
 }
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -488,6 +488,14 @@ typedef struct EbConfig {
     int                 mrp_level;
 } EbConfig;
 
+typedef struct EncChannel {
+    AppExitConditionType exit_cond_output; // Processing loop exit condition
+    AppExitConditionType exit_cond_recon; // Processing loop exit condition
+    AppExitConditionType exit_cond_input; // Processing loop exit condition
+    AppExitConditionType exit_cond; // Processing loop exit condition
+    EbBool active;
+} EncChannel;
+
 typedef struct EncApp {
     SvtAv1FixedBuf rc_twopasses_stats;
 } EncApp;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -16,6 +16,8 @@
 
 #include "EbSvtAv1Enc.h"
 
+typedef struct EbAppContext_ EbAppContext;
+
 #ifdef _WIN32
 #define fseeko _fseeki64
 #define ftello _ftelli64
@@ -489,6 +491,9 @@ typedef struct EbConfig {
 } EbConfig;
 
 typedef struct EncChannel {
+    EbConfig        *config; // Encoder Configuration
+    EbAppContext    *app_callback; // Instances App callback date
+    EbErrorType     return_error; // Error Handling
     AppExitConditionType exit_cond_output; // Processing loop exit condition
     AppExitConditionType exit_cond_recon; // Processing loop exit condition
     AppExitConditionType exit_cond_input; // Processing loop exit condition
@@ -504,8 +509,11 @@ EbConfig * eb_config_ctor(EncodePass pass);
 void eb_config_dtor(EbConfig *config_ptr);
 void eb_2pass_config_update(EbConfig *config_ptr);
 
-extern EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **config,
-                                     uint32_t num_channels, EbErrorType *return_errors,
+EbErrorType enc_channel_ctor(EncChannel* c, EncodePass pass);
+void enc_channel_dctor(EncChannel* c);
+
+extern EbErrorType read_command_line(int32_t argc, char *const argv[], EncChannel *channels,
+                                     uint32_t num_channels,
                                      char *warning_str[WARNING_LENGTH]);
 extern uint32_t    get_help(int32_t argc, char *const argv[]);
 extern uint32_t    get_number_of_channels(int32_t argc, char *const argv[]);

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -492,9 +492,9 @@ typedef struct EncApp {
     SvtAv1FixedBuf rc_twopasses_stats;
 } EncApp;
 
-extern void eb_2pass_config_update(EbConfig *config_ptr);
-extern void eb_config_ctor(EbConfig *config_ptr);
-extern void eb_config_dtor(EbConfig *config_ptr);
+EbConfig * eb_config_ctor(EncodePass pass);
+void eb_config_dtor(EbConfig *config_ptr);
+void eb_2pass_config_update(EbConfig *config_ptr);
 
 extern EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **config,
                                      uint32_t num_channels, EbErrorType *return_errors,

--- a/Source/App/EncApp/EbAppContext.h
+++ b/Source/App/EncApp/EbAppContext.h
@@ -19,7 +19,7 @@
 
  * App Callback data struct
  ***************************************/
-typedef struct EbAppContext {
+struct EbAppContext_ {
     EbSvtAv1EncConfiguration eb_enc_parameters;
 
     // Output Ports Active Flags
@@ -34,7 +34,7 @@ typedef struct EbAppContext {
 
     // Instance Index
     uint8_t instance_idx;
-} EbAppContext;
+};
 
 /********************************
  * External Function

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -87,6 +87,7 @@ typedef struct EncContext {
     EbAppContext    *app_callbacks[MAX_CHANNEL_NUMBER]; // Instances App callback date
     char            *warning[MAX_NUM_TOKENS];
     EbErrorType     return_errors[MAX_CHANNEL_NUMBER]; // Error Handling
+    AppExitConditionType exit_cond[MAX_CHANNEL_NUMBER]; // Processing loop exit condition
     EbBool          channel_active[MAX_CHANNEL_NUMBER];
     EncodePass      pass;
 } EncContext;
@@ -182,6 +183,193 @@ static void enc_context_dctor(EncContext* enc_context){
 }
 
 double get_psnr(double sse, double max);
+static void print_summary(const EncContext* const enc_context)
+{
+    EbConfig*   const* configs = enc_context->configs;
+    for (uint32_t inst_cnt = 0; inst_cnt < enc_context->num_channels; ++inst_cnt) {
+        if (enc_context->exit_cond[inst_cnt] == APP_ExitConditionFinished &&
+            enc_context->return_errors[inst_cnt] == EB_ErrorNone) {
+            uint64_t frame_count =
+                (uint32_t)configs[inst_cnt]->performance_context.frame_count;
+            uint32_t max_luma_value = (configs[inst_cnt]->encoder_bit_depth == 8) ? 255
+                                                                                    : 1023;
+            double max_luma_sse = (double)max_luma_value * max_luma_value *
+                (configs[inst_cnt]->source_width * configs[inst_cnt]->source_height);
+            double max_chroma_sse = (double)max_luma_value * max_luma_value *
+                (configs[inst_cnt]->source_width / 2 * configs[inst_cnt]->source_height /
+                    2);
+
+            if ((configs[inst_cnt]->frame_rate_numerator != 0 &&
+                    configs[inst_cnt]->frame_rate_denominator != 0) ||
+                configs[inst_cnt]->frame_rate != 0) {
+                double frame_rate = configs[inst_cnt]->frame_rate_numerator &&
+                        configs[inst_cnt]->frame_rate_denominator
+                    ? (double)configs[inst_cnt]->frame_rate_numerator /
+                        (double)configs[inst_cnt]->frame_rate_denominator
+                    : configs[inst_cnt]->frame_rate > 1000
+                        // Correct for 16-bit fixed-point fractional precision
+                        ? (double)configs[inst_cnt]->frame_rate / (1 << 16)
+                        : (double)configs[inst_cnt]->frame_rate;
+
+                if (configs[inst_cnt]->stat_report) {
+                    if (configs[inst_cnt]->stat_file) {
+                        fprintf(configs[inst_cnt]->stat_file,
+                                "\nSUMMARY "
+                                "------------------------------------------------------"
+                                "---------------\n");
+                        fprintf(configs[inst_cnt]->stat_file,
+                                "\n\t\t\t\tAverage PSNR (using per-frame "
+                                "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|"
+                                "\tAverage SSIM\n");
+                        fprintf(configs[inst_cnt]->stat_file,
+                                "Total Frames\tAverage QP  \tY-PSNR   \tU-PSNR   "
+                                "\tV-PSNR\t\t| \tY-PSNR   \tU-PSNR   \tV-PSNR   \t|"
+                                "\tY-SSIM   \tU-SSIM   \tV-SSIM   "
+                                "\t|\tBitrate\n");
+                        fprintf(
+                            configs[inst_cnt]->stat_file,
+                            "%10ld  \t   %2.2f    \t%3.2f dB\t%3.2f dB\t%3.2f dB  "
+                            "\t|\t%3.2f dB\t%3.2f dB\t%3.2f dB \t|\t%1.5f \t%1.5f "
+                            "\t%1.5f\t\t|\t%.2f kbps\n",
+                            (long int)frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_qp /
+                                frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_luma_psnr /
+                                frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_cb_psnr /
+                                frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_cr_psnr /
+                                frame_count,
+                            (float)(get_psnr(
+                                (configs[inst_cnt]->performance_context.sum_luma_sse /
+                                    frame_count),
+                                max_luma_sse)),
+                            (float)(get_psnr(
+                                (configs[inst_cnt]->performance_context.sum_cb_sse /
+                                    frame_count),
+                                max_chroma_sse)),
+                            (float)(get_psnr(
+                                (configs[inst_cnt]->performance_context.sum_cr_sse /
+                                    frame_count),
+                                max_chroma_sse)),
+                            (float)configs[inst_cnt]->performance_context.sum_luma_ssim /
+                                frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_cb_ssim /
+                                frame_count,
+                            (float)configs[inst_cnt]->performance_context.sum_cr_ssim /
+                                frame_count,
+                            ((double)(configs[inst_cnt]->performance_context.byte_count
+                                        << 3) *
+                                frame_rate / (configs[inst_cnt]->frames_encoded * 1000)));
+                    }
+                }
+
+                fprintf(stderr,
+                        "\nSUMMARY --------------------------------- Channel %u  "
+                        "--------------------------------\n",
+                        inst_cnt + 1);
+                {
+                    fprintf(stderr,
+                            "Total Frames\t\tFrame Rate\t\tByte Count\t\tBitrate\n");
+                    fprintf(
+                        stderr,
+                        "%12d\t\t%4.2f fps\t\t%10.0f\t\t%5.2f kbps\n",
+                        (int32_t)frame_count,
+                        (double)frame_rate,
+                        (double)configs[inst_cnt]->performance_context.byte_count,
+                        ((double)(configs[inst_cnt]->performance_context.byte_count << 3) *
+                            frame_rate / (configs[inst_cnt]->frames_encoded * 1000)));
+                }
+
+                if (configs[inst_cnt]->stat_report) {
+                    fprintf(stderr,
+                            "\n\t\tAverage PSNR (using per-frame "
+                            "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|\t"
+                            "Average SSIM\n");
+                    fprintf(stderr,
+                            "Average "
+                            "QP\tY-PSNR\t\tU-PSNR\t\tV-PSNR\t\t|\tY-PSNR\t\tU-"
+                            "PSNR\t\tV-PSNR\t\t|\tY-SSIM\tU-SSIM\tV-SSIM\n");
+                    fprintf(
+                        stderr,
+                        "%11.2f\t%4.2f dB\t%4.2f dB\t%4.2f dB\t|\t%4.2f "
+                        "dB\t%4.2f dB\t%4.2f dB\t|\t%1.5f\t%1.5f\t%1.5f\n",
+                        (float)configs[inst_cnt]->performance_context.sum_qp / frame_count,
+                        (float)configs[inst_cnt]->performance_context.sum_luma_psnr /
+                            frame_count,
+                        (float)configs[inst_cnt]->performance_context.sum_cb_psnr /
+                            frame_count,
+                        (float)configs[inst_cnt]->performance_context.sum_cr_psnr /
+                            frame_count,
+                        (float)(get_psnr(
+                            (configs[inst_cnt]->performance_context.sum_luma_sse /
+                                frame_count),
+                            max_luma_sse)),
+                        (float)(get_psnr(
+                            (configs[inst_cnt]->performance_context.sum_cb_sse /
+                                frame_count),
+                            max_chroma_sse)),
+                        (float)(get_psnr(
+                            (configs[inst_cnt]->performance_context.sum_cr_sse /
+                                frame_count),
+                            max_chroma_sse)),
+                        (float)configs[inst_cnt]->performance_context.sum_luma_ssim /
+                            frame_count,
+                        (float)configs[inst_cnt]->performance_context.sum_cb_ssim /
+                            frame_count,
+                        (float)configs[inst_cnt]->performance_context.sum_cr_ssim /
+                            frame_count);
+                }
+
+                fflush(stdout);
+            }
+        }
+    }
+    fprintf(stderr, "\n");
+    fflush(stdout);
+}
+
+static void print_performance(const EncContext* const enc_context)
+{
+    EbConfig*   const* configs = enc_context->configs;
+    for (uint32_t inst_cnt = 0; inst_cnt < enc_context->num_channels; ++inst_cnt) {
+        if (enc_context->exit_cond[inst_cnt] == APP_ExitConditionFinished &&
+            enc_context->return_errors[inst_cnt] == EB_ErrorNone) {
+            if (configs[inst_cnt]->stop_encoder == EB_FALSE) {
+                fprintf(stderr,
+                        "\nChannel %u\nAverage Speed:\t\t%.3f fps\nTotal Encoding Time:\t%.0f "
+                        "ms\nTotal Execution Time:\t%.0f ms\nAverage Latency:\t%.0f ms\nMax "
+                        "Latency:\t\t%u ms\n",
+                        (uint32_t)(inst_cnt + 1),
+                        configs[inst_cnt]->performance_context.average_speed,
+                        configs[inst_cnt]->performance_context.total_encode_time * 1000,
+                        configs[inst_cnt]->performance_context.total_execution_time * 1000,
+                        configs[inst_cnt]->performance_context.average_latency,
+                        (uint32_t)(configs[inst_cnt]->performance_context.max_latency));
+            } else
+                fprintf(
+                    stderr, "\nChannel %u Encoding Interrupted\n", (uint32_t)(inst_cnt + 1));
+        } else if (enc_context->return_errors[inst_cnt] == EB_ErrorInsufficientResources)
+            fprintf(stderr, "Could not allocate enough memory for channel %u\n", inst_cnt + 1);
+        else
+            fprintf(stderr,
+                    "Error encoding at channel %u! Check error log file for more details "
+                    "... \n",
+                    inst_cnt + 1);
+    }
+}
+
+static void print_warnnings(const EncContext* const enc_context)
+{
+    char* const* warning = enc_context->warning;
+    for (uint32_t warning_id = 0;; warning_id++) {
+        if (*warning[warning_id] == '-')
+            fprintf(stderr, "warning: %s\n", warning[warning_id]);
+        else if (*warning[warning_id + 1] != '-')
+                break;
+    }
+
+}
 
 static const char *get_pass_name(EncodePass pass) {
     switch (pass) {
@@ -195,15 +383,14 @@ static EbErrorType encode(EncApp* enc_app, EncContext* enc_context) {
     EbErrorType          return_error   = EB_ErrorNone;
     AppExitConditionType exit_condition = APP_ExitConditionNone; // Processing loop exit condition
 
-    AppExitConditionType exit_cond[MAX_CHANNEL_NUMBER]; // Processing loop exit condition
     AppExitConditionType exit_cond_output[MAX_CHANNEL_NUMBER]; // Processing loop exit condition
     AppExitConditionType exit_cond_recon[MAX_CHANNEL_NUMBER]; // Processing loop exit condition
     AppExitConditionType exit_cond_input[MAX_CHANNEL_NUMBER]; // Processing loop exit condition
 
+    AppExitConditionType* exit_cond = enc_context->exit_cond;
     EbBool* channel_active = enc_context->channel_active;
     EbConfig **configs = enc_context->configs; // Encoder Configuration
     EbAppContext **app_callbacks = enc_context->app_callbacks; // Instances App callback date
-    char **warning = enc_context->warning;
     // Get num_channels
     uint32_t num_channels = enc_context->num_channels;
 
@@ -244,12 +431,7 @@ static EbErrorType encode(EncApp* enc_app, EncContext* enc_context) {
                 EB_APP_MEMORY();
 #endif
             }
-            for (uint32_t warning_id = 0;; warning_id++) {
-                if (*warning[warning_id] == '-')
-                    fprintf(stderr, "warning: %s\n", warning[warning_id]);
-                else if (*warning[warning_id + 1] != '-')
-                    break;
-            }
+            print_warnnings(enc_context);
 
             fprintf(stderr, "%sEncoding          ", get_pass_name(pass));
 
@@ -299,174 +481,10 @@ static EbErrorType encode(EncApp* enc_app, EncContext* enc_context) {
                         exit_condition = APP_ExitConditionNone;
                 }
             }
-
-            for (uint32_t inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {
-                if (exit_cond[inst_cnt] == APP_ExitConditionFinished &&
-                    return_errors[inst_cnt] == EB_ErrorNone) {
-                    uint64_t frame_count =
-                        (uint32_t)configs[inst_cnt]->performance_context.frame_count;
-                    uint32_t max_luma_value = (configs[inst_cnt]->encoder_bit_depth == 8) ? 255
-                                                                                          : 1023;
-                    double max_luma_sse = (double)max_luma_value * max_luma_value *
-                        (configs[inst_cnt]->source_width * configs[inst_cnt]->source_height);
-                    double max_chroma_sse = (double)max_luma_value * max_luma_value *
-                        (configs[inst_cnt]->source_width / 2 * configs[inst_cnt]->source_height /
-                         2);
-
-                    if ((configs[inst_cnt]->frame_rate_numerator != 0 &&
-                         configs[inst_cnt]->frame_rate_denominator != 0) ||
-                        configs[inst_cnt]->frame_rate != 0) {
-                        double frame_rate = configs[inst_cnt]->frame_rate_numerator &&
-                                configs[inst_cnt]->frame_rate_denominator
-                            ? (double)configs[inst_cnt]->frame_rate_numerator /
-                                (double)configs[inst_cnt]->frame_rate_denominator
-                            : configs[inst_cnt]->frame_rate > 1000
-                                // Correct for 16-bit fixed-point fractional precision
-                                ? (double)configs[inst_cnt]->frame_rate / (1 << 16)
-                                : (double)configs[inst_cnt]->frame_rate;
-
-                        if (configs[inst_cnt]->stat_report) {
-                            if (configs[inst_cnt]->stat_file) {
-                                fprintf(configs[inst_cnt]->stat_file,
-                                        "\nSUMMARY "
-                                        "------------------------------------------------------"
-                                        "---------------\n");
-                                fprintf(configs[inst_cnt]->stat_file,
-                                        "\n\t\t\t\tAverage PSNR (using per-frame "
-                                        "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|"
-                                        "\tAverage SSIM\n");
-                                fprintf(configs[inst_cnt]->stat_file,
-                                        "Total Frames\tAverage QP  \tY-PSNR   \tU-PSNR   "
-                                        "\tV-PSNR\t\t| \tY-PSNR   \tU-PSNR   \tV-PSNR   \t|"
-                                        "\tY-SSIM   \tU-SSIM   \tV-SSIM   "
-                                        "\t|\tBitrate\n");
-                                fprintf(
-                                    configs[inst_cnt]->stat_file,
-                                    "%10ld  \t   %2.2f    \t%3.2f dB\t%3.2f dB\t%3.2f dB  "
-                                    "\t|\t%3.2f dB\t%3.2f dB\t%3.2f dB \t|\t%1.5f \t%1.5f "
-                                    "\t%1.5f\t\t|\t%.2f kbps\n",
-                                    (long int)frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_qp /
-                                        frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_luma_psnr /
-                                        frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_cb_psnr /
-                                        frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_cr_psnr /
-                                        frame_count,
-                                    (float)(get_psnr(
-                                        (configs[inst_cnt]->performance_context.sum_luma_sse /
-                                         frame_count),
-                                        max_luma_sse)),
-                                    (float)(get_psnr(
-                                        (configs[inst_cnt]->performance_context.sum_cb_sse /
-                                         frame_count),
-                                        max_chroma_sse)),
-                                    (float)(get_psnr(
-                                        (configs[inst_cnt]->performance_context.sum_cr_sse /
-                                         frame_count),
-                                        max_chroma_sse)),
-                                    (float)configs[inst_cnt]->performance_context.sum_luma_ssim /
-                                        frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_cb_ssim /
-                                        frame_count,
-                                    (float)configs[inst_cnt]->performance_context.sum_cr_ssim /
-                                        frame_count,
-                                    ((double)(configs[inst_cnt]->performance_context.byte_count
-                                              << 3) *
-                                     frame_rate / (configs[inst_cnt]->frames_encoded * 1000)));
-                            }
-                        }
-
-                        fprintf(stderr,
-                                "\nSUMMARY --------------------------------- Channel %u  "
-                                "--------------------------------\n",
-                                inst_cnt + 1);
-                        {
-                            fprintf(stderr,
-                                    "Total Frames\t\tFrame Rate\t\tByte Count\t\tBitrate\n");
-                            fprintf(
-                                stderr,
-                                "%12d\t\t%4.2f fps\t\t%10.0f\t\t%5.2f kbps\n",
-                                (int32_t)frame_count,
-                                (double)frame_rate,
-                                (double)configs[inst_cnt]->performance_context.byte_count,
-                                ((double)(configs[inst_cnt]->performance_context.byte_count << 3) *
-                                 frame_rate / (configs[inst_cnt]->frames_encoded * 1000)));
-                        }
-
-                        if (configs[inst_cnt]->stat_report) {
-                            fprintf(stderr,
-                                    "\n\t\tAverage PSNR (using per-frame "
-                                    "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|\t"
-                                    "Average SSIM\n");
-                            fprintf(stderr,
-                                    "Average "
-                                    "QP\tY-PSNR\t\tU-PSNR\t\tV-PSNR\t\t|\tY-PSNR\t\tU-"
-                                    "PSNR\t\tV-PSNR\t\t|\tY-SSIM\tU-SSIM\tV-SSIM\n");
-                            fprintf(
-                                stderr,
-                                "%11.2f\t%4.2f dB\t%4.2f dB\t%4.2f dB\t|\t%4.2f "
-                                "dB\t%4.2f dB\t%4.2f dB\t|\t%1.5f\t%1.5f\t%1.5f\n",
-                                (float)configs[inst_cnt]->performance_context.sum_qp / frame_count,
-                                (float)configs[inst_cnt]->performance_context.sum_luma_psnr /
-                                    frame_count,
-                                (float)configs[inst_cnt]->performance_context.sum_cb_psnr /
-                                    frame_count,
-                                (float)configs[inst_cnt]->performance_context.sum_cr_psnr /
-                                    frame_count,
-                                (float)(get_psnr(
-                                    (configs[inst_cnt]->performance_context.sum_luma_sse /
-                                     frame_count),
-                                    max_luma_sse)),
-                                (float)(get_psnr(
-                                    (configs[inst_cnt]->performance_context.sum_cb_sse /
-                                     frame_count),
-                                    max_chroma_sse)),
-                                (float)(get_psnr(
-                                    (configs[inst_cnt]->performance_context.sum_cr_sse /
-                                     frame_count),
-                                    max_chroma_sse)),
-                                (float)configs[inst_cnt]->performance_context.sum_luma_ssim /
-                                    frame_count,
-                                (float)configs[inst_cnt]->performance_context.sum_cb_ssim /
-                                    frame_count,
-                                (float)configs[inst_cnt]->performance_context.sum_cr_ssim /
-                                    frame_count);
-                        }
-
-                        fflush(stdout);
-                    }
-                }
-            }
-            fprintf(stderr, "\n");
-            fflush(stdout);
+            print_summary(enc_context);
         }
-        for (uint32_t inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {
-            if (exit_cond[inst_cnt] == APP_ExitConditionFinished &&
-                return_errors[inst_cnt] == EB_ErrorNone) {
-                if (configs[inst_cnt]->stop_encoder == EB_FALSE) {
-                    fprintf(stderr,
-                            "\nChannel %u\nAverage Speed:\t\t%.3f fps\nTotal Encoding Time:\t%.0f "
-                            "ms\nTotal Execution Time:\t%.0f ms\nAverage Latency:\t%.0f ms\nMax "
-                            "Latency:\t\t%u ms\n",
-                            (uint32_t)(inst_cnt + 1),
-                            configs[inst_cnt]->performance_context.average_speed,
-                            configs[inst_cnt]->performance_context.total_encode_time * 1000,
-                            configs[inst_cnt]->performance_context.total_execution_time * 1000,
-                            configs[inst_cnt]->performance_context.average_latency,
-                            (uint32_t)(configs[inst_cnt]->performance_context.max_latency));
-                } else
-                    fprintf(
-                        stderr, "\nChannel %u Encoding Interrupted\n", (uint32_t)(inst_cnt + 1));
-            } else if (return_errors[inst_cnt] == EB_ErrorInsufficientResources)
-                fprintf(stderr, "Could not allocate enough memory for channel %u\n", inst_cnt + 1);
-            else
-                fprintf(stderr,
-                        "Error encoding at channel %u! Check error log file for more details "
-                        "... \n",
-                        inst_cnt + 1);
-        }
+        print_performance(enc_context);
+
     } else {
     }
     // Destruct the App memory variables

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -452,14 +452,6 @@ static EbErrorType encode(EncApp* enc_app, EncContext* enc_context) {
     // Get num_channels
     uint32_t num_channels = enc_context->num_channels;
 
-    for (uint32_t inst_cnt = 0; inst_cnt < MAX_CHANNEL_NUMBER; ++inst_cnt) {
-        exit_cond[inst_cnt]        = APP_ExitConditionError; // Processing loop exit condition
-        exit_cond_output[inst_cnt] = APP_ExitConditionError; // Processing loop exit condition
-        exit_cond_recon[inst_cnt]  = APP_ExitConditionError; // Processing loop exit condition
-        exit_cond_input[inst_cnt]  = APP_ExitConditionError; // Processing loop exit condition
-        channel_active[inst_cnt]   = EB_FALSE;
-    }
-
     EbErrorType* return_errors = enc_context->return_errors;
     EncodePass pass = enc_context->pass;
     // Start the Encoder

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -113,17 +113,11 @@ static EbErrorType encode(EncApp* enc_app, int32_t argc, char *argv[], EncodePas
         return EB_ErrorBadParameter;
     // Initialize config
     for (uint32_t inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {
-        configs[inst_cnt] = (EbConfig *)malloc(sizeof(EbConfig));
+        configs[inst_cnt] = eb_config_ctor(pass);
         if (!configs[inst_cnt]) {
-            while (inst_cnt-- > 0) free(configs[inst_cnt]);
+            while (inst_cnt-- > 0) eb_config_dtor(configs[inst_cnt]);
             return EB_ErrorInsufficientResources;
         }
-        eb_config_ctor(configs[inst_cnt]);
-        if (pass == ENCODE_FIRST_PASS)
-            configs[inst_cnt]->pass = 1;
-        else if (pass == ENCODE_LAST_PASS)
-            configs[inst_cnt]->pass = 2;
-        eb_2pass_config_update(configs[inst_cnt]);
         return_errors[inst_cnt] = EB_ErrorNone;
     }
 
@@ -452,8 +446,6 @@ static EbErrorType encode(EncApp* enc_app, int32_t argc, char *argv[], EncodePas
     // Destruct the App memory variables
     for (uint32_t inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {
         eb_config_dtor(configs[inst_cnt]);
-        if (configs[inst_cnt])
-            free(configs[inst_cnt]);
         if (app_callbacks[inst_cnt])
             free(app_callbacks[inst_cnt]);
     }

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -47,12 +47,12 @@
 /***************************************
  * External Functions
  ***************************************/
-extern AppExitConditionType process_input_buffer(EbConfig *config, EbAppContext *app_call_back);
+void process_input_buffer(EncChannel* c, EbConfig *config, EbAppContext *app_call_back);
 
-extern AppExitConditionType process_output_recon_buffer(EbConfig *    config,
+void process_output_recon_buffer(EncChannel* c, EbConfig *    config,
                                                         EbAppContext *app_call_back);
 
-extern AppExitConditionType process_output_stream_buffer(EncApp* enc_app, EbConfig *    config,
+void process_output_stream_buffer(EncChannel* c, EncApp* enc_app, EbConfig *    config,
                                                          EbAppContext *app_call_back,
                                                          uint8_t       pic_send_done,
                                                          int32_t      *frame_count);
@@ -395,14 +395,9 @@ static void enc_channel_step(EncApp* enc_app, EncContext* enc_context, uint32_t 
 
     EncChannel* c = enc_context->channels + inst_cnt;
     EbConfig **configs = enc_context->configs; // Encoder Configuration
-    if (c->exit_cond_input == APP_ExitConditionNone)
-        c->exit_cond_input = process_input_buffer(
-            configs[inst_cnt], app_callbacks[inst_cnt]);
-    if (c->exit_cond_recon == APP_ExitConditionNone)
-        c->exit_cond_recon = process_output_recon_buffer(
-            configs[inst_cnt], app_callbacks[inst_cnt]);
-    if (c->exit_cond_output == APP_ExitConditionNone)
-        c->exit_cond_output = process_output_stream_buffer(
+    process_input_buffer(c, configs[inst_cnt], app_callbacks[inst_cnt]);
+    process_output_recon_buffer(c, configs[inst_cnt], app_callbacks[inst_cnt]);
+    process_output_stream_buffer(c,
             enc_app,
             configs[inst_cnt],
             app_callbacks[inst_cnt],

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -861,7 +861,9 @@ static unsigned char send_qp_on_the_fly(FILE *const qp_file, uint8_t *use_qp_fil
 // Reads yuv frames from file and copy
 // them into the input buffer
 /************************************/
-void process_input_buffer(EncChannel* channel, EbConfig *config, EbAppContext *app_call_back) {
+void process_input_buffer(EncChannel* channel) {
+    EbConfig *config = channel->config;
+    EbAppContext *app_call_back = channel->app_callback;
     uint8_t             is_16bit         = (uint8_t)(config->encoder_bit_depth > 8);
     EbBufferHeaderType *header_ptr       = app_call_back->input_buffer_pool;
     EbComponentType *   component_handle = (EbComponentType *)app_call_back->svt_encoder_handle;
@@ -1090,8 +1092,10 @@ void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *
     return;
 }
 
-void process_output_stream_buffer(EncChannel* channel, EncApp* enc_app, EbConfig *config, EbAppContext *app_call_back,
-                                                  uint8_t pic_send_done, int32_t *frame_count) {
+void process_output_stream_buffer(EncChannel* channel, EncApp* enc_app,
+                                                int32_t *frame_count) {
+    EbConfig *config = channel->config;
+    EbAppContext *app_call_back = channel->app_callback;
     AppPortActiveType *  port_state = &app_call_back->output_stream_port_active;
     EbBufferHeaderType * header_ptr;
     EbComponentType *    component_handle = (EbComponentType *)app_call_back->svt_encoder_handle;
@@ -1108,6 +1112,10 @@ void process_output_stream_buffer(EncChannel* channel, EncApp* enc_app, EbConfig
     uint8_t  is_alt_ref    = 1;
     if (channel->exit_cond_output != APP_ExitConditionNone)
         return;
+    uint8_t pic_send_done = (channel->exit_cond_input == APP_ExitConditionNone) ||
+            (channel->exit_cond_recon == APP_ExitConditionNone)
+            ? 0
+            : 1;
     while (is_alt_ref) {
         is_alt_ref = 0;
         // non-blocking call until all input frames are sent
@@ -1227,8 +1235,9 @@ void process_output_stream_buffer(EncChannel* channel, EncApp* enc_app, EbConfig
     }
     channel->exit_cond_output = return_value;
 }
-void process_output_recon_buffer(EncChannel* channel, EbConfig *config, EbAppContext *app_call_back) {
-
+void process_output_recon_buffer(EncChannel* channel) {
+    EbConfig *config = channel->config;
+    EbAppContext *app_call_back = channel->app_callback;
     EbBufferHeaderType *header_ptr =
         app_call_back->recon_buffer; // needs to change for buffered input
     EbComponentType *    component_handle = (EbComponentType *)app_call_back->svt_encoder_handle;

--- a/test/e2e_test/ConfigEncoder.cc
+++ b/test/e2e_test/ConfigEncoder.cc
@@ -22,9 +22,8 @@ void set_enc_config(void *config_ptr, const char *name, const char *value) {
 }
 
 void *create_enc_config() {
-    EbConfig *config = (EbConfig *)malloc(sizeof(EbConfig));
+    EbConfig *config = eb_config_ctor(ENCODE_SINGLE_PASS);
     assert(config != NULL);
-    eb_config_ctor(config);
     return config;
 }
 
@@ -32,7 +31,6 @@ void release_enc_config(void *config_ptr) {
     if (config_ptr) {
         EbConfig *config = (EbConfig *)config_ptr;
         eb_config_dtor(config);
-        free(config_ptr);
     }
 }
 


### PR DESCRIPTION
# Description
split encode function to smaller functions to more readable samller functions. 

Tested command:

- SvtAv1EncApp -lp 4 -lad 0 -q 20  -n 3 -intra-period 119 -i ~/bits/SVT/172x144.y4m -i ~/bits/SVT/172x144.y4m -b two_passes.ivf --passes 2 --preset 3 -tttt
- SvtAv1EncApp -lp 4 -lad 0 -q 20  -n 3 -intra-period 119 -i ~/bits/SVT/172x144.y4m -i ~/bits/SVT/172x144.y4m -b two_passes.ivf --passes 2 --preset 3
- SvtAv1EncApp -nch 2 -c 1.cfg 2.cfg

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Guangxin.Xu@intel.com

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
