### PR TITLE
safestringlib: Compile strnlen_s based on availability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,18 @@ macro(ASM_COMPILE_TO_TARGET target)
     endif()
 endmacro()
 
+file(WRITE ${CMAKE_BINARY_DIR}/conftest.c "
+#include <string.h>
+#include <stdint.h>
+int main() {
+    return (uintptr_t)strnlen_s;
+}
+")
+
+try_compile(HAVE_STRNLEN_S ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/conftest.c)
+
+add_definitions(-DHAVE_STRNLEN_S=1)
+
 add_subdirectory(third_party/safestringlib)
 
 # Add Subdirectories

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -22,6 +22,9 @@
 #else
 #include <unistd.h>
 #include <sys/file.h>
+#endif
+
+#if !defined(_WIN32) || !defined(HAVE_STRNLEN_S)
 #include "safe_str_lib.h"
 #endif
 

--- a/Source/App/EncApp/EbAppInputy4m.c
+++ b/Source/App/EncApp/EbAppInputy4m.c
@@ -10,9 +10,8 @@
 */
 
 #include "EbAppInputy4m.h"
-#ifdef _WIN32
 #include <string.h>
-#else
+#if !defined(_WIN32) || !defined(HAVE_STRNLEN_S)
 #include "safe_str_lib.h"
 #endif
 #define YFM_HEADER_MAX 80

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -38,6 +38,9 @@
 #include <semaphore.h>
 #include <time.h>
 #include <errno.h>
+#endif
+
+#if !defined(_WIN32) || !defined(HAVE_STRNLEN_S)
 #include "safe_str_lib.h"
 #endif
 

--- a/third_party/safestringlib/CMakeLists.txt
+++ b/third_party/safestringlib/CMakeLists.txt
@@ -1,6 +1,19 @@
 if(WIN32)
-    file(WRITE dummy.c "")
-    add_library(safestringlib OBJECT dummy.c)
+    if(HAVE_STRNLEN_S)
+        file(WRITE dummy.c "")
+        add_library(safestringlib OBJECT dummy.c)
+    else()
+        add_library(safestringlib OBJECT
+            safeclib_private.h
+            safe_lib.h
+            safe_types.h
+            safe_lib_errno.h
+            safe_str_lib.h
+            safe_str_constraint.h
+            strnlen_s.c
+            safe_str_constraint.c
+            ignore_handler_s.c)
+    endif()
 else()
     add_library(safestringlib OBJECT
         safe_lib_errno.h
@@ -14,5 +27,6 @@ else()
         ignore_handler_s.c
         strncpy_s.c
         strnlen_s.c)
-    target_compile_definitions(safestringlib PUBLIC SAFECLIB_STR_NULL_SLACK=1)
 endif()
+
+target_compile_definitions(safestringlib PUBLIC SAFECLIB_STR_NULL_SLACK=1)


### PR DESCRIPTION

# Description

mingw-w64 clang does not have strnlen_s available, but mingw-w64 gcc seems to be fine


# Issue

Fixes https://github.com/m-ab-s/media-autobuild_suite/issues/1815
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
