### PR TITLE
Align parameter defaults

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1423,6 +1423,7 @@ EbConfig * eb_config_ctor(EncodePass pass) {
     config_ptr->intra_refresh_type                        = 1;
     config_ptr->hierarchical_levels                       = 4;
     config_ptr->pred_structure                            = 2;
+    config_ptr->disable_dlf_flag                          = EB_FALSE;
     config_ptr->enable_global_motion                      = EB_TRUE;
     config_ptr->progress                                  = 1;
     config_ptr->enable_warped_motion                      = DEFAULT;
@@ -1452,9 +1453,12 @@ EbConfig * eb_config_ctor(EncodePass pass) {
     config_ptr->filter_intra_level                        = DEFAULT;
     config_ptr->enable_intra_edge_filter                  = DEFAULT;
     config_ptr->pic_based_rate_est                        = DEFAULT;
+    config_ptr->ext_block_flag                            = EB_FALSE;
     config_ptr->use_default_me_hme                        = EB_TRUE;
     config_ptr->enable_hme_flag                           = EB_TRUE;
     config_ptr->enable_hme_level0_flag                    = EB_TRUE;
+    config_ptr->enable_hme_level1_flag                    = EB_FALSE;
+    config_ptr->enable_hme_level2_flag                    = EB_FALSE;
     config_ptr->search_area_width                         = 16;
     config_ptr->search_area_height                        = 7;
     config_ptr->number_hme_search_region_in_width         = 2;
@@ -1478,6 +1482,7 @@ EbConfig * eb_config_ctor(EncodePass pass) {
     config_ptr->intrabc_mode                              = DEFAULT;
     config_ptr->palette_level                             = DEFAULT;
     config_ptr->injector_frame_rate                       = 60 << 16;
+    config_ptr->speed_control_flag                        = 0;
 
     // ASM Type
     config_ptr->cpu_flags_limit = CPU_FLAGS_ALL;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2909,6 +2909,8 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->target_bit_rate = 7000000;
     config_ptr->max_qp_allowed = 63;
     config_ptr->min_qp_allowed = 10;
+
+    config_ptr->enable_adaptive_quantization = 2;
     config_ptr->enc_mode = MAX_ENC_PRESET;
     config_ptr->intra_period_length = -2;
     config_ptr->intra_refresh_type = 1;
@@ -2970,13 +2972,15 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->palette_level = DEFAULT;
     config_ptr->enable_manual_pred_struct = EB_FALSE;
     config_ptr->encoder_color_format = EB_YUV420;
+    config_ptr->mrp_level = DEFAULT;
+
     // Bitstream options
     //config_ptr->codeVpsSpsPps = 0;
     //config_ptr->codeEosNal = 0;
     config_ptr->unrestricted_motion_vector = EB_TRUE;
 
     config_ptr->high_dynamic_range_input = 0;
-    config_ptr->screen_content_mode = 0;
+    config_ptr->screen_content_mode = 2;
 
     config_ptr->intrabc_mode = DEFAULT;
 


### PR DESCRIPTION
# Description
Aligns the parameter defaults between the encoder app and the library so that things such as the ffmpeg plugin has similar default behaviour compared to the encoder app.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
