### PR TITLE
Time: Refactor time functions similar to SVT-VP9

### DIFF
--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -36,7 +36,6 @@
 #else
 #include <pthread.h>
 #include <semaphore.h>
-#include <time.h>
 #include <errno.h>
 #endif
 
@@ -132,8 +131,8 @@ static EbErrorType enc_context_ctor(EncApp* enc_app, EncContext* enc_context, in
             config->active_channel_count = num_channels;
             config->channel_id           = inst_cnt;
 
-            start_time((uint64_t *)&config->performance_context.lib_start_time[0],
-                        (uint64_t *)&config->performance_context.lib_start_time[1]);
+            app_svt_av1_get_time(&config->performance_context.lib_start_time[0],
+                                 &config->performance_context.lib_start_time[1]);
 
             if (pass == ENCODE_FIRST_PASS) {
                 //TODO: remove this if we can use a quick first pass in svt av1 library.
@@ -422,11 +421,9 @@ static void enc_channel_start(EncChannel* c)
             : APP_ExitConditionError;
         c->exit_cond_input = APP_ExitConditionNone;
         c->active  = EB_TRUE;
-        start_time(
-            (uint64_t *)&config->performance_context.encode_start_time[0],
-            (uint64_t *)&config->performance_context.encode_start_time[1]);
+        app_svt_av1_get_time(&config->performance_context.encode_start_time[0],
+                             &config->performance_context.encode_start_time[1]);
     }
-
 }
 
 static EbErrorType encode(EncApp* enc_app, EncContext* enc_context) {

--- a/Source/App/EncApp/EbTime.c
+++ b/Source/App/EncApp/EbTime.c
@@ -9,128 +9,55 @@
 * PATENTS file, you can obtain it at https://www.aomedia.org/license/patent-license.
 */
 
-#include <stdint.h>
-
-#ifndef __USE_POSIX199309
+#ifdef _WIN32
+#include <sys/timeb.h>
+#include <windows.h>
+#elif !defined(__USE_POSIX199309)
 #define __USE_POSIX199309
 #endif
+
 #include <time.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
+#if !defined(CLOCK_MONOTONIC) && !defined(_WIN32)
 #include <sys/time.h>
 #endif
 
 #include "EbTime.h"
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC__)
-__attribute__((optimize("unroll-loops")))
-#endif
-
-void start_time(uint64_t *start_seconds, uint64_t *start_u_seconds) {
+void app_svt_av1_sleep(const unsigned milliseconds) {
+    if (!milliseconds)
+        return;
 #ifdef _WIN32
-    *start_seconds = (uint64_t)clock();
-    (void)(*start_u_seconds);
+    Sleep(milliseconds);
 #else
-    struct timeval start;
-    gettimeofday(&start, NULL);
-    *start_seconds   = start.tv_sec;
-    *start_u_seconds = start.tv_usec;
+    nanosleep(&(struct timespec){milliseconds / 1000, (milliseconds % 1000) * 1000000}, NULL);
 #endif
 }
 
-void finish_time(uint64_t *finish_seconds, uint64_t *finish_u_seconds) {
-#ifdef _WIN32
-    *finish_seconds = (uint64_t)clock();
-    (void)(*finish_u_seconds);
-#else
-    struct timeval finish;
-    gettimeofday(&finish, NULL);
-    *finish_seconds   = finish.tv_sec;
-    *finish_u_seconds = finish.tv_usec;
-#endif
+double app_svt_av1_compute_overall_elapsed_time(const uint64_t start_seconds,
+                                                const uint64_t start_useconds,
+                                                const uint64_t finish_seconds,
+                                                const uint64_t finish_useconds) {
+    const int64_t s_diff = (int64_t)finish_seconds - (int64_t)start_seconds,
+                  u_diff = (int64_t)finish_useconds - (int64_t)start_useconds;
+    return ((double)s_diff * 1000.0 + (double)u_diff / 1000.0 + 0.5) / 1000.0;
 }
 
-void compute_overall_elapsed_time(uint64_t start_seconds, uint64_t start_u_seconds,
-                                  uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                  double *duration) {
+void app_svt_av1_get_time(uint64_t *const seconds, uint64_t *const useconds) {
 #ifdef _WIN32
-    //double  duration;
-    *duration = (double)(finish_seconds - start_seconds) / CLOCKS_PER_SEC;
-    (void)(start_u_seconds);
-    (void)(finish_u_seconds);
+    struct _timeb curr_time;
+    _ftime_s(&curr_time);
+    *seconds  = curr_time.time;
+    *useconds = curr_time.millitm;
+#elif defined(CLOCK_MONOTONIC)
+    struct timespec curr_time;
+    clock_gettime(CLOCK_MONOTONIC, &curr_time);
+    *seconds  = (uint64_t)curr_time.tv_sec;
+    *useconds = (uint64_t)curr_time.tv_nsec / 1000UL;
 #else
-    long mtime, seconds, useconds;
-    seconds   = finish_seconds - start_seconds;
-    useconds  = finish_u_seconds - start_u_seconds;
-    mtime     = ((seconds)*1000 + useconds / 1000.0) + 0.5;
-    *duration = (double)mtime / 1000;
+    struct timeval curr_time;
+    gettimeofday(&curr_time, NULL);
+    *seconds  = curr_time.tv_sec;
+    *useconds = curr_time.tv_usec;
 #endif
-}
-
-static void sleep_ms(uint64_t milli_seconds) {
-    if (milli_seconds) {
-#ifdef _WIN32
-        Sleep((DWORD)milli_seconds);
-#else
-        struct timespec req, rem;
-        req.tv_sec = (int32_t)(milli_seconds / 1000);
-        milli_seconds -= req.tv_sec * 1000;
-        req.tv_nsec = milli_seconds * 1000000UL;
-        nanosleep(&req, &rem);
-#endif
-    }
-}
-
-void injector(uint64_t processed_frame_count, uint32_t injector_frame_rate) {
-#ifdef _WIN32
-    static LARGE_INTEGER start_count; // this is the start time
-    static LARGE_INTEGER counter_freq; // performance counter frequency
-    LARGE_INTEGER        now_count; // this is the current time
-#else
-    uint64_t        currentTimesSeconds  = 0;
-    uint64_t        currentTimesuSeconds = 0;
-    static uint64_t startTimesSeconds;
-    static uint64_t startTimesuSeconds;
-#endif
-
-    double injector_interval =
-        (double)(1 << 16) /
-        (double)injector_frame_rate; // 1.0 / injector frame rate (in this case, 1.0/encodRate)
-    static int32_t first_time = 0;
-
-    if (first_time == 0) {
-        first_time = 1;
-
-#ifdef _WIN32
-        QueryPerformanceFrequency(&counter_freq);
-        QueryPerformanceCounter(&start_count);
-#else
-        start_time((uint64_t *)&startTimesSeconds, (uint64_t *)&startTimesuSeconds);
-#endif
-    } else {
-#ifdef _WIN32
-        QueryPerformanceCounter(&now_count);
-        double elapsed_time = (double)(now_count.QuadPart - start_count.QuadPart) /
-            (double)counter_freq.QuadPart;
-#else
-        double elapsed_time;
-        finish_time((uint64_t *)&currentTimesSeconds,
-                                        (uint64_t *)&currentTimesuSeconds);
-        compute_overall_elapsed_time(startTimesSeconds,
-                                     startTimesuSeconds,
-                                     currentTimesSeconds,
-                                     currentTimesuSeconds,
-                                     &elapsed_time);
-#endif
-        const int32_t buffer_frames  = 1; // How far ahead of time should we let it get
-        double        predicted_time = (processed_frame_count - buffer_frames) * injector_interval;
-        const int32_t millisec_ahead = (int32_t)(1000 * (predicted_time - elapsed_time));
-        if (millisec_ahead > 0) {
-            //  timeBeginPeriod(1);
-            sleep_ms(millisec_ahead);
-            //  timeEndPeriod (1);
-        }
-    }
 }

--- a/Source/App/EncApp/EbTime.h
+++ b/Source/App/EncApp/EbTime.h
@@ -14,22 +14,12 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
-#define NANOSECS_PER_SEC ((uint32_t)(1000000000L))
-
-void start_time(uint64_t *start_seconds, uint64_t *start_u_seconds);
-void finish_time(uint64_t *finish_seconds, uint64_t *finish_u_seconds);
-void compute_overall_elapsed_time(uint64_t start_seconds, uint64_t start_u_seconds,
-                                  uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                  double *duration);
-void injector(uint64_t processed_frame_count, uint32_t injector_frame_rate);
-
-#ifdef __cplusplus
-}
-#endif // __cplusplus
+void   app_svt_av1_sleep(const unsigned milliseconds);
+double app_svt_av1_compute_overall_elapsed_time(const uint64_t start_seconds,
+                                                const uint64_t start_useconds,
+                                                const uint64_t finish_seconds,
+                                                const uint64_t finish_useconds);
+void   app_svt_av1_get_time(uint64_t *const seconds, uint64_t *const useconds);
 
 #endif // EbTime_h
 /* File EOF */

--- a/Source/Lib/Common/Codec/EbTime.c
+++ b/Source/Lib/Common/Codec/EbTime.c
@@ -9,93 +9,45 @@
 * PATENTS file, you can obtain it at https://www.aomedia.org/license/patent-license.
 */
 
-#ifndef __USE_POSIX199309
+#ifdef _WIN32
+#include <sys/timeb.h>
+#include <windows.h>
+#elif !defined(__USE_POSIX199309)
 #define __USE_POSIX199309
 #endif
 
 #include <time.h>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
+#if !defined(CLOCK_MONOTONIC) && !defined(_WIN32)
 #include <sys/time.h>
 #endif
 
 #include "EbTime.h"
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC__)
-__attribute__((optimize("unroll-loops")))
-#endif
-
-void eb_start_time(uint64_t *start_seconds, uint64_t *start_u_seconds) {
-#ifdef _WIN32
-    *start_seconds = (uint64_t)clock();
-    (void)(*start_u_seconds);
-#else
-    struct timeval start;
-    gettimeofday(&start, NULL);
-    *start_seconds   = start.tv_sec;
-    *start_u_seconds = start.tv_usec;
-#endif
+double svt_av1_compute_overall_elapsed_time_ms(const uint64_t start_seconds,
+                                               const uint64_t start_useconds,
+                                               const uint64_t finish_seconds,
+                                               const uint64_t finish_useconds) {
+    const int64_t s_diff = (int64_t)finish_seconds - (int64_t)start_seconds,
+                  u_diff = (int64_t)finish_useconds - (int64_t)start_useconds;
+    return (double)s_diff * 1000.0 + (double)u_diff / 1000.0 + 0.5;
 }
 
-void eb_finish_time(uint64_t *finish_seconds, uint64_t *finish_u_seconds) {
+void svt_av1_get_time(uint64_t *const seconds, uint64_t *const useconds) {
 #ifdef _WIN32
-    *finish_seconds = (uint64_t)clock();
-    (void)(*finish_u_seconds);
+    struct _timeb curr_time;
+    _ftime_s(&curr_time);
+    *seconds  = curr_time.time;
+    *useconds = curr_time.millitm;
+#elif defined(CLOCK_MONOTONIC)
+    struct timespec curr_time;
+    clock_gettime(CLOCK_MONOTONIC, &curr_time);
+    *seconds  = curr_time.tv_sec;
+    *useconds = curr_time.tv_nsec / 1000;
 #else
-    struct timeval finish;
-    gettimeofday(&finish, NULL);
-    *finish_seconds   = finish.tv_sec;
-    *finish_u_seconds = finish.tv_usec;
+    struct timeval curr_time;
+    gettimeofday(&curr_time, NULL);
+    *seconds  = curr_time.tv_sec;
+    *useconds = curr_time.tv_usec;
 #endif
 }
-
-void eb_compute_overall_elapsed_time(uint64_t start_seconds, uint64_t start_u_seconds,
-                                     uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                     double *duration) {
-#ifdef _WIN32
-    //double  duration;
-    *duration = (double)(finish_seconds - start_seconds) / CLOCKS_PER_SEC;
-    (void)(start_u_seconds);
-    (void)(finish_u_seconds);
-#else
-    long mtime, seconds, useconds;
-    seconds   = finish_seconds - start_seconds;
-    useconds  = finish_u_seconds - start_u_seconds;
-    mtime     = ((seconds)*1000 + useconds / 1000.0) + 0.5;
-    *duration = (double)mtime / 1000;
-#endif
-}
-
-void eb_compute_overall_elapsed_time_ms(uint64_t start_seconds, uint64_t start_u_seconds,
-                                        uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                        double *duration) {
-#ifdef _WIN32
-    //double  duration;
-    *duration = (double)(finish_seconds - start_seconds);
-    (void)(start_u_seconds);
-    (void)(finish_u_seconds);
-#else
-    long mtime, seconds, useconds;
-    seconds   = finish_seconds - start_seconds;
-    useconds  = finish_u_seconds - start_u_seconds;
-    mtime     = ((seconds)*1000 + useconds / 1000.0) + 0.5;
-    *duration = (double)mtime;
-#endif
-}
-
-void eb_sleep_ms(uint64_t milli_seconds) {
-    if (milli_seconds) {
-#ifdef _WIN32
-        Sleep((DWORD)milli_seconds);
-#else
-        struct timespec req, rem;
-        req.tv_sec = (int32_t)(milli_seconds / 1000);
-        milli_seconds -= req.tv_sec * 1000;
-        req.tv_nsec = milli_seconds * 1000000UL;
-        nanosleep(&req, &rem);
-#endif
-    }
-}
-

--- a/Source/Lib/Common/Codec/EbTime.h
+++ b/Source/Lib/Common/Codec/EbTime.h
@@ -16,23 +16,17 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif
 
-#define NANOSECS_PER_SEC ((uint32_t)(1000000000L))
-
-void eb_start_time(uint64_t *start_seconds, uint64_t *start_u_seconds);
-void eb_finish_time(uint64_t *finish_seconds, uint64_t *finish_u_seconds);
-void eb_compute_overall_elapsed_time(uint64_t start_seconds, uint64_t start_u_seconds,
-                                     uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                     double *duration);
-void eb_compute_overall_elapsed_time_ms(uint64_t start_seconds, uint64_t start_u_seconds,
-                                        uint64_t finish_seconds, uint64_t finish_u_seconds,
-                                        double *duration);
-void eb_sleep_ms(uint64_t milli_seconds);
+double svt_av1_compute_overall_elapsed_time_ms(const uint64_t start_seconds,
+                                               const uint64_t start_useconds,
+                                               const uint64_t finish_seconds,
+                                               const uint64_t finish_useconds);
+void   svt_av1_get_time(uint64_t *const seconds, uint64_t *const useconds);
 
 #ifdef __cplusplus
 }
-#endif // __cplusplus
+#endif
 
 #endif // EbTime_h
 /* File EOF */

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -494,18 +494,15 @@ static void collect_frames_info(PacketizationContext* context_ptr, const EncodeC
         (void)context_ptr;
 #endif
         // Calculate frame latency in milliseconds
-        double   latency               = 0.0;
         uint64_t finish_time_seconds   = 0;
         uint64_t finish_time_u_seconds = 0;
-        eb_finish_time(&finish_time_seconds, &finish_time_u_seconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_u_seconds);
 
-        eb_compute_overall_elapsed_time_ms(queue_entry_ptr->start_time_seconds,
-                                            queue_entry_ptr->start_time_u_seconds,
-                                            finish_time_seconds,
-                                            finish_time_u_seconds,
-                                            &latency);
-
-        output_stream_ptr->n_tick_count  = (uint32_t)latency;
+        output_stream_ptr->n_tick_count = (uint32_t)svt_av1_compute_overall_elapsed_time_ms(
+            queue_entry_ptr->start_time_seconds,
+            queue_entry_ptr->start_time_u_seconds,
+            finish_time_seconds,
+            finish_time_u_seconds);
         output_stream_ptr->p_app_private = queue_entry_ptr->out_meta_data;
         if (queue_entry_ptr->is_alt_ref)
             output_stream_ptr->flags |= (uint32_t)EB_BUFFERFLAG_IS_ALT_REF;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -12,8 +12,6 @@
 #ifndef EbPictureControlSet_h
 #define EbPictureControlSet_h
 
-#include <time.h>
-
 #include "EbSvtAv1Enc.h"
 #include "EbDefinitions.h"
 #include "EbSystemResourceManager.h"

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -213,24 +213,23 @@ void speed_buffer_control(ResourceCoordinationContext *context_ptr,
     eb_block_on_mutex(scs_ptr->encode_context_ptr->sc_buffer_mutex);
 
     if (scs_ptr->encode_context_ptr->sc_frame_in == 0)
-        eb_start_time(&context_ptr->first_in_pic_arrived_time_seconds,
-                      &context_ptr->first_in_pic_arrived_timeu_seconds);
+        svt_av1_get_time(&context_ptr->first_in_pic_arrived_time_seconds,
+                         &context_ptr->first_in_pic_arrived_timeu_seconds);
     else if (scs_ptr->encode_context_ptr->sc_frame_in == SC_FRAMES_TO_IGNORE)
         context_ptr->start_flag = EB_TRUE;
     // Compute duration since the start of the encode and since the previous checkpoint
-    eb_finish_time(&curs_time_seconds, &curs_time_useconds);
+    svt_av1_get_time(&curs_time_seconds, &curs_time_useconds);
 
-    eb_compute_overall_elapsed_time_ms(context_ptr->first_in_pic_arrived_time_seconds,
-                                       context_ptr->first_in_pic_arrived_timeu_seconds,
-                                       curs_time_seconds,
-                                       curs_time_useconds,
-                                       &overall_duration);
+    overall_duration = svt_av1_compute_overall_elapsed_time_ms(
+        context_ptr->first_in_pic_arrived_time_seconds,
+        context_ptr->first_in_pic_arrived_timeu_seconds,
+        curs_time_seconds,
+        curs_time_useconds);
 
-    eb_compute_overall_elapsed_time_ms(context_ptr->prevs_time_seconds,
-                                       context_ptr->prevs_timeu_seconds,
-                                       curs_time_seconds,
-                                       curs_time_useconds,
-                                       &inst_duration);
+    inst_duration = svt_av1_compute_overall_elapsed_time_ms(context_ptr->prevs_time_seconds,
+                                                            context_ptr->prevs_timeu_seconds,
+                                                            curs_time_seconds,
+                                                            curs_time_useconds);
 
     input_frames_count =
         (int64_t)overall_duration * (scs_ptr->static_config.injector_frame_rate >> 16) / 1000;
@@ -906,7 +905,7 @@ void *resource_coordination_kernel(void *input_ptr) {
             pcs_ptr->input_ptr            = eb_input_ptr;
             end_of_sequence_flag =
                 (pcs_ptr->input_ptr->flags & EB_BUFFERFLAG_EOS) ? EB_TRUE : EB_FALSE;
-            eb_start_time(&pcs_ptr->start_time_seconds, &pcs_ptr->start_time_u_seconds);
+            svt_av1_get_time(&pcs_ptr->start_time_seconds, &pcs_ptr->start_time_u_seconds);
 
             pcs_ptr->scs_wrapper_ptr =
                 context_ptr->sequence_control_set_active_array[instance_index];

--- a/test/CdefTest.cc
+++ b/test/CdefTest.cc
@@ -240,7 +240,7 @@ class CDEFBlockTest : public ::testing::TestWithParam<cdef_dir_param_t> {
 
         prepare_data(0, 1);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             for (dir = 0; dir < 8; dir++) {
@@ -273,7 +273,7 @@ class CDEFBlockTest : public ::testing::TestWithParam<cdef_dir_param_t> {
             }
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             for (dir = 0; dir < 8; dir++) {
@@ -306,17 +306,15 @@ class CDEFBlockTest : public ::testing::TestWithParam<cdef_dir_param_t> {
             }
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("Average Nanoseconds per Function Call\n");
         printf("    eb_cdef_filter_block_c()   : %6.2f\n",
@@ -796,7 +794,7 @@ TEST(CdefToolTest, DISABLED_SearchOneDualSpeedTest) {
             uint64_t middle_time_seconds, middle_time_useconds;
             uint64_t finish_time_seconds, finish_time_useconds;
             const uint64_t num_loop = 10000;
-            eb_start_time(&start_time_seconds, &start_time_useconds);
+            svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
             for (uint64_t k = 0; k < num_loop; k++) {
                 best_mse_ref = search_one_dual_c(lvl_luma_ref,
@@ -808,7 +806,7 @@ TEST(CdefToolTest, DISABLED_SearchOneDualSpeedTest) {
                                                  end_gi);
             }
 
-            eb_start_time(&middle_time_seconds, &middle_time_useconds);
+            svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
             for (uint64_t k = 0; k < num_loop; k++) {
                 best_mse_tst = search_one_dual_func_table[i](lvl_luma_tst,
@@ -820,7 +818,7 @@ TEST(CdefToolTest, DISABLED_SearchOneDualSpeedTest) {
                                                              end_gi);
             }
 
-            eb_start_time(&finish_time_seconds, &finish_time_useconds);
+            svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
             ASSERT_EQ(best_mse_tst, best_mse_ref)
                 << "search_one_dual_avx2 return different best mse "
@@ -834,16 +832,16 @@ TEST(CdefToolTest, DISABLED_SearchOneDualSpeedTest) {
                     << " nb_strength: " << nb_strengths << " pos " << h;
             }
 
-            eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                          start_time_useconds,
-                                          middle_time_seconds,
-                                          middle_time_useconds,
-                                          &time_c);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                          middle_time_useconds,
-                                          finish_time_seconds,
-                                          finish_time_useconds,
-                                          &time_o);
+            time_c =
+                svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                        start_time_useconds,
+                                                        middle_time_seconds,
+                                                        middle_time_useconds);
+            time_o =
+                svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                        middle_time_useconds,
+                                                        finish_time_seconds,
+                                                        finish_time_useconds);
 
             printf("Average Nanoseconds per Function Call\n");
             printf("    search_one_dual_c()       : %6.2f\n",

--- a/test/EbUnitTestUtility.h
+++ b/test/EbUnitTestUtility.h
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "EbDefinitions.h"
+#include "EbTime.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -185,14 +186,6 @@ extern void eb_unit_test_log_image_u32(const char *const nameBuf,
                                        const uint32_t width,
                                        const uint32_t height,
                                        const ptrdiff_t stride);
-
-extern void eb_start_time(uint64_t *Startseconds, uint64_t *Startuseconds);
-extern void eb_finish_time(uint64_t *Finishseconds, uint64_t *Finishuseconds);
-extern void eb_compute_overall_elapsed_time_ms(uint64_t Startseconds,
-                                          uint64_t Startuseconds,
-                                          uint64_t Finishseconds,
-                                          uint64_t Finishuseconds,
-                                          double *duration);
 
 #ifdef __cplusplus
 }

--- a/test/EncodeTxbAsmTest.cc
+++ b/test/EncodeTxbAsmTest.cc
@@ -220,17 +220,17 @@ class EncodeTxbInitLevelTest
         // prepare data, same input, differente output by default.
         prepare_data(tx_size);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             ref_func_(input_coeff_, width, height, levels_ref_);
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             test_func(input_coeff_, width, height, levels_test_);
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         // compare the result
         const int stride = width + TX_PAD_HOR;
@@ -243,16 +243,16 @@ class EncodeTxbInitLevelTest
         }
 
         if (is_speed) {
-            eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                          start_time_useconds,
-                                          middle_time_seconds,
-                                          middle_time_useconds,
-                                          &time_c);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                          middle_time_useconds,
-                                          finish_time_seconds,
-                                          finish_time_useconds,
-                                          &time_o);
+            time_c =
+                svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                        start_time_useconds,
+                                                        middle_time_seconds,
+                                                        middle_time_useconds);
+            time_o =
+                svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                        middle_time_useconds,
+                                                        finish_time_seconds,
+                                                        finish_time_useconds);
             printf("eb_av1_txb_init_levels(%2dx%2d): %6.2f\n",
                    width,
                    height,

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -547,27 +547,27 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
             eb_buf_random_s32(input_, MAX_TX_SQUARE);
             memcpy(input, input_, MAX_TX_SQUARE * sizeof(int32_t));
 
-            eb_start_time(&start_time_seconds, &start_time_useconds);
+            svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
             for (uint64_t i = 0; i < num_loop; i++)
                 energy_ref = htf_ref_funcs[idx](input_);
 
-            eb_start_time(&middle_time_seconds, &middle_time_useconds);
+            svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
             for (uint64_t i = 0; i < num_loop; i++)
                 energy_asm = htf_asm_funcs[idx](input);
 
-            eb_start_time(&finish_time_seconds, &finish_time_useconds);
-            eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                          start_time_useconds,
-                                          middle_time_seconds,
-                                          middle_time_useconds,
-                                          &time_c);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                          middle_time_useconds,
-                                          finish_time_seconds,
-                                          finish_time_useconds,
-                                          &time_o);
+            svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+            time_c =
+                svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                        start_time_useconds,
+                                                        middle_time_seconds,
+                                                        middle_time_useconds);
+            time_o =
+                svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                        middle_time_useconds,
+                                                        finish_time_seconds,
+                                                        finish_time_useconds);
 
             ASSERT_EQ(energy_ref, energy_asm);
 

--- a/test/MotionEstimationTest.cc
+++ b/test/MotionEstimationTest.cc
@@ -176,28 +176,26 @@ void sadMxN_speed_test(const AomSadFn *const func_table) {
         const uint64_t num_loop = 100000000 / (width + height);
         uint32_t sad_org, sad_opt;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             sad_org = aom_sad_c_func_ptr_array[j](
                 src_ptr, src_stride, ref_ptr, ref_stride);
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             sad_opt = func_table[j](src_ptr, src_stride, ref_ptr, ref_stride);
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         EXPECT_EQ(sad_org, sad_opt);
 
@@ -237,29 +235,27 @@ void sadMxNx4d_speed_test(const AomSadMultiDFn *const func_table) {
         const uint32_t height = sad_size_info[j].height;
         const uint64_t num_loop = 20000000 / (width + height);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             aom_sad_4d_c_func_ptr_array[j](
                 src_ptr, src_stride, ref_ptr, ref_stride, sad_array_org);
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++)
             func_table[j](
                 src_ptr, src_stride, ref_ptr, ref_stride, sad_array_opt);
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         for (int l = 0; l < 4; l++)
             EXPECT_EQ(sad_array_org[l], sad_array_opt[l]);

--- a/test/PaletteModeUtilTest.cc
+++ b/test/PaletteModeUtilTest.cc
@@ -483,7 +483,7 @@ class Av1KMeansDim : public ::testing::WithParamInterface<Av1KMeansDimParam>,
 
         prepare_data();
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             for (int k = PALETTE_MIN_SIZE; k <= PALETTE_MAX_SIZE; k++) {
@@ -491,7 +491,7 @@ class Av1KMeansDim : public ::testing::WithParamInterface<Av1KMeansDimParam>,
             }
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             for (int k = PALETTE_MIN_SIZE; k <= PALETTE_MAX_SIZE; k++) {
@@ -499,20 +499,18 @@ class Av1KMeansDim : public ::testing::WithParamInterface<Av1KMeansDimParam>,
             }
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         check_output();
 
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("    speedup %5.2fx\n", time_c / time_o);
     }

--- a/test/ResidualTest.cc
+++ b/test/ResidualTest.cc
@@ -226,7 +226,7 @@ class ResidualKernelTest
 
         prepare_data();
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             residual_kernel8bit_c(input_,
@@ -239,19 +239,18 @@ class ResidualKernelTest
                           area_height_);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
 
         for (int i = 0; i < (int) (sizeof(residual_kernel8bit_func_table) /
                                 sizeof(*residual_kernel8bit_func_table));
              i++) {
             eb_buf_random_s16(residual2_, test_size_);
 
-            eb_start_time(&middle_time_seconds, &middle_time_useconds);
+            svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
             for (uint64_t j = 0; j < num_loop; j++) {
                 residual_kernel8bit_func_table[i](input_,
@@ -265,12 +264,12 @@ class ResidualKernelTest
             }
             check_residuals(area_width_, area_height_);
 
-            eb_start_time(&finish_time_seconds, &finish_time_useconds);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                              middle_time_useconds,
-                                              finish_time_seconds,
-                                              finish_time_useconds,
-                                              &time_o);
+            svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+            time_o =
+                svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                        middle_time_useconds,
+                                                        finish_time_seconds,
+                                                        finish_time_useconds);
 
             printf("residual_kernel8bit(%3dx%3d): %6.2f\n",
                    area_width_,

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -159,7 +159,7 @@ class av1_compute_stats_test
 
         const uint64_t num_loop = 100000 / (wiener_win * wiener_win);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             eb_av1_compute_stats_c(wiener_win,
@@ -175,7 +175,7 @@ class av1_compute_stats_test
                                    H_org);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func(wiener_win,
@@ -191,17 +191,15 @@ class av1_compute_stats_test
                  H_opt);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                            start_time_useconds,
-                                            middle_time_seconds,
-                                            middle_time_useconds,
-                                            &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                            middle_time_useconds,
-                                            finish_time_seconds,
-                                            finish_time_useconds,
-                                            &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
         ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));
@@ -405,7 +403,7 @@ class av1_compute_stats_test_hbd
 
         const uint64_t num_loop = 1000000 / (wiener_win * wiener_win);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             eb_av1_compute_stats_highbd_c(wiener_win,
@@ -422,7 +420,7 @@ class av1_compute_stats_test_hbd
                                             bit_depth);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func(wiener_win,
@@ -439,17 +437,15 @@ class av1_compute_stats_test_hbd
                     bit_depth);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                            start_time_useconds,
-                                            middle_time_seconds,
-                                            middle_time_useconds,
-                                            &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                            middle_time_useconds,
-                                            finish_time_seconds,
-                                            finish_time_useconds,
-                                            &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
         ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -704,7 +704,7 @@ class sad_LoopTest : public ::testing::WithParamInterface<sad_LoopTestParam>,
         int16_t y_search_center0 = 0;
         int16_t y_search_center1 = 0;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_c_(src_aligned_,
@@ -721,7 +721,7 @@ class sad_LoopTest : public ::testing::WithParamInterface<sad_LoopTestParam>,
                     search_area_height_);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_o_(src_aligned_,
@@ -738,7 +738,7 @@ class sad_LoopTest : public ::testing::WithParamInterface<sad_LoopTestParam>,
                     search_area_height_);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         EXPECT_EQ(best_sad0, best_sad1)
             << "compare best_sad error"
@@ -756,16 +756,14 @@ class sad_LoopTest : public ::testing::WithParamInterface<sad_LoopTestParam>,
             << "search area [" << search_area_width_ << " x "
             << search_area_height_ << "]";
 
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                           start_time_useconds,
-                                           middle_time_seconds,
-                                           middle_time_useconds,
-                                           &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                           middle_time_useconds,
-                                           finish_time_seconds,
-                                           finish_time_useconds,
-                                           &time_o);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("    sad_loop_kernel(%dx%d) search area[%dx%d]: %5.2fx)\n",
                width_,
@@ -1330,33 +1328,33 @@ class SADTestSubSample16bit
         for (uint32_t area_width = 4; area_width <= 128; area_width += 4) {
             const uint32_t area_height = area_width;
             const int num_loops = 1000000000 / (area_width * area_height);
-            eb_start_time(&start_time_seconds, &start_time_useconds);
+            svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
             for (int i = 0; i < num_loops; ++i) {
                 sad_c = sad_16b_kernel_c(
                     src_, src_stride_, ref_, ref_stride_, height_, width_);
             }
 
-            eb_start_time(&middle_time_seconds, &middle_time_useconds);
+            svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
             for (int i = 0; i < num_loops; ++i) {
                 sad_avx2 = sad_16bit_kernel_avx2(
                     src_, src_stride_, ref_, ref_stride_, height_, width_);
             }
-            eb_start_time(&finish_time_seconds, &finish_time_useconds);
+            svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
             EXPECT_EQ(sad_c, sad_avx2) << area_width << "x" << area_height;
 
-            eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                               start_time_useconds,
-                                               middle_time_seconds,
-                                               middle_time_useconds,
-                                               &time_c);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                               middle_time_useconds,
-                                               finish_time_seconds,
-                                               finish_time_useconds,
-                                               &time_o);
+            time_c =
+                svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                        start_time_useconds,
+                                                        middle_time_seconds,
+                                                        middle_time_useconds);
+            time_o =
+                svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                        middle_time_useconds,
+                                                        finish_time_seconds,
+                                                        finish_time_useconds);
             printf("Average Nanoseconds per Function Call\n");
             printf("    sad_16b_kernel_c  (%dx%d) : %6.2f\n",
                    area_width,

--- a/test/SelfGuidedUtilTest.cc
+++ b/test/SelfGuidedUtilTest.cc
@@ -205,7 +205,7 @@ class PixelProjErrorTest
 
         const uint64_t num_loop = 1000000;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             err_ref = ref_func_(src,
@@ -222,7 +222,7 @@ class PixelProjErrorTest
                                 &params);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             err_test = tst_func_(src,
@@ -239,20 +239,18 @@ class PixelProjErrorTest
                                  &params);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         ASSERT_EQ(err_ref, err_test);
 
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("Average Nanoseconds per Function Call\n");
         printf(

--- a/test/SpatialFullDistortionTest.cc
+++ b/test/SpatialFullDistortionTest.cc
@@ -122,7 +122,7 @@ void SpatialFullDistortionTest::RunSpeedTest() {
     for (uint32_t area_width = 4; area_width <= 128; area_width += 4) {
         const uint32_t area_height = area_width;
         const int num_loops = 1000000000 / (area_width * area_height);
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (int i = 0; i < num_loops; ++i) {
             dist_org = spatial_full_distortion_kernel_c(input_,
@@ -135,7 +135,7 @@ void SpatialFullDistortionTest::RunSpeedTest() {
                                                         area_height);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (int i = 0; i < num_loops; ++i) {
             dist_opt = func_(input_,
@@ -147,20 +147,18 @@ void SpatialFullDistortionTest::RunSpeedTest() {
                              area_width,
                              area_height);
         }
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         EXPECT_EQ(dist_org, dist_opt) << area_width << "x" << area_height;
 
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
         printf("Average Nanoseconds per Function Call\n");
         printf("    spatial_full_distortion_kernel_c  (%dx%d) : %6.2f\n",
                area_width,
@@ -478,7 +476,7 @@ void FullDistortionKernel16BitsFuncTest::RunSpeedTest() {
     for (uint32_t area_width = 4; area_width <= 128; area_width += 4) {
         const uint32_t area_height = area_width;
         const int num_loops = 1000000000 / (area_width * area_height);
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (int i = 0; i < num_loops; ++i) {
             dist_org = full_distortion_kernel16_bits_c(input_,
@@ -491,7 +489,7 @@ void FullDistortionKernel16BitsFuncTest::RunSpeedTest() {
                                                        area_height);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (int i = 0; i < num_loops; ++i) {
             dist_opt = test_func_(input_,
@@ -503,20 +501,18 @@ void FullDistortionKernel16BitsFuncTest::RunSpeedTest() {
                                   area_width,
                                   area_height);
         }
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
         EXPECT_EQ(dist_org, dist_opt) << area_width << "x" << area_height;
 
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
         printf("Average Nanoseconds per Function Call\n");
         printf("    full_distortion_kernel16_bits_c  (%dx%d) : %6.2f\n",
                area_width,

--- a/test/TemporalFilterTestPlanewise.cc
+++ b/test/TemporalFilterTestPlanewise.cc
@@ -308,7 +308,7 @@ void TemporalFilterTestPlanewise::RunTest(int width, int height,
         uint64_t test_timer_seconds, test_timer_useconds;
         double ref_time, tst_time;
 
-        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
+        svt_av1_get_time(&ref_timer_seconds, &ref_timer_useconds);
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
                 context_ptr = &context1;
@@ -340,7 +340,7 @@ void TemporalFilterTestPlanewise::RunTest(int width, int height,
                      accum_ref_ptr[C_V],
                      count_ref_ptr[C_V]);
         }
-        eb_start_time(&middle_timer_seconds, &middle_timer_useconds);
+        svt_av1_get_time(&middle_timer_seconds, &middle_timer_useconds);
 
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
@@ -373,19 +373,19 @@ void TemporalFilterTestPlanewise::RunTest(int width, int height,
                      accum_tst_ptr[C_V],
                      count_tst_ptr[C_V]);
         }
-        eb_start_time(&test_timer_seconds, &test_timer_useconds);
+        svt_av1_get_time(&test_timer_seconds, &test_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(ref_timer_seconds,
-                                           ref_timer_useconds,
-                                           middle_timer_seconds,
-                                           middle_timer_useconds,
-                                           &ref_time);
+        ref_time =
+            svt_av1_compute_overall_elapsed_time_ms(ref_timer_seconds,
+                                                    ref_timer_useconds,
+                                                    middle_timer_seconds,
+                                                    middle_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(middle_timer_seconds,
-                                           middle_timer_useconds,
-                                           test_timer_seconds,
-                                           test_timer_useconds,
-                                           &tst_time);
+        tst_time =
+            svt_av1_compute_overall_elapsed_time_ms(middle_timer_seconds,
+                                                    middle_timer_useconds,
+                                                    test_timer_seconds,
+                                                    test_timer_useconds);
 
         printf(
             "c_time=%lf \t simd_time=%lf \t "
@@ -597,7 +597,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
         uint64_t test_timer_seconds, test_timer_useconds;
         double ref_time, tst_time;
 
-        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
+        svt_av1_get_time(&ref_timer_seconds, &ref_timer_useconds);
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
                 context_ptr = &context1;
@@ -629,7 +629,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_ref_ptr[C_V],
                      count_ref_ptr[C_V]);
         }
-        eb_start_time(&middle_timer_seconds, &middle_timer_useconds);
+        svt_av1_get_time(&middle_timer_seconds, &middle_timer_useconds);
 
         for (int j = 0; j < run_times; j++) {
             tst_func(
@@ -657,19 +657,19 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_tst_ptr[C_V],
                      count_tst_ptr[C_V]);
         }
-        eb_start_time(&test_timer_seconds, &test_timer_useconds);
+        svt_av1_get_time(&test_timer_seconds, &test_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(ref_timer_seconds,
-                                           ref_timer_useconds,
-                                           middle_timer_seconds,
-                                           middle_timer_useconds,
-                                           &ref_time);
+        ref_time =
+            svt_av1_compute_overall_elapsed_time_ms(ref_timer_seconds,
+                                                    ref_timer_useconds,
+                                                    middle_timer_seconds,
+                                                    middle_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(middle_timer_seconds,
-                                           middle_timer_useconds,
-                                           test_timer_seconds,
-                                           test_timer_useconds,
-                                           &tst_time);
+        tst_time =
+            svt_av1_compute_overall_elapsed_time_ms(middle_timer_seconds,
+                                                    middle_timer_useconds,
+                                                    test_timer_seconds,
+                                                    test_timer_useconds);
 
         printf(
             "c_time=%lf \t simd_time=%lf \t "
@@ -699,4 +699,3 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::Values(svt_av1_apply_temporal_filter_planewise_hbd_c),
         ::testing::Values(svt_av1_apply_temporal_filter_planewise_hbd_avx2)));
-

--- a/test/convolve_2d_test.cc
+++ b/test/convolve_2d_test.cc
@@ -709,7 +709,7 @@ class AV1LbdConvolve2DTest
 
         const uint64_t num_loop = 10000000000 / (output_w * output_h);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_ref_(input + offset_r * src_stride + offset_c,
@@ -725,7 +725,7 @@ class AV1LbdConvolve2DTest
                       conv_params_ref);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_tst_(input + offset_r * src_stride + offset_c,
@@ -741,17 +741,15 @@ class AV1LbdConvolve2DTest
                       conv_params_tst);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("convolve(%3dx%3d, tap (%d, %d)): %6.2f\n",
                output_w,
@@ -916,7 +914,7 @@ class AV1HbdConvolve2DTest
 
         const uint64_t num_loop = 10000000 / (output_w * output_h);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_ref_(input + offset_r * src_stride + offset_c,
@@ -933,7 +931,7 @@ class AV1HbdConvolve2DTest
                       bd);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_tst_(input + offset_r * src_stride + offset_c,
@@ -950,17 +948,15 @@ class AV1HbdConvolve2DTest
                       bd);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf(
             "convolve(%3dx%3d): %6.2f\n", output_w, output_h, time_c / time_o);

--- a/test/corner_match_test.cc
+++ b/test/corner_match_test.cc
@@ -94,30 +94,28 @@ void AV1CornerMatchTest::RunCheckOutput(int run_times) {
     double res_simd = target_func(input1, w, x1, y1, input2, w, x2, y2);
 
     if (run_times > 1) {
-      eb_start_time(&start_time_seconds, &start_time_useconds);
+      svt_av1_get_time(&start_time_seconds, &start_time_useconds);
       for (j = 0; j < run_times; j++) {
-        eb_av1_compute_cross_correlation_c(input1, w, x1, y1, input2, w, x2, y2);
+          eb_av1_compute_cross_correlation_c(
+              input1, w, x1, y1, input2, w, x2, y2);
       }
-      eb_start_time(&middle_time_seconds, &middle_time_useconds);
+      svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
       for (j = 0; j < run_times; j++) {
         target_func(input1, w, x1, y1, input2, w, x2, y2);
       }
 
-      eb_start_time(&finish_time_seconds, &finish_time_useconds);
+      svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
 
-
-       eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                    start_time_useconds,
-                                    middle_time_seconds,
-                                    middle_time_useconds,
-                                    &time);
+      time = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                     start_time_useconds,
+                                                     middle_time_seconds,
+                                                     middle_time_useconds);
       time_c += time;
-      eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                    middle_time_useconds,
-                                    finish_time_seconds,
-                                    finish_time_useconds,
-                                    &time);
+      time = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                     middle_time_useconds,
+                                                     finish_time_seconds,
+                                                     finish_time_useconds);
       time_o += time;
 
 

--- a/test/frame_error_test.cc
+++ b/test/frame_error_test.cc
@@ -131,17 +131,16 @@ void AV1FrameErrorTest::RunSpeedTest(frame_error_func test_impl, int width,
         uint64_t start_time_seconds, start_time_useconds;
         uint64_t finish_time_seconds, finish_time_useconds;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
         frame_error_func func = funcs[i];
         for (int j = 0; j < num_loops; ++j) {
             func(ref, stride, dst, width, height, stride);
         }
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                       start_time_useconds,
+                                                       finish_time_seconds,
+                                                       finish_time_useconds);
         elapsed_time[i] = 1000.0 * time / num_loops;
     }
     eb_aom_free(dst);

--- a/test/quantize_func_test.cc
+++ b/test/quantize_func_test.cc
@@ -338,7 +338,7 @@ TEST_P(QuantizeLbdTest, DISABLED_Speed) {
     for (int cnt = 0; cnt <= rows; cnt++) {
         FillCoeffRandomRows(cnt * cols);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
         for (int n = 0; n < kNumTests; ++n) {
             quant_ref_(coeff_ptr,
                        n_coeffs,
@@ -354,7 +354,7 @@ TEST_P(QuantizeLbdTest, DISABLED_Speed) {
                        sc->iscan);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (int n = 0; n < kNumTests; ++n) {
             quant_(coeff_ptr,
@@ -370,17 +370,15 @@ TEST_P(QuantizeLbdTest, DISABLED_Speed) {
                    sc->scan,
                    sc->iscan);
         }
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("c_time = %f \t simd_time = %f \t Gain = %f \n",
                time_c,
@@ -546,7 +544,7 @@ TEST_P(QuantizeHbdTest, DISABLED_Speed) {
     for (int cnt = 0; cnt <= rows; cnt++) {
         FillCoeffRandomRows(cnt * cols);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
         for (int n = 0; n < kNumTests; ++n) {
             quant_ref_(coeff_ptr,
                        n_coeffs,
@@ -563,7 +561,7 @@ TEST_P(QuantizeHbdTest, DISABLED_Speed) {
                        av1_get_tx_scale(tx_size_));
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (int n = 0; n < kNumTests; ++n) {
             quant_(coeff_ptr,
@@ -580,17 +578,15 @@ TEST_P(QuantizeHbdTest, DISABLED_Speed) {
                    sc->iscan,
                    av1_get_tx_scale(tx_size_));
         }
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("c_time = %f \t simd_time = %f \t Gain = %f \n",
                time_c,

--- a/test/selfguided_filter_test.cc
+++ b/test/selfguided_filter_test.cc
@@ -84,7 +84,7 @@ class AV1SelfguidedFilterTest
         uint64_t middle_time_seconds, middle_time_useconds;
         uint64_t finish_time_seconds, finish_time_useconds;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
         for (i = 0; i < NUM_ITERS; ++i) {
             for (k = 0; k < height; k += pu_height)
                 for (j = 0; j < width; j += pu_width) {
@@ -105,7 +105,7 @@ class AV1SelfguidedFilterTest
                                                    0);
                 }
         }
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (i = 0; i < NUM_ITERS; ++i) {
             for (k = 0; k < height; k += pu_height)
@@ -128,17 +128,17 @@ class AV1SelfguidedFilterTest
                 }
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &ref_time);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &tst_time);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        ref_time =
+            svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                    start_time_useconds,
+                                                    middle_time_seconds,
+                                                    middle_time_useconds);
+        tst_time =
+            svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                    middle_time_useconds,
+                                                    finish_time_seconds,
+                                                    finish_time_useconds);
 
         std::cout << "[          ] C time = " << ref_time / 1000
                   << " ms, SIMD time = " << tst_time / 1000 << " ms\n";
@@ -307,7 +307,7 @@ class AV1HighbdSelfguidedFilterTest
         uint64_t middle_time_seconds, middle_time_useconds;
         uint64_t finish_time_seconds, finish_time_useconds;
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
         for (i = 0; i < NUM_ITERS; ++i) {
             for (k = 0; k < height; k += pu_height)
                 for (j = 0; j < width; j += pu_width) {
@@ -328,7 +328,7 @@ class AV1HighbdSelfguidedFilterTest
                                                    1);
                 }
         }
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (i = 0; i < NUM_ITERS; ++i) {
             for (k = 0; k < height; k += pu_height)
@@ -351,17 +351,17 @@ class AV1HighbdSelfguidedFilterTest
                 }
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &ref_time);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &tst_time);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        ref_time =
+            svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                    start_time_useconds,
+                                                    middle_time_seconds,
+                                                    middle_time_useconds);
+        tst_time =
+            svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                    middle_time_useconds,
+                                                    finish_time_seconds,
+                                                    finish_time_useconds);
 
         std::cout << "[          ] C time = " << ref_time / 1000
                   << " ms, SIMD time = " << tst_time / 1000 << " ms\n";
@@ -777,31 +777,29 @@ TEST(IntegralImagesTest, DISABLED_integral_images_speed) {
 
     const uint64_t num_loop = 1000000;
 
-    eb_start_time(&start_time_seconds, &start_time_useconds);
+    svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
     for (uint64_t i = 0; i < num_loop; i++) {
         integral_images_c(
             src8, src_stride, width_ext, height_ext, Ctl_c, Dtl_c, buf_stride);
     }
 
-    eb_start_time(&middle_time_seconds, &middle_time_useconds);
+    svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
     for (uint64_t i = 0; i < num_loop; i++) {
         integral_images(
             src8, src_stride, width_ext, height_ext, Ctl_o, Dtl_o, buf_stride);
     }
 
-    eb_start_time(&finish_time_seconds, &finish_time_useconds);
-    eb_compute_overall_elapsed_time_ms(start_time_seconds,
+    svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+    time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
                                   start_time_useconds,
                                   middle_time_seconds,
-                                  middle_time_useconds,
-                                  &time_c);
-    eb_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                  middle_time_useconds);
+    time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
                                   middle_time_useconds,
                                   finish_time_seconds,
-                                  finish_time_useconds,
-                                  &time_o);
+                                  finish_time_useconds);
 
     for (int y = 0; y < height_ext; y++) {
         for (int x = 0; x < width_ext; x++) {
@@ -817,31 +815,29 @@ TEST(IntegralImagesTest, DISABLED_integral_images_speed) {
            1000000 * time_o / num_loop,
            time_c / time_o);
 
-    eb_start_time(&start_time_seconds, &start_time_useconds);
+    svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
     for (uint64_t i = 0; i < num_loop; i++) {
         integral_images_highbd_c(
             src16, src_stride, width_ext, height_ext, Ctl_c, Dtl_c, buf_stride);
     }
 
-    eb_start_time(&middle_time_seconds, &middle_time_useconds);
+    svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
     for (uint64_t i = 0; i < num_loop; i++) {
         integral_images_highbd(
             src16, src_stride, width_ext, height_ext, Ctl_o, Dtl_o, buf_stride);
     }
 
-    eb_start_time(&finish_time_seconds, &finish_time_useconds);
-    eb_compute_overall_elapsed_time_ms(start_time_seconds,
+    svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+    time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
                                   start_time_useconds,
                                   middle_time_seconds,
-                                  middle_time_useconds,
-                                  &time_c);
-    eb_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                  middle_time_useconds);
+    time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
                                   middle_time_useconds,
                                   finish_time_seconds,
-                                  finish_time_useconds,
-                                  &time_o);
+                                  finish_time_useconds);
 
     for (int y = 0; y < height_ext; y++) {
         for (int x = 0; x < width_ext; x++) {

--- a/test/warp_filter_test_util.cc
+++ b/test/warp_filter_test_util.cc
@@ -201,7 +201,7 @@ void AV1WarpFilterTest::RunSpeedTest(warp_affine_func test_impl) {
     uint64_t start_time_seconds, start_time_useconds;
     uint64_t finish_time_seconds, finish_time_useconds;
 
-    eb_start_time(&start_time_seconds, &start_time_useconds);
+    svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
     for (int i = 0; i < num_loops; ++i)
         test_impl(mat,
@@ -223,12 +223,12 @@ void AV1WarpFilterTest::RunSpeedTest(warp_affine_func test_impl) {
                   gamma,
                   delta);
 
-    eb_start_time(&finish_time_seconds, &finish_time_useconds);
-    eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                  start_time_useconds,
-                                  finish_time_seconds,
-                                  finish_time_useconds,
-                                  &elapsed_time);
+    svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+    elapsed_time =
+        svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                start_time_useconds,
+                                                finish_time_seconds,
+                                                finish_time_useconds);
     printf("warp %3dx%-3d: %7.2f ns\n",
            out_w,
            out_h,
@@ -499,7 +499,7 @@ void AV1HighbdWarpFilterTest::RunSpeedTest(highbd_warp_affine_func test_impl) {
     uint64_t start_time_seconds_ref, start_time_useconds_ref;
     uint64_t finish_time_seconds_ref, finish_time_useconds_ref;
 
-    eb_start_time(&start_time_seconds_tst, &start_time_useconds_tst);
+    svt_av1_get_time(&start_time_seconds_tst, &start_time_useconds_tst);
 
     for (int i = 0; i < num_loops; ++i)
         test_impl(mat,
@@ -522,14 +522,14 @@ void AV1HighbdWarpFilterTest::RunSpeedTest(highbd_warp_affine_func test_impl) {
                   gamma,
                   delta);
 
-    eb_start_time(&finish_time_seconds_tst, &finish_time_useconds_tst);
-    eb_compute_overall_elapsed_time_ms(start_time_seconds_tst,
-                                  start_time_useconds_tst,
-                                  finish_time_seconds_tst,
-                                  finish_time_useconds_tst,
-                                  &elapsed_time_tst);
+    svt_av1_get_time(&finish_time_seconds_tst, &finish_time_useconds_tst);
+    elapsed_time_tst =
+        svt_av1_compute_overall_elapsed_time_ms(start_time_seconds_tst,
+                                                start_time_useconds_tst,
+                                                finish_time_seconds_tst,
+                                                finish_time_useconds_tst);
 
-    eb_start_time(&start_time_seconds_ref, &start_time_useconds_ref);
+    svt_av1_get_time(&start_time_seconds_ref, &start_time_useconds_ref);
 
     for (int i = 0; i < num_loops; ++i)
         eb_av1_highbd_warp_affine_c(mat,
@@ -552,12 +552,12 @@ void AV1HighbdWarpFilterTest::RunSpeedTest(highbd_warp_affine_func test_impl) {
                                     gamma,
                                     delta);
 
-    eb_start_time(&finish_time_seconds_ref, &finish_time_useconds_ref);
-    eb_compute_overall_elapsed_time_ms(start_time_seconds_ref,
-                                  start_time_useconds_ref,
-                                  finish_time_seconds_ref,
-                                  finish_time_useconds_ref,
-                                  &elapsed_time_ref);
+    svt_av1_get_time(&finish_time_seconds_ref, &finish_time_useconds_ref);
+    elapsed_time_ref =
+        svt_av1_compute_overall_elapsed_time_ms(start_time_seconds_ref,
+                                                start_time_useconds_ref,
+                                                finish_time_seconds_ref,
+                                                finish_time_useconds_ref);
 
     printf("highbd warp %3dx%-3d: %7.2fx faster\n",
            out_w,

--- a/test/wiener_convolve_test.cc
+++ b/test/wiener_convolve_test.cc
@@ -377,7 +377,7 @@ class AV1WienerConvolveLbdTest
 
         const uint64_t num_loop = 10000000000 / (out_w_ * out_h_);
 
-        eb_start_time(&start_time_seconds, &start_time_useconds);
+        svt_av1_get_time(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             eb_av1_wiener_convolve_add_src_c(
@@ -392,7 +392,7 @@ class AV1WienerConvolveLbdTest
                 &params);
         }
 
-        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+        svt_av1_get_time(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
             func_tst_(input + offset_r * input_stride + offset_c,
@@ -406,17 +406,15 @@ class AV1WienerConvolveLbdTest
                       &params);
         }
 
-        eb_start_time(&finish_time_seconds, &finish_time_useconds);
-        eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                           start_time_useconds,
-                                           middle_time_seconds,
-                                           middle_time_useconds,
-                                           &time_c);
-        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                           middle_time_useconds,
-                                           finish_time_seconds,
-                                           finish_time_useconds,
-                                           &time_o);
+        svt_av1_get_time(&finish_time_seconds, &finish_time_useconds);
+        time_c = svt_av1_compute_overall_elapsed_time_ms(start_time_seconds,
+                                                         start_time_useconds,
+                                                         middle_time_seconds,
+                                                         middle_time_useconds);
+        time_o = svt_av1_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                                         middle_time_useconds,
+                                                         finish_time_seconds,
+                                                         finish_time_useconds);
 
         printf("convolve(%3dx%3d, tap %d): %6.2f\n",
                out_w_,


### PR DESCRIPTION
# Description

Changes some of the time-related functions so that we are using a more accurate function on Linux and windows.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
