### PR TITLE
Port LibAom optimization and bug fixes

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/highbd_warp_affine_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_warp_affine_avx2.c
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2020, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+ * Media Patent License 1.0 was not distributed with this source code in the
+ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+ */
+#include <immintrin.h>
+#include "common_dsp_rtcd.h"
+#include "EbWarpedMotion.h"
+
+void eb_av1_highbd_warp_affine_avx2(const int32_t *mat, const uint16_t *ref,
+                                 int width, int height, int stride,
+                                 uint16_t *pred, int p_col, int p_row,
+                                 int p_width, int p_height, int p_stride,
+                                 int subsampling_x, int subsampling_y, int bd,
+                                 ConvolveParams *conv_params, int16_t alpha,
+                                 int16_t beta, int16_t gamma, int16_t delta) {
+  __m256i tmp[15];
+  const int reduce_bits_horiz =
+      conv_params->round_0 +
+      AOMMAX(bd + FILTER_BITS - conv_params->round_0 - 14, 0);
+  const int reduce_bits_vert = conv_params->is_compound
+                                   ? conv_params->round_1
+                                   : 2 * FILTER_BITS - reduce_bits_horiz;
+  const int max_bits_horiz = bd + FILTER_BITS + 1 - reduce_bits_horiz;
+  const int offset_bits_horiz = bd + FILTER_BITS - 1;
+  const int offset_bits_vert = bd + 2 * FILTER_BITS - reduce_bits_horiz;
+  const int round_bits =
+      2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+  const int offset_bits = bd + 2 * FILTER_BITS - conv_params->round_0;
+  (void)max_bits_horiz;
+  assert(IMPLIES(conv_params->is_compound, conv_params->dst != NULL));
+
+  const __m256i clip_pixel =
+      _mm256_set1_epi16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+  const __m128i reduce_bits_vert_shift = _mm_cvtsi32_si128(reduce_bits_vert);
+  const __m256i reduce_bits_vert_const =
+      _mm256_set1_epi32(((1 << reduce_bits_vert) >> 1));
+  const __m256i res_add_const = _mm256_set1_epi32(1 << offset_bits_vert);
+  const __m256i res_sub_const =
+      _mm256_set1_epi32(-(1 << (offset_bits - conv_params->round_1)) -
+                        (1 << (offset_bits - conv_params->round_1 - 1)));
+  __m128i round_bits_shift = _mm_cvtsi32_si128(round_bits);
+  __m256i round_bits_const = _mm256_set1_epi32(((1 << round_bits) >> 1));
+
+  const int w0 = conv_params->fwd_offset;
+  const int w1 = conv_params->bck_offset;
+  const __m256i wt0 = _mm256_set1_epi32(w0);
+  const __m256i wt1 = _mm256_set1_epi32(w1);
+
+  __m256i v_rbhoriz = _mm256_set1_epi32(1 << (reduce_bits_horiz - 1));
+  __m256i v_zeros = _mm256_setzero_si256();
+  int ohoriz = 1 << offset_bits_horiz;
+  int mhoriz = 1 << max_bits_horiz;
+  (void)mhoriz;
+  int sx;
+
+  for (int i = 0; i < p_height; i += 8) {
+    for (int j = 0; j < p_width; j += 8) {
+      // Calculate the center of this 8x8 block,
+      // project to luma coordinates (if in a subsampled chroma plane),
+      // apply the affine transformation,
+      // then convert back to the original coordinates (if necessary)
+      const int32_t src_x = (p_col + j + 4) << subsampling_x;
+      const int32_t src_y = (p_row + i + 4) << subsampling_y;
+      const int32_t dst_x = mat[2] * src_x + mat[3] * src_y + mat[0];
+      const int32_t dst_y = mat[4] * src_x + mat[5] * src_y + mat[1];
+      const int32_t x4 = dst_x >> subsampling_x;
+      const int32_t y4 = dst_y >> subsampling_y;
+
+      const int16_t ix4 = x4 >> WARPEDMODEL_PREC_BITS;
+      int32_t sx4 = x4 & ((1 << WARPEDMODEL_PREC_BITS) - 1);
+      const int16_t iy4 = y4 >> WARPEDMODEL_PREC_BITS;
+      int32_t sy4 = y4 & ((1 << WARPEDMODEL_PREC_BITS) - 1);
+
+      sx4 += alpha * (-4) + beta * (-4) + (1 << (WARPEDDIFF_PREC_BITS - 1)) +
+             (WARPEDPIXEL_PREC_SHIFTS << WARPEDDIFF_PREC_BITS);
+      sy4 += gamma * (-4) + delta * (-4) + (1 << (WARPEDDIFF_PREC_BITS - 1)) +
+             (WARPEDPIXEL_PREC_SHIFTS << WARPEDDIFF_PREC_BITS);
+
+      sx4 &= ~((1 << WARP_PARAM_REDUCE_BITS) - 1);
+      sy4 &= ~((1 << WARP_PARAM_REDUCE_BITS) - 1);
+
+      // Horizontal filter
+      if (ix4 <= -7) {
+        for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+          int iy = iy4 + k;
+          if (iy < 0)
+            iy = 0;
+          else if (iy > height - 1)
+            iy = height - 1;
+          tmp[k + 7] = _mm256_cvtepi16_epi32(_mm_set1_epi16(
+              (1 << (bd + FILTER_BITS - reduce_bits_horiz - 1)) +
+              ref[iy * stride] * (1 << (FILTER_BITS - reduce_bits_horiz))));
+        }
+      } else if (ix4 >= width + 6) {
+        for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+          int iy = iy4 + k;
+          if (iy < 0)
+            iy = 0;
+          else if (iy > height - 1)
+            iy = height - 1;
+          tmp[k + 7] = _mm256_cvtepi16_epi32(
+              _mm_set1_epi16((1 << (bd + FILTER_BITS - reduce_bits_horiz - 1)) +
+                             ref[iy * stride + (width - 1)] *
+                                 (1 << (FILTER_BITS - reduce_bits_horiz))));
+        }
+      } else if (((ix4 - 7) < 0) || ((ix4 + 9) > width)) {
+        int32_t tmp1[8];
+        for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+          const int iy = clamp(iy4 + k, 0, height - 1);
+
+          sx = sx4 + beta * (k + 4);
+          for (int l = -4; l < 4; ++l) {
+            int ix = ix4 + l - 3;
+            const int offs = sx >> WARPEDDIFF_PREC_BITS;
+            const int16_t *coeffs = eb_warped_filter[offs];
+
+            int32_t sum = 1 << offset_bits_horiz;
+            for (int m = 0; m < 8; ++m) {
+              const int sample_x = clamp(ix + m, 0, width - 1);
+              sum += ref[iy * stride + sample_x] * coeffs[m];
+            }
+            sum = ROUND_POWER_OF_TWO(sum, reduce_bits_horiz);
+            tmp1[(l + 4) / 2 + ((l + 4) % 2) * 4] = sum;
+            sx += alpha;
+          }
+          tmp[k + 7] = _mm256_loadu_si256((__m256i *)tmp1);
+        }
+      } else {
+        if (beta == 0 && alpha == 0) {
+          sx = sx4;
+          __m128i v_01 = _mm_loadu_si128(
+              (__m128i *)
+                  eb_warped_filter[sx >>
+                                    WARPEDDIFF_PREC_BITS]);  // A7A6A5A4A3A2A1A0
+          __m256i v_c01 = _mm256_broadcastd_epi32(v_01);     // A1A0A1A0A1A0A1A0
+          __m256i v_c23 = _mm256_broadcastd_epi32(
+              _mm_shuffle_epi32(v_01, 1));  // A3A2A3A2A3A2A3A2
+          __m256i v_c45 = _mm256_broadcastd_epi32(
+              _mm_shuffle_epi32(v_01, 2));  // A5A4A5A4A5A4A5A4
+          __m256i v_c67 = _mm256_broadcastd_epi32(
+              _mm_shuffle_epi32(v_01, 3));  // A7A6A7A6A7A6A7A6
+          for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+            int iy = iy4 + k;
+            if (iy < 0)
+              iy = 0;
+            else if (iy > height - 1)
+              iy = height - 1;
+            iy = iy * stride;
+
+            __m256i v_refl = _mm256_inserti128_si256(
+                _mm256_set1_epi16(0),
+                _mm_loadu_si128((__m128i *)&ref[iy + ix4 - 7]), 0);
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm_loadu_si128((__m128i *)&ref[iy + ix4 + 1]),
+                1);  // R15 .. R0
+
+            __m256i v_ref = _mm256_permute4x64_epi64(v_refl, 0xEE);
+
+            __m256i v_refu =
+                _mm256_alignr_epi8(v_ref, v_refl, 2);  // R8R15R14...R2R1
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm256_extracti128_si256(v_refu, 0), 1);
+            v_refu = _mm256_inserti128_si256(
+                v_refu, _mm256_extracti128_si256(v_ref, 0), 0);
+
+            __m256i v_sum = _mm256_set1_epi32(ohoriz);
+            __m256i parsum = _mm256_madd_epi16(
+                v_c01, _mm256_alignr_epi8(v_refu, v_refl,
+                                          0));  // R8R7R6..R1R7R6R5..R1R0
+            __m256i v_sum1 = _mm256_add_epi32(v_sum, parsum);
+
+            parsum = _mm256_madd_epi16(
+                v_c23,
+                _mm256_alignr_epi8(v_refu, v_refl, 4));  // R10R9..R3R9R8..R3R2
+            __m256i v_sum2 = _mm256_add_epi32(v_sum1, parsum);
+            parsum = _mm256_madd_epi16(
+                v_c45, _mm256_alignr_epi8(v_refu, v_refl,
+                                          8));  // R12R11..R5R11R10..R5R4
+            __m256i v_sum3 = _mm256_add_epi32(v_sum2, parsum);
+            parsum = _mm256_madd_epi16(
+                v_c67, _mm256_alignr_epi8(v_refu, v_refl,
+                                          12));  // R14R13..R7R13R12..R7R6
+            __m256i v_sum4 = _mm256_add_epi32(v_sum3, parsum);
+
+            tmp[k + 7] = _mm256_srai_epi32(_mm256_add_epi32(v_sum4, v_rbhoriz),
+                                           reduce_bits_horiz);
+          }
+        } else if (alpha == 0) {
+          for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+            int iy = iy4 + k;
+            if (iy < 0)
+              iy = 0;
+            else if (iy > height - 1)
+              iy = height - 1;
+            iy = iy * stride;
+
+            sx = sx4 + beta * (k + 4);
+
+            __m128i v_01 = _mm_loadu_si128(
+                (__m128i *)eb_warped_filter
+                    [sx >> WARPEDDIFF_PREC_BITS]);          // A7A6A5A4A3A2A1A0
+            __m256i v_c01 = _mm256_broadcastd_epi32(v_01);  // A1A0A1A0A1A0A1A0
+            __m256i v_c23 = _mm256_broadcastd_epi32(
+                _mm_shuffle_epi32(v_01, 1));  // A3A2A3A2A3A2A3A2
+            __m256i v_c45 = _mm256_broadcastd_epi32(
+                _mm_shuffle_epi32(v_01, 2));  // A5A4A5A4A5A4A5A4
+            __m256i v_c67 = _mm256_broadcastd_epi32(
+                _mm_shuffle_epi32(v_01, 3));  // A7A6A7A6A7A6A7A6
+
+            __m256i v_refl = _mm256_inserti128_si256(
+                _mm256_set1_epi16(0),
+                _mm_loadu_si128((__m128i *)&ref[iy + ix4 - 7]), 0);
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm_loadu_si128((__m128i *)&ref[iy + ix4 + 1]),
+                1);  // R15 .. R0
+
+            __m256i v_ref = _mm256_permute4x64_epi64(v_refl, 0xEE);
+
+            __m256i v_refu =
+                _mm256_alignr_epi8(v_ref, v_refl, 2);  // R8R15R14...R2R1
+
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm256_extracti128_si256(v_refu, 0), 1);
+            v_refu = _mm256_inserti128_si256(
+                v_refu, _mm256_extracti128_si256(v_ref, 0), 0);
+
+            __m256i v_sum = _mm256_set1_epi32(ohoriz);
+            __m256i parsum =
+                _mm256_madd_epi16(v_c01, _mm256_alignr_epi8(v_refu, v_refl, 0));
+            __m256i v_sum1 = _mm256_add_epi32(v_sum, parsum);
+
+            parsum =
+                _mm256_madd_epi16(v_c23, _mm256_alignr_epi8(v_refu, v_refl, 4));
+            __m256i v_sum2 = _mm256_add_epi32(v_sum1, parsum);
+            parsum =
+                _mm256_madd_epi16(v_c45, _mm256_alignr_epi8(v_refu, v_refl, 8));
+            __m256i v_sum3 = _mm256_add_epi32(v_sum2, parsum);
+            parsum = _mm256_madd_epi16(v_c67,
+                                       _mm256_alignr_epi8(v_refu, v_refl, 12));
+            __m256i v_sum4 = _mm256_add_epi32(v_sum3, parsum);
+
+            tmp[k + 7] = _mm256_srai_epi32(_mm256_add_epi32(v_sum4, v_rbhoriz),
+                                           reduce_bits_horiz);
+          }
+        } else if (beta == 0) {
+          sx = sx4;
+          __m256i v_coeff01 = _mm256_inserti128_si256(
+              v_zeros,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx) >> WARPEDDIFF_PREC_BITS]),
+              0);
+          v_coeff01 = _mm256_inserti128_si256(
+              v_coeff01,
+              _mm_loadu_si128(
+                  (__m128i *)
+                  eb_warped_filter[(sx + alpha) >> WARPEDDIFF_PREC_BITS]),
+              1);  // B7B6..B1B0A7A6..A1A0
+          __m256i v_coeff23 = _mm256_inserti128_si256(
+              v_zeros,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 2 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              0);
+          v_coeff23 = _mm256_inserti128_si256(
+              v_coeff23,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 3 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              1);  // D7D6..D1D0C7C6..C1C0
+          __m256i v_coeff45 = _mm256_inserti128_si256(
+              v_zeros,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 4 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              0);
+          v_coeff45 = _mm256_inserti128_si256(
+              v_coeff45,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 5 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              1);  // F7F6..F1F0E7E6..E1E0
+          __m256i v_coeff67 = _mm256_inserti128_si256(
+              v_zeros,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 6 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              0);
+          v_coeff67 = _mm256_inserti128_si256(
+              v_coeff67,
+              _mm_loadu_si128(
+                  (__m128i *)eb_warped_filter[(sx + 7 * alpha) >>
+                                               WARPEDDIFF_PREC_BITS]),
+              1);  // H7H6..H1H0G7G6..G1G0
+
+          __m256i v_c0123 = _mm256_unpacklo_epi32(
+              v_coeff01,
+              v_coeff23);  // D3D2B3B2D1D0B1B0C3C2A3A2C1C0A1A0
+          __m256i v_c0123u = _mm256_unpackhi_epi32(
+              v_coeff01,
+              v_coeff23);  // D7D6B7B6D5D4B5B4C7C6A7A6C5C4A5A4
+          __m256i v_c4567 = _mm256_unpacklo_epi32(
+              v_coeff45,
+              v_coeff67);  // H3H2F3F2H1H0F1F0G3G2E3E2G1G0E1E0
+          __m256i v_c4567u = _mm256_unpackhi_epi32(
+              v_coeff45,
+              v_coeff67);  // H7H6F7F6H5H4F5F4G7G6E7E6G5G4E5E4
+
+          __m256i v_c01 = _mm256_unpacklo_epi64(
+              v_c0123, v_c4567);  // H1H0F1F0D1D0B1B0G1G0E1E0C1C0A1A0
+          __m256i v_c23 =
+              _mm256_unpackhi_epi64(v_c0123, v_c4567);  // H3H2 ... A3A2
+          __m256i v_c45 =
+              _mm256_unpacklo_epi64(v_c0123u, v_c4567u);  // H5H4 ... A5A4
+          __m256i v_c67 =
+              _mm256_unpackhi_epi64(v_c0123u, v_c4567u);  // H7H6 ... A7A6
+
+          for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+            int iy = iy4 + k;
+            if (iy < 0)
+              iy = 0;
+            else if (iy > height - 1)
+              iy = height - 1;
+            iy = iy * stride;
+
+            __m256i v_refl = _mm256_inserti128_si256(
+                _mm256_set1_epi16(0),
+                _mm_loadu_si128((__m128i *)&ref[iy + ix4 - 7]), 0);
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm_loadu_si128((__m128i *)&ref[iy + ix4 + 1]),
+                1);  // R15 .. R0
+
+            __m256i v_ref = _mm256_permute4x64_epi64(v_refl, 0xEE);
+
+            __m256i v_refu =
+                _mm256_alignr_epi8(v_ref, v_refl, 2);  // R8R15R14...R2R1
+
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm256_extracti128_si256(v_refu, 0), 1);
+            v_refu = _mm256_inserti128_si256(
+                v_refu, _mm256_extracti128_si256(v_ref, 0), 0);
+
+            __m256i v_sum = _mm256_set1_epi32(ohoriz);
+            __m256i parsum = _mm256_madd_epi16(
+                v_c01, _mm256_alignr_epi8(v_refu, v_refl,
+                                          0));  // R8R7R6..R1R7R6R5..R1R0
+            __m256i v_sum1 = _mm256_add_epi32(v_sum, parsum);
+
+            parsum = _mm256_madd_epi16(
+                v_c23,
+                _mm256_alignr_epi8(v_refu, v_refl, 4));  // R10R9..R3R9R8..R3R2
+            __m256i v_sum2 = _mm256_add_epi32(v_sum1, parsum);
+            parsum = _mm256_madd_epi16(
+                v_c45, _mm256_alignr_epi8(v_refu, v_refl,
+                                          8));  // R12R11..R5R11R10..R5R4
+            __m256i v_sum3 = _mm256_add_epi32(v_sum2, parsum);
+            parsum = _mm256_madd_epi16(
+                v_c67, _mm256_alignr_epi8(v_refu, v_refl,
+                                          12));  // R14R13..R7R13R12..R7R6
+            __m256i v_sum4 = _mm256_add_epi32(v_sum3, parsum);
+
+            tmp[k + 7] = _mm256_srai_epi32(_mm256_add_epi32(v_sum4, v_rbhoriz),
+                                           reduce_bits_horiz);
+          }
+
+        } else {
+          for (int k = -7; k < AOMMIN(8, p_height - i); ++k) {
+            int iy = iy4 + k;
+            if (iy < 0)
+              iy = 0;
+            else if (iy > height - 1)
+              iy = height - 1;
+            iy = iy * stride;
+
+            sx = sx4 + beta * (k + 4);
+
+            __m256i v_coeff01 = _mm256_inserti128_si256(
+                v_zeros,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx) >> WARPEDDIFF_PREC_BITS]),
+                0);
+            v_coeff01 = _mm256_inserti128_si256(
+                v_coeff01,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                1);  // B7B6..B1B0A7A6..A1A0
+            __m256i v_coeff23 = _mm256_inserti128_si256(
+                v_zeros,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 2 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                0);
+            v_coeff23 = _mm256_inserti128_si256(
+                v_coeff23,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 3 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                1);  // D7D6..D1D0C7C6..C1C0
+            __m256i v_coeff45 = _mm256_inserti128_si256(
+                v_zeros,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 4 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                0);
+            v_coeff45 = _mm256_inserti128_si256(
+                v_coeff45,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 5 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                1);  // F7F6..F1F0E7E6..E1E0
+            __m256i v_coeff67 = _mm256_inserti128_si256(
+                v_zeros,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 6 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                0);
+            v_coeff67 = _mm256_inserti128_si256(
+                v_coeff67,
+                _mm_loadu_si128(
+                    (__m128i *)eb_warped_filter[(sx + 7 * alpha) >>
+                                                 WARPEDDIFF_PREC_BITS]),
+                1);  // H7H6..H1H0G7G6..G1G0
+
+            __m256i v_c0123 = _mm256_unpacklo_epi32(
+                v_coeff01,
+                v_coeff23);  // D3D2B3B2D1D0B1B0C3C2A3A2C1C0A1A0
+            __m256i v_c0123u = _mm256_unpackhi_epi32(
+                v_coeff01,
+                v_coeff23);  // D7D6B7B6D5D4B5B4C7C6A7A6C5C4A5A4
+            __m256i v_c4567 = _mm256_unpacklo_epi32(
+                v_coeff45,
+                v_coeff67);  // H3H2F3F2H1H0F1F0G3G2E3E2G1G0E1E0
+            __m256i v_c4567u = _mm256_unpackhi_epi32(
+                v_coeff45,
+                v_coeff67);  // H7H6F7F6H5H4F5F4G7G6E7E6G5G4E5E4
+
+            __m256i v_c01 = _mm256_unpacklo_epi64(
+                v_c0123, v_c4567);  // H1H0F1F0D1D0B1B0G1G0E1E0C1C0A1A0
+            __m256i v_c23 =
+                _mm256_unpackhi_epi64(v_c0123, v_c4567);  // H3H2 ... A3A2
+            __m256i v_c45 =
+                _mm256_unpacklo_epi64(v_c0123u, v_c4567u);  // H5H4 ... A5A4
+            __m256i v_c67 =
+                _mm256_unpackhi_epi64(v_c0123u, v_c4567u);  // H7H6 ... A7A6
+
+            __m256i v_refl = _mm256_inserti128_si256(
+                _mm256_set1_epi16(0),
+                _mm_loadu_si128((__m128i *)&ref[iy + ix4 - 7]), 0);
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm_loadu_si128((__m128i *)&ref[iy + ix4 + 1]),
+                1);  // R15 .. R0
+
+            __m256i v_ref = _mm256_permute4x64_epi64(v_refl, 0xEE);
+
+            __m256i v_refu =
+                _mm256_alignr_epi8(v_ref, v_refl, 2);  // R8R15R14...R2R1
+
+            v_refl = _mm256_inserti128_si256(
+                v_refl, _mm256_extracti128_si256(v_refu, 0), 1);
+            v_refu = _mm256_inserti128_si256(
+                v_refu, _mm256_extracti128_si256(v_ref, 0), 0);
+
+            __m256i v_sum = _mm256_set1_epi32(ohoriz);
+            __m256i parsum =
+                _mm256_madd_epi16(v_c01, _mm256_alignr_epi8(v_refu, v_refl, 0));
+            __m256i v_sum1 = _mm256_add_epi32(v_sum, parsum);
+
+            parsum =
+                _mm256_madd_epi16(v_c23, _mm256_alignr_epi8(v_refu, v_refl, 4));
+            __m256i v_sum2 = _mm256_add_epi32(v_sum1, parsum);
+            parsum =
+                _mm256_madd_epi16(v_c45, _mm256_alignr_epi8(v_refu, v_refl, 8));
+            __m256i v_sum3 = _mm256_add_epi32(v_sum2, parsum);
+            parsum = _mm256_madd_epi16(v_c67,
+                                       _mm256_alignr_epi8(v_refu, v_refl, 12));
+            __m256i v_sum4 = _mm256_add_epi32(v_sum3, parsum);
+
+            tmp[k + 7] = _mm256_srai_epi32(_mm256_add_epi32(v_sum4, v_rbhoriz),
+                                           reduce_bits_horiz);
+          }
+        }
+      }
+
+      // Vertical filter
+      for (int k = -4; k < AOMMIN(4, p_height - i - 4); ++k) {
+        int sy = sy4 + delta * (k + 4);
+        const __m256i *src = tmp + (k + 4);
+
+        __m256i v_coeff01 = _mm256_inserti128_si256(
+            v_zeros,
+            _mm_loadu_si128(
+                (__m128i *)eb_warped_filter[(sy) >> WARPEDDIFF_PREC_BITS]),
+            0);
+        v_coeff01 = _mm256_inserti128_si256(
+            v_coeff01,
+            _mm_loadu_si128(
+                (__m128i *)
+                    eb_warped_filter[(sy + gamma) >> WARPEDDIFF_PREC_BITS]),
+            1);
+        __m256i v_coeff23 = _mm256_inserti128_si256(
+            v_zeros,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 2 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            0);
+        v_coeff23 = _mm256_inserti128_si256(
+            v_coeff23,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 3 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            1);
+        __m256i v_coeff45 = _mm256_inserti128_si256(
+            v_zeros,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 4 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            0);
+        v_coeff45 = _mm256_inserti128_si256(
+            v_coeff45,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 5 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            1);
+        __m256i v_coeff67 = _mm256_inserti128_si256(
+            v_zeros,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 6 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            0);
+        v_coeff67 = _mm256_inserti128_si256(
+            v_coeff67,
+            _mm_loadu_si128((__m128i *)eb_warped_filter[(sy + 7 * gamma) >>
+                                                         WARPEDDIFF_PREC_BITS]),
+            1);
+
+        __m256i v_c0123 = _mm256_unpacklo_epi32(
+            v_coeff01,
+            v_coeff23);  // D3D2B3B2D1D0B1B0C3C2A3A2C1C0A1A0
+        __m256i v_c0123u = _mm256_unpackhi_epi32(
+            v_coeff01,
+            v_coeff23);  // D7D6B7B6D5D4B5B4C7C6A7A6C5C4A5A4
+        __m256i v_c4567 = _mm256_unpacklo_epi32(
+            v_coeff45,
+            v_coeff67);  // H3H2F3F2H1H0F1F0G3G2E3E2G1G0E1E0
+        __m256i v_c4567u = _mm256_unpackhi_epi32(
+            v_coeff45,
+            v_coeff67);  // H7H6F7F6H5H4F5F4G7G6E7E6G5G4E5E4
+
+        __m256i v_c01 = _mm256_unpacklo_epi64(
+            v_c0123, v_c4567);  // H1H0F1F0D1D0B1B0G1G0E1E0C1C0A1A0
+        __m256i v_c23 =
+            _mm256_unpackhi_epi64(v_c0123, v_c4567);  // H3H2 ... A3A2
+        __m256i v_c45 =
+            _mm256_unpacklo_epi64(v_c0123u, v_c4567u);  // H5H4 ... A5A4
+        __m256i v_c67 =
+            _mm256_unpackhi_epi64(v_c0123u, v_c4567u);  // H7H6 ... A7A6
+
+        __m256i v_src01l =
+            _mm256_unpacklo_epi32(src[0], src[1]);  // T13T03T11T01T12T02T10T00
+        __m256i v_src01u =
+            _mm256_unpackhi_epi32(src[0], src[1]);  // T17T07T15T05T16T06T14T04
+        __m256i v_sum =
+            _mm256_madd_epi16(_mm256_packus_epi32(v_src01l, v_src01u),
+                              v_c01);  // S7S5S3S1S6S4S2S0
+
+        __m256i v_src23l = _mm256_unpacklo_epi32(src[2], src[3]);
+        __m256i v_src23u = _mm256_unpackhi_epi32(src[2], src[3]);
+        v_sum = _mm256_add_epi32(
+            v_sum,
+            _mm256_madd_epi16(_mm256_packus_epi32(v_src23l, v_src23u), v_c23));
+
+        __m256i v_src45l = _mm256_unpacklo_epi32(src[4], src[5]);
+        __m256i v_src45u = _mm256_unpackhi_epi32(src[4], src[5]);
+        v_sum = _mm256_add_epi32(
+            v_sum,
+            _mm256_madd_epi16(_mm256_packus_epi32(v_src45l, v_src45u), v_c45));
+
+        __m256i v_src67l = _mm256_unpacklo_epi32(src[6], src[7]);
+        __m256i v_src67u = _mm256_unpackhi_epi32(src[6], src[7]);
+        v_sum = _mm256_add_epi32(
+            v_sum,
+            _mm256_madd_epi16(_mm256_packus_epi32(v_src67l, v_src67u), v_c67));
+
+        // unpack S7S5S3S1S6S4S2S0 to S7S6S5S4S3S2S1S0
+
+        __m256i v_suml =
+            _mm256_permute4x64_epi64(v_sum, 0xD8);  // S7S5S6S4S3S1S2S0
+        __m256i v_sumh =
+            _mm256_permute4x64_epi64(v_sum, 0x32);      // S2S0S7S5S2S0S3S1
+        v_sum = _mm256_unpacklo_epi32(v_suml, v_sumh);  // S7S6S5S4S3S2S1S0
+
+        if (conv_params->is_compound) {
+          __m128i *const p =
+              (__m128i *)&conv_params
+                  ->dst[(i + k + 4) * conv_params->dst_stride + j];
+
+          v_sum = _mm256_add_epi32(v_sum, res_add_const);
+          v_sum =
+              _mm256_sra_epi32(_mm256_add_epi32(v_sum, reduce_bits_vert_const),
+                               reduce_bits_vert_shift);
+          if (conv_params->do_average) {
+            __m128i *const dst16 = (__m128i *)&pred[(i + k + 4) * p_stride + j];
+            __m256i p_32 = _mm256_cvtepu16_epi32(_mm_loadu_si128(p));
+
+            if (conv_params->use_dist_wtd_comp_avg) {
+              v_sum = _mm256_add_epi32(_mm256_mullo_epi32(p_32, wt0),
+                                       _mm256_mullo_epi32(v_sum, wt1));
+              v_sum = _mm256_srai_epi32(v_sum, DIST_PRECISION_BITS);
+            } else {
+              v_sum = _mm256_srai_epi32(_mm256_add_epi32(p_32, v_sum), 1);
+            }
+
+            __m256i v_sum1 = _mm256_add_epi32(v_sum, res_sub_const);
+            v_sum1 = _mm256_sra_epi32(
+                _mm256_add_epi32(v_sum1, round_bits_const), round_bits_shift);
+
+            __m256i v_sum16 = _mm256_packus_epi32(v_sum1, v_sum1);
+            v_sum16 = _mm256_permute4x64_epi64(v_sum16, 0xD8);
+            v_sum16 = _mm256_min_epi16(v_sum16, clip_pixel);
+            _mm_storeu_si128(dst16, _mm256_extracti128_si256(v_sum16, 0));
+          } else {
+            v_sum = _mm256_packus_epi32(v_sum, v_sum);
+            __m256i v_sum16 = _mm256_permute4x64_epi64(v_sum, 0xD8);
+            _mm_storeu_si128(p, _mm256_extracti128_si256(v_sum16, 0));
+          }
+        } else {
+          // Round and pack into 8 bits
+          const __m256i round_const =
+              _mm256_set1_epi32(-(1 << (bd + reduce_bits_vert - 1)) +
+                                ((1 << reduce_bits_vert) >> 1));
+
+          __m256i v_sum1 = _mm256_srai_epi32(
+              _mm256_add_epi32(v_sum, round_const), reduce_bits_vert);
+
+          v_sum1 = _mm256_packus_epi32(v_sum1, v_sum1);
+          __m256i v_sum16 = _mm256_permute4x64_epi64(v_sum1, 0xD8);
+          // Clamp res_16bit to the range [0, 2^bd - 1]
+          const __m256i max_val = _mm256_set1_epi16((1 << bd) - 1);
+          const __m256i zero = _mm256_setzero_si256();
+          v_sum16 = _mm256_max_epi16(_mm256_min_epi16(v_sum16, max_val), zero);
+
+          __m128i *const p = (__m128i *)&pred[(i + k + 4) * p_stride + j];
+
+          _mm_storeu_si128(p, _mm256_extracti128_si256(v_sum16, 0));
+        }
+      }
+    }
+  }
+}

--- a/Source/Lib/Common/ASM_AVX2/highbd_warp_affine_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_warp_affine_avx2.c
@@ -603,7 +603,7 @@ void eb_av1_highbd_warp_affine_avx2(const int32_t *mat, const uint16_t *ref,
             __m128i *const dst16 = (__m128i *)&pred[(i + k + 4) * p_stride + j];
             __m256i p_32 = _mm256_cvtepu16_epi32(_mm_loadu_si128(p));
 
-            if (conv_params->use_dist_wtd_comp_avg) {
+            if (conv_params->use_jnt_comp_avg) {
               v_sum = _mm256_add_epi32(_mm256_mullo_epi32(p_32, wt0),
                                        _mm256_mullo_epi32(v_sum, wt1));
               v_sum = _mm256_srai_epi32(v_sum, DIST_PRECISION_BITS);

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -1227,8 +1227,8 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
             eb_cdef_filter_block_8x8_16 = eb_cdef_filter_block_8x8_16_avx512;
         }
 #endif
-        SET_SSE41(
-            eb_av1_highbd_warp_affine, eb_av1_highbd_warp_affine_c, eb_av1_highbd_warp_affine_sse4_1);
+        SET_AVX2(
+            eb_av1_highbd_warp_affine, eb_av1_highbd_warp_affine_c, eb_av1_highbd_warp_affine_avx2);
         if (flags & HAS_AVX2) eb_av1_warp_affine = eb_av1_warp_affine_avx2;
         SET_SSE2(svt_aom_highbd_lpf_horizontal_14, svt_aom_highbd_lpf_horizontal_14_c, svt_aom_highbd_lpf_horizontal_14_sse2);
         SET_SSE2(svt_aom_highbd_lpf_horizontal_4, svt_aom_highbd_lpf_horizontal_4_c, svt_aom_highbd_lpf_horizontal_4_sse2);

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -2172,7 +2172,7 @@ extern "C" {
 
             void eb_copy_rect8_8bit_to_16bit_avx2(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
 
-            void eb_av1_highbd_warp_affine_sse4_1(const int32_t *mat, const uint16_t *ref, int width, int height, int stride, uint16_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, int bd, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
+            void eb_av1_highbd_warp_affine_avx2(const int32_t *mat, const uint16_t *ref, int width, int height, int stride, uint16_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, int bd, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
 
             void eb_av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
 

--- a/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
@@ -418,7 +418,7 @@ static void apply_temporal_filter_planewise_hbd(
     const uint16_t *frame2, const unsigned int stride2, const int block_width,
     const int block_height, const double sigma, const int decay_control, unsigned int *accumulator,
     uint16_t *count, uint32_t *luma_sq_error, uint32_t *chroma_sq_error, int plane, int ss_x_shift,
-    int ss_y_shift) {
+    int ss_y_shift, uint32_t encoder_bit_depth) {
     assert(TF_PLANEWISE_FILTER_WINDOW_LENGTH == 5);
     assert(((block_width == 32) && (block_height == 32)) ||
            ((block_width == 16) && (block_height == 16)));
@@ -502,7 +502,7 @@ static void apply_temporal_filter_planewise_hbd(
                     }
                 }
             }
-            diff_sse >>= 4;
+            diff_sse >>= ((encoder_bit_depth - 8) * 2);
             // Combine window error and block error, and normalize it.
             double    window_error = (double)diff_sse / num_ref_pixels;
             const int subblock_idx = (i >= block_height / 2) * 2 + (j >= block_width / 2);
@@ -557,7 +557,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_avx2(
     const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
     unsigned int block_height, int ss_x, int ss_y, const double *noise_levels,
     const int decay_control, uint32_t *y_accum, uint16_t *y_count, uint32_t *u_accum,
-    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count) {
+    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count,uint32_t encoder_bit_depth) {
     // Loop variables
     assert(block_width <= BW && "block width too large");
     assert(block_height <= BH && "block height too large");
@@ -597,6 +597,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_avx2(
                                             chroma_sq_error,
                                             plane,
                                             ss_x_shift,
-                                            ss_y_shift);
+                                            ss_y_shift,
+                                            encoder_bit_depth);
     }
 }

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -617,7 +617,7 @@ static const int64_t cc2_12 = 61817334;  // (64^2*(.03*4095)^2
 static double similarity(uint32_t sum_s, uint32_t sum_r, uint32_t sum_sq_s,
                          uint32_t sum_sq_r, uint32_t sum_sxr, int count,
                          uint32_t bd) {
-  int64_t ssim_n, ssim_d;
+  double ssim_n, ssim_d;
   int64_t c1, c2;
 
   if (bd == 8) {
@@ -635,14 +635,14 @@ static double similarity(uint32_t sum_s, uint32_t sum_r, uint32_t sum_sq_s,
     assert(0);
   }
 
-  ssim_n = ((int64_t)2 * sum_s * sum_r + c1) *
-           ((int64_t)2 * count * sum_sxr - (int64_t)2 * sum_s * sum_r + c2);
+  ssim_n = (2.0 * sum_s * sum_r + c1) *
+           (2.0 * count * sum_sxr - 2.0 * sum_s * sum_r + c2);
 
-  ssim_d = ((int64_t)sum_s * sum_s + (int64_t)sum_r * sum_r + c1) *
-           ((int64_t)count * sum_sq_s - (int64_t)sum_s * sum_s +
-            (int64_t)count * sum_sq_r - (int64_t)sum_r * sum_r + c2);
+  ssim_d = ((double)sum_s * sum_s + (double)sum_r * sum_r + c1) *
+           ((double)count * sum_sq_s - (double)sum_s * sum_s +
+            (double)count * sum_sq_r - (double)sum_r * sum_r + c2);
 
-  return ssim_n * 1.0 / ssim_d;
+  return ssim_n / ssim_d;
 }
 
 static double ssim_8x8(const uint8_t *s, int sp, const uint8_t *r, int rp) {

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.h
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.h
@@ -126,7 +126,7 @@ void svt_av1_apply_temporal_filter_planewise_hbd_c(
     const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
     unsigned int block_height, int ss_x, int ss_y, const double *noise_levels,
     const int decay_control, uint32_t *y_accum, uint16_t *y_count, uint32_t *u_accum,
-    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count);
+    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, uint32_t encoder_bit_depth);
 double estimate_noise(const uint8_t *src, uint16_t width, uint16_t height,
     uint16_t stride_y);
 

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -535,7 +535,7 @@ extern "C" {
         const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
         unsigned int block_height, int ss_x, int ss_y, const double *noise_levels,
         const int decay_control, uint32_t *y_accum, uint16_t *y_count, uint32_t *u_accum,
-        uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count);
+        uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, uint32_t encoder_bit_depth);
     RTCD_EXTERN void(*ext_sad_calculation_8x8_16x16)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t *p_best_sad_8x8, uint32_t *p_best_sad_16x16, uint32_t *p_best_mv8x8, uint32_t *p_best_mv16x16, uint32_t mv, uint32_t *p_sad16x16, uint32_t *p_sad8x8, EbBool sub_sad);
     void ext_sad_calculation_8x8_16x16_c(uint8_t *src, uint32_t src_stride, uint8_t *ref,
         uint32_t ref_stride, uint32_t *p_best_sad_8x8,
@@ -1122,7 +1122,7 @@ extern "C" {
         const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
         unsigned int block_height, int ss_x, int ss_y, const double *noise_levels,
         const int decay_control, uint32_t *y_accum, uint16_t *y_count, uint32_t *u_accum,
-        uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count);
+        uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, uint32_t encoder_bit_depth);
     uint32_t variance_highbd_avx2(const uint16_t *a, int a_stride, const uint16_t *b, int b_stride,
                               int w, int h, uint32_t *sse);
     int eb_av1_haar_ac_sad_8x8_uint8_input_avx2(uint8_t *input, int stride, int hbd);

--- a/test/TemporalFilterTestPlanewise.cc
+++ b/test/TemporalFilterTestPlanewise.cc
@@ -666,7 +666,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
         double ref_time, tst_time;
 
         encoder_bit_depth = 10;
-        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
+        svt_av1_get_time(&ref_timer_seconds, &ref_timer_useconds);
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
                 context_ptr = &context1;
@@ -753,7 +753,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
             encoder_bit_depth);
 
         encoder_bit_depth = 12;
-        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
+        svt_av1_get_time(&ref_timer_seconds, &ref_timer_useconds);
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
                 context_ptr = &context1;
@@ -787,7 +787,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                 count_ref_ptr[C_V],
                 encoder_bit_depth);
         }
-        eb_start_time(&middle_timer_seconds, &middle_timer_useconds);
+        svt_av1_get_time(&middle_timer_seconds, &middle_timer_useconds);
 
         for (int j = 0; j < run_times; j++) {
             tst_func(
@@ -816,19 +816,19 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                 count_tst_ptr[C_V],
                 encoder_bit_depth);
         }
-        eb_start_time(&test_timer_seconds, &test_timer_useconds);
+        svt_av1_get_time(&test_timer_seconds, &test_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(ref_timer_seconds,
-            ref_timer_useconds,
-            middle_timer_seconds,
-            middle_timer_useconds,
-            &ref_time);
+        ref_time =
+            svt_av1_compute_overall_elapsed_time_ms(ref_timer_seconds,
+                                                    ref_timer_useconds,
+                                                    middle_timer_seconds,
+                                                    middle_timer_useconds);
 
-        eb_compute_overall_elapsed_time_ms(middle_timer_seconds,
-            middle_timer_useconds,
-            test_timer_seconds,
-            test_timer_useconds,
-            &tst_time);
+        tst_time =
+            svt_av1_compute_overall_elapsed_time_ms(middle_timer_seconds,
+                                                    middle_timer_useconds,
+                                                    test_timer_seconds,
+                                                    test_timer_useconds);
 
         printf(
             "c_time=%lf \t simd_time=%lf \t "

--- a/test/TemporalFilterTestPlanewise.cc
+++ b/test/TemporalFilterTestPlanewise.cc
@@ -37,7 +37,7 @@ typedef void (*TemporalFilterFuncHbd)(
     const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
     unsigned int block_height, int ss_x, int ss_y, const double *noise_levels,
     const int decay_control, uint32_t *y_accum, uint16_t *y_count,
-    uint32_t *u_accum, uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count);
+    uint32_t *u_accum, uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, uint32_t encoder_bit_depth);
 
 #define MAX_STRIDE 256
 
@@ -511,6 +511,7 @@ class TemporalFilterTestPlanewiseHbd
     uint32_t stride_pred[COLOR_CHANNELS];
     double noise_levels[COLOR_CHANNELS];
     int decay_control;
+    uint32_t encoder_bit_depth;
 };
 
 void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
@@ -527,6 +528,7 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
             } else {
                 context_ptr = &context2;
             }
+            encoder_bit_depth = 10;
             ref_func(
                      context_ptr,
                      src_ptr[C_Y],
@@ -550,11 +552,11 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_ref_ptr[C_U],
                      count_ref_ptr[C_U],
                      accum_ref_ptr[C_V],
-                     count_ref_ptr[C_V]);
+                     count_ref_ptr[C_V],
+                     encoder_bit_depth);
 
             tst_func(
                      context_ptr,
-
                      src_ptr[C_Y],
                      stride[C_Y],
                      pred_ptr[C_Y],
@@ -576,7 +578,8 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_tst_ptr[C_U],
                      count_tst_ptr[C_U],
                      accum_tst_ptr[C_V],
-                     count_tst_ptr[C_V]);
+                     count_tst_ptr[C_V],
+                     encoder_bit_depth);
 
             for (int color_channel = 0; color_channel < COLOR_CHANNELS;
                  color_channel++) {
@@ -590,6 +593,71 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                                  MAX_STRIDE * MAX_STRIDE * sizeof(uint16_t)),
                           0);
             }
+            encoder_bit_depth = 12;
+            ref_func(
+                context_ptr,
+                src_ptr[C_Y],
+                stride[C_Y],
+                pred_ptr[C_Y],
+                stride_pred[C_Y],
+                src_ptr[C_U],
+                src_ptr[C_V],
+                stride[C_U],
+                pred_ptr[C_U],
+                pred_ptr[C_V],
+                stride_pred[C_U],
+                width,
+                height,
+                1,  // subsampling
+                1,  // subsampling
+                noise_levels,
+                decay_control,
+                accum_ref_ptr[C_Y],
+                count_ref_ptr[C_Y],
+                accum_ref_ptr[C_U],
+                count_ref_ptr[C_U],
+                accum_ref_ptr[C_V],
+                count_ref_ptr[C_V],
+                encoder_bit_depth);
+
+            tst_func(
+                context_ptr,
+                src_ptr[C_Y],
+                stride[C_Y],
+                pred_ptr[C_Y],
+                stride_pred[C_Y],
+                src_ptr[C_U],
+                src_ptr[C_V],
+                stride[C_U],
+                pred_ptr[C_U],
+                pred_ptr[C_V],
+                stride_pred[C_U],
+                width,
+                height,
+                1,  // subsampling
+                1,  // subsampling
+                noise_levels,
+                decay_control,
+                accum_tst_ptr[C_Y],
+                count_tst_ptr[C_Y],
+                accum_tst_ptr[C_U],
+                count_tst_ptr[C_U],
+                accum_tst_ptr[C_V],
+                count_tst_ptr[C_V],
+                encoder_bit_depth);
+
+            for (int color_channel = 0; color_channel < COLOR_CHANNELS;
+                color_channel++) {
+                EXPECT_EQ(memcmp(accum_ref_ptr[color_channel],
+                    accum_tst_ptr[color_channel],
+                    MAX_STRIDE * MAX_STRIDE * sizeof(uint32_t)),
+                    0);
+
+                EXPECT_EQ(memcmp(count_ref_ptr[color_channel],
+                    count_tst_ptr[color_channel],
+                    MAX_STRIDE * MAX_STRIDE * sizeof(uint16_t)),
+                    0);
+            }
         }
     } else {
         uint64_t ref_timer_seconds, ref_timer_useconds;
@@ -597,7 +665,8 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
         uint64_t test_timer_seconds, test_timer_useconds;
         double ref_time, tst_time;
 
-        svt_av1_get_time(&ref_timer_seconds, &ref_timer_useconds);
+        encoder_bit_depth = 10;
+        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
         for (int j = 0; j < run_times; j++) {
             if (j % 2 == 0) {
                 context_ptr = &context1;
@@ -627,7 +696,8 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_ref_ptr[C_U],
                      count_ref_ptr[C_U],
                      accum_ref_ptr[C_V],
-                     count_ref_ptr[C_V]);
+                     count_ref_ptr[C_V],
+                     encoder_bit_depth);
         }
         svt_av1_get_time(&middle_timer_seconds, &middle_timer_useconds);
 
@@ -655,7 +725,8 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
                      accum_tst_ptr[C_U],
                      count_tst_ptr[C_U],
                      accum_tst_ptr[C_V],
-                     count_tst_ptr[C_V]);
+                     count_tst_ptr[C_V],
+                     encoder_bit_depth);
         }
         svt_av1_get_time(&test_timer_seconds, &test_timer_useconds);
 
@@ -673,12 +744,101 @@ void TemporalFilterTestPlanewiseHbd::RunTest(int width, int height,
 
         printf(
             "c_time=%lf \t simd_time=%lf \t "
-            "gain=%lf\t width=%d\t height=%d \n",
+            "gain=%lf\t width=%d\t height=%d \t encoder_bit_depth=%d \n",
             ref_time / 1000,
             tst_time / 1000,
             ref_time / tst_time,
             width,
-            height);
+            height,
+            encoder_bit_depth);
+
+        encoder_bit_depth = 12;
+        eb_start_time(&ref_timer_seconds, &ref_timer_useconds);
+        for (int j = 0; j < run_times; j++) {
+            if (j % 2 == 0) {
+                context_ptr = &context1;
+            }
+            else {
+                context_ptr = &context2;
+            }
+            ref_func(
+                context_ptr,
+                src_ptr[C_Y],
+                stride[C_Y],
+                pred_ptr[C_Y],
+                stride_pred[C_Y],
+                src_ptr[C_U],
+                src_ptr[C_V],
+                stride[C_U],
+                pred_ptr[C_U],
+                pred_ptr[C_V],
+                stride_pred[C_U],
+                width,
+                height,
+                1,  // subsampling
+                1,  // subsampling
+                noise_levels,
+                decay_control,
+                accum_ref_ptr[C_Y],
+                count_ref_ptr[C_Y],
+                accum_ref_ptr[C_U],
+                count_ref_ptr[C_U],
+                accum_ref_ptr[C_V],
+                count_ref_ptr[C_V],
+                encoder_bit_depth);
+        }
+        eb_start_time(&middle_timer_seconds, &middle_timer_useconds);
+
+        for (int j = 0; j < run_times; j++) {
+            tst_func(
+                context_ptr,
+                src_ptr[C_Y],
+                stride[C_Y],
+                pred_ptr[C_Y],
+                stride_pred[C_Y],
+                src_ptr[C_U],
+                src_ptr[C_V],
+                stride[C_U],
+                pred_ptr[C_U],
+                pred_ptr[C_V],
+                stride_pred[C_U],
+                width,
+                height,
+                1,  // subsampling
+                1,  // subsampling
+                noise_levels,
+                decay_control,
+                accum_tst_ptr[C_Y],
+                count_tst_ptr[C_Y],
+                accum_tst_ptr[C_U],
+                count_tst_ptr[C_U],
+                accum_tst_ptr[C_V],
+                count_tst_ptr[C_V],
+                encoder_bit_depth);
+        }
+        eb_start_time(&test_timer_seconds, &test_timer_useconds);
+
+        eb_compute_overall_elapsed_time_ms(ref_timer_seconds,
+            ref_timer_useconds,
+            middle_timer_seconds,
+            middle_timer_useconds,
+            &ref_time);
+
+        eb_compute_overall_elapsed_time_ms(middle_timer_seconds,
+            middle_timer_useconds,
+            test_timer_seconds,
+            test_timer_useconds,
+            &tst_time);
+
+        printf(
+            "c_time=%lf \t simd_time=%lf \t "
+            "gain=%lf\t width=%d\t height=%d \t encoder_bit_depth=%d \n",
+            ref_time / 1000,
+            tst_time / 1000,
+            ref_time / tst_time,
+            width,
+            height,
+            encoder_bit_depth);
     }
 }
 

--- a/test/warp_filter_test.cc
+++ b/test/warp_filter_test.cc
@@ -41,7 +41,7 @@ INSTANTIATE_TEST_CASE_P(
     AVX2, AV1WarpFilterTest,
     libaom_test::AV1WarpFilter::BuildParams(eb_av1_warp_affine_avx2));
 
-INSTANTIATE_TEST_CASE_P(SSE4_1, AV1HighbdWarpFilterTest,
+INSTANTIATE_TEST_CASE_P(AVX2, AV1HighbdWarpFilterTest,
                         libaom_test::AV1HighbdWarpFilter::BuildParams(
-                            eb_av1_highbd_warp_affine_sse4_1));
+                            eb_av1_highbd_warp_affine_avx2));
 }  // namespace


### PR DESCRIPTION
# Description

- Fix integer overflow in 12bit SSIM calculation

- Scale the pixel difference in temporal filtering according to its bit depth. This resolves a compression performance regression in

12 bit setting

- port av1_highbd_warp_affine_avx2 and use it instead of the SSE4.1 version

# Author(s)
@ttrigui 
@spawlows 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
