### PR TITLE
Fix nxm_sad_kernel_helper_avx2: Assertion `0' failed

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -3336,6 +3336,38 @@ uint32_t eb_compute64x_m_sad_avx2_intrin(
     return compute64x_m_sad_avx2(src, src_stride, ref, ref_stride, height);
 }
 
+/*******************************************************************************
+* Requirement: height % 4 = 0
+*******************************************************************************/
+uint32_t eb_compute56x_m_sad_avx2_intrin(
+    const uint8_t *src, // input parameter, source samples Ptr
+    uint32_t       src_stride, // input parameter, source stride
+    const uint8_t *ref, // input parameter, reference samples Ptr
+    uint32_t       ref_stride, // input parameter, reference stride
+    uint32_t       height, // input parameter, block height (M)
+    uint32_t       width) // input parameter, block width (N)
+{
+
+    return eb_compute48x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width) +
+        compute8x_m_sad_avx2(src + 48, src_stride, ref + 48, ref_stride, height);
+}
+
+/*******************************************************************************
+* Requirement: height % 4 = 0
+*******************************************************************************/
+uint32_t eb_compute40x_m_sad_avx2_intrin(
+    const uint8_t *src, // input parameter, source samples Ptr
+    uint32_t       src_stride, // input parameter, source stride
+    const uint8_t *ref, // input parameter, reference samples Ptr
+    uint32_t       ref_stride, // input parameter, reference stride
+    uint32_t       height, // input parameter, block height (M)
+    uint32_t       width) // input parameter, block width (N)
+{
+    (void)width;
+    return compute32x_m_sad_avx2(src, src_stride, ref, ref_stride, height) +
+        compute8x_m_sad_avx2(src + 32, src_stride, ref + 32, ref_stride, height);
+}
+
 uint32_t eb_compute128x_m_sad_avx2_intrin(
     const uint8_t *src, // input parameter, source samples Ptr
     uint32_t       src_stride, // input parameter, source stride
@@ -4630,7 +4662,8 @@ uint32_t nxm_sad_kernel_sub_sampled_helper_avx2(const uint8_t *src, uint32_t src
     case 128:
         nxm_sad = eb_compute128x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
         break;
-    default: assert(0);
+    default:
+        nxm_sad = nxm_sad_kernel_helper_c(src, src_stride, ref, ref_stride, height, width);
     }
 
     return nxm_sad;
@@ -4656,15 +4689,20 @@ uint32_t nxm_sad_kernel_helper_avx2(const uint8_t *src, uint32_t src_stride, con
     case 32:
         nxm_sad = eb_compute32x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
         break;
+    case 40:
+        nxm_sad = eb_compute40x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
+        break;
     case 48:
         nxm_sad = eb_compute48x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
+        break;
+    case 56:
+        nxm_sad = eb_compute56x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
         break;
     case 64:
         nxm_sad = eb_compute64x_m_sad_avx2_intrin(src, src_stride, ref, ref_stride, height, width);
         break;
-    case 40:
-    case 52: break; //void_func();
-    default: assert(0);
+    default:
+        nxm_sad = nxm_sad_kernel_helper_c(src, src_stride, ref, ref_stride, height, width);
     }
 
     return nxm_sad;

--- a/Source/Lib/Encoder/C_DEFAULT/EbComputeSAD_C.c
+++ b/Source/Lib/Encoder/C_DEFAULT/EbComputeSAD_C.c
@@ -206,21 +206,6 @@ sadMxNx4D(64, 16);
 
 uint32_t nxm_sad_kernel_helper_c(const uint8_t *src, uint32_t src_stride, const uint8_t *ref,
                                  uint32_t ref_stride, uint32_t height, uint32_t width) {
-    uint32_t nxm_sad = 0;
 
-    switch (width) {
-    case 4:
-    case 8:
-    case 16:
-    case 24:
-    case 32:
-    case 48:
-    case 64:
-    case 128:
-        nxm_sad = fast_loop_nxm_sad_kernel(src, src_stride, ref, ref_stride, height, width);
-        break;
-    default: assert(0);
-    }
-
-    return nxm_sad;
+    return fast_loop_nxm_sad_kernel(src, src_stride, ref, ref_stride, height, width);
 };

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -98,7 +98,8 @@ BlkSize TEST_BLOCK_SIZES[] = {
     BlkSize(24, 16), BlkSize(16, 24), BlkSize(24, 8),  BlkSize(8, 24),
     BlkSize(64, 24), BlkSize(48, 24), BlkSize(32, 24), BlkSize(24, 32),
     BlkSize(48, 48), BlkSize(48, 16), BlkSize(48, 32), BlkSize(16, 48),
-    BlkSize(32, 48), BlkSize(48, 64), BlkSize(64, 48)};
+    BlkSize(32, 48), BlkSize(48, 64), BlkSize(64, 48), BlkSize(56, 32),
+    BlkSize(40, 32)};
 
 BlkSize TEST_BLOCK_SIZES_SMALL[] = {
     BlkSize(6, 2),   BlkSize(6, 4),   BlkSize(6, 8),   BlkSize(6, 16),


### PR DESCRIPTION
# Description

Added support for width=56/40 in nxm_sad_kernel_helper_avx2() and changed default condition


# Issue
Fixes #1512 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
