### PR TITLE
fix sub_sad/full_sad selection

### DIFF
--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.h
@@ -174,7 +174,8 @@ extern "C" {
         uint32_t *p_best_mv8x8,
         uint32_t *p_best_mv16x16,
         uint32_t p_eight_sad16x16[16][8],
-        uint32_t p_eight_sad8x8[64][8]);
+        uint32_t p_eight_sad8x8[64][8],
+        EbBool sub_sad);
 
     /*******************************************
     Calculate SAD for 32x32,64x64 from 16x16

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -444,7 +444,7 @@ EbErrorType tf_signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr
     // HME Search Method
         context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
     // ME Search Method
-        context_ptr->me_context_ptr->me_search_method = FULL_SAD_SEARCH;
+        context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
 
     // Set hme/me based reference pruning level (0-4)
     // Ref pruning is disallowed for TF in motion_estimate_sb()

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -546,7 +546,7 @@ extern "C" {
     void ext_sad_calculation_32x32_64x64_c(uint32_t *p_sad16x16, uint32_t *p_best_sad_32x32,
         uint32_t *p_best_sad_64x64, uint32_t *p_best_mv32x32,
         uint32_t *p_best_mv64x64, uint32_t mv, uint32_t *p_sad32x32);
-    RTCD_EXTERN void(*ext_all_sad_calculation_8x8_16x16)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t mv, uint32_t *p_best_sad_8x8, uint32_t *p_best_sad_16x16, uint32_t *p_best_mv8x8, uint32_t *p_best_mv16x16, uint32_t p_eight_sad16x16[16][8], uint32_t p_eight_sad8x8[64][8]);
+    RTCD_EXTERN void(*ext_all_sad_calculation_8x8_16x16)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t mv, uint32_t *p_best_sad_8x8, uint32_t *p_best_sad_16x16, uint32_t *p_best_mv8x8, uint32_t *p_best_mv16x16, uint32_t p_eight_sad16x16[16][8], uint32_t p_eight_sad8x8[64][8], EbBool sub_sad);
     RTCD_EXTERN void(*ext_eight_sad_calculation_32x32_64x64)(uint32_t p_sad16x16[16][8], uint32_t *p_best_sad_32x32, uint32_t *p_best_sad_64x64, uint32_t *p_best_mv32x32, uint32_t *p_best_mv64x64, uint32_t mv, uint32_t p_sad32x32[4][8]);
     RTCD_EXTERN uint32_t(*eb_sad_kernel4x4)(const uint8_t *src, uint32_t src_stride, const uint8_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN void(*initialize_buffer_32bits)(uint32_t* pointer, uint32_t count128, uint32_t count32, uint32_t value);
@@ -1067,7 +1067,7 @@ extern "C" {
         uint32_t *p_best_sad_8x8, uint32_t *p_best_sad_16x16,
         uint32_t *p_best_mv8x8, uint32_t *p_best_mv16x16,
         uint32_t p_eight_sad16x16[16][8],
-        uint32_t p_eight_sad8x8[64][8]);
+        uint32_t p_eight_sad8x8[64][8], EbBool sub_sad);
     void ext_eight_sad_calculation_32x32_64x64_avx2(uint32_t  p_sad16x16[16][8],
         uint32_t *p_best_sad_32x32,
         uint32_t *p_best_sad_64x64,

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -2144,7 +2144,7 @@ EbErrorType first_pass_signal_derivation_me_kernel(
     context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
 
     // ME Search Method
-    context_ptr->me_context_ptr->me_search_method = FULL_SAD_SEARCH;
+    context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
 
     context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
 


### PR DESCRIPTION


# Description
Add the ability to do full_sad calculation in ME by updating the ext_all_sad_calculation_8x8_16x16 code. Set me_search_method to sub_sad by default.

# Author(s)
@ttrigui 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [x] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
