### PR TITLE
get_help: Send to stdout and improve readability

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2035,10 +2035,8 @@ int32_t find_token_multiple_inputs(int32_t argc, char *const argv[], const char 
     return return_error;
 }
 
-uint32_t check_long(ConfigEntry cfg_entry, ConfigEntry cfg_entry_next) {
-    if (cfg_entry_next.name == NULL) { return 0; }
-    if (strcmp(cfg_entry.name, cfg_entry_next.name) == 0) { return 1; }
-    return 0;
+static int check_long(ConfigEntry cfg_entry, ConfigEntry cfg_entry_next) {
+    return cfg_entry_next.name ? !strcmp(cfg_entry.name, cfg_entry_next.name) : 0;
 }
 
 uint32_t get_help(int32_t argc, char *const argv[]) {

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2054,117 +2054,112 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
         "Or a combined cli:\n"
         "    SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i src_filename\n"
         "\nOptions:\n");
-    for (int options_token_index = -1; config_entry_options[++options_token_index].token;) {
+    for (ConfigEntry *options_token_index = config_entry_options; options_token_index->token;
+         ++options_token_index) {
         // this only works if short and long token are one after another
-        switch (check_long(config_entry_options[options_token_index],
-                           config_entry_options[options_token_index + 1])) {
+        switch (check_long(*options_token_index, options_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_options[options_token_index].token,
-                   config_entry_options[options_token_index + 1].token,
-                   config_entry_options[options_token_index].name);
+                   options_token_index->token,
+                   options_token_index[1].token,
+                   options_token_index->name);
             ++options_token_index;
             break;
         default:
-            printf(*(config_entry_options[options_token_index].token + 1) == '-'
-                       ? "      %-25s    %-25s\n"
-                       : "      -%-25s   %-25s\n",
-                   config_entry_options[options_token_index].token,
-                   config_entry_options[options_token_index].name);
+            printf(options_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                        : "      -%-25s   %-25s\n",
+                   options_token_index->token,
+                   options_token_index->name);
         }
     }
     printf("\nEncoder Global Options:\n");
-    for (int global_options_token_index = -1;
-         config_entry_global_options[++global_options_token_index].token;) {
-        switch (check_long(config_entry_global_options[global_options_token_index],
-                           config_entry_global_options[global_options_token_index + 1])) {
+    for (ConfigEntry *global_options_token_index = config_entry_global_options;
+         global_options_token_index->token;
+         ++global_options_token_index) {
+        switch (check_long(*global_options_token_index, global_options_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_global_options[global_options_token_index].token,
-                   config_entry_global_options[global_options_token_index + 1].token,
-                   config_entry_global_options[global_options_token_index].name);
+                   global_options_token_index->token,
+                   global_options_token_index[1].token,
+                   global_options_token_index->name);
             ++global_options_token_index;
             break;
         default:
-            printf(*(config_entry_global_options[global_options_token_index].token + 1) == '-'
-                       ? "      %-25s    %-25s\n"
-                       : "      -%-25s   %-25s\n",
-                   config_entry_global_options[global_options_token_index].token,
-                   config_entry_global_options[global_options_token_index].name);
+            printf(global_options_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                               : "      -%-25s   %-25s\n",
+                   global_options_token_index->token,
+                   global_options_token_index->name);
         }
     }
     printf("\nRate Control Options:\n");
-    for (int rc_token_index = -1; config_entry_rc[++rc_token_index].token;) {
-        switch (check_long(config_entry_rc[rc_token_index], config_entry_rc[rc_token_index + 1])) {
+    for (ConfigEntry *rc_token_index = config_entry_rc; rc_token_index->token; ++rc_token_index) {
+        switch (check_long(*rc_token_index, rc_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_rc[rc_token_index].token,
-                   config_entry_rc[rc_token_index + 1].token,
-                   config_entry_rc[rc_token_index].name);
+                   rc_token_index->token,
+                   rc_token_index[1].token,
+                   rc_token_index->name);
             ++rc_token_index;
             break;
         default:
-            printf(*(config_entry_rc[rc_token_index].token + 1) == '-' ? "      %-25s    %-25s\n"
-                                                                       : "      -%-25s   %-25s\n",
-                   config_entry_rc[rc_token_index].token,
-                   config_entry_rc[rc_token_index].name);
+            printf(rc_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                   : "      -%-25s   %-25s\n",
+                   rc_token_index->token,
+                   rc_token_index->name);
         }
     }
     printf("\nTwopass Options:\n");
-    for (int two_p_token_index = -1; config_entry_2p[++two_p_token_index].token;) {
-        switch (check_long(config_entry_2p[two_p_token_index],
-                           config_entry_2p[two_p_token_index + 1])) {
+    for (ConfigEntry *two_p_token_index = config_entry_2p; two_p_token_index->token;
+         ++two_p_token_index) {
+        switch (check_long(*two_p_token_index, two_p_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_2p[two_p_token_index].token,
-                   config_entry_2p[two_p_token_index + 1].token,
-                   config_entry_2p[two_p_token_index].name);
+                   two_p_token_index->token,
+                   two_p_token_index[1].token,
+                   two_p_token_index->name);
             ++two_p_token_index;
             break;
         default:
-            printf(*(config_entry_2p[two_p_token_index].token + 1) == '-'
-                       ? "      %-25s    %-25s\n"
-                       : "      -%-25s   %-25s\n",
-                   config_entry_2p[two_p_token_index].token,
-                   config_entry_2p[two_p_token_index].name);
+            printf(two_p_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                      : "      -%-25s   %-25s\n",
+                   two_p_token_index->token,
+                   two_p_token_index->name);
         }
     }
     printf("\nKeyframe Placement Options:\n");
-    for (int kf_token_index = -1; config_entry_intra_refresh[++kf_token_index].token;) {
-        switch (check_long(config_entry_intra_refresh[kf_token_index],
-                           config_entry_intra_refresh[kf_token_index + 1])) {
+    for (ConfigEntry *kf_token_index = config_entry_intra_refresh; kf_token_index->token;
+         ++kf_token_index) {
+        switch (check_long(*kf_token_index, kf_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_intra_refresh[kf_token_index].token,
-                   config_entry_intra_refresh[kf_token_index + 1].token,
-                   config_entry_intra_refresh[kf_token_index].name);
+                   kf_token_index->token,
+                   kf_token_index[1].token,
+                   kf_token_index->name);
             ++kf_token_index;
             break;
         default:
-            printf(*(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
-                       ? "      %-25s    %-25s\n"
-                       : "      -%-25s   %-25s\n",
-                   config_entry_intra_refresh[kf_token_index].token,
-                   config_entry_intra_refresh[kf_token_index].name);
+            printf(kf_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                   : "      -%-25s   %-25s\n",
+                   kf_token_index->token,
+                   kf_token_index->name);
         }
     }
     printf("\nAV1 Specific Options:\n");
-    for (int sp_token_index = -1; config_entry_specific[++sp_token_index].token;) {
-        switch (check_long(config_entry_specific[sp_token_index],
-                           config_entry_specific[sp_token_index + 1])) {
+    for (ConfigEntry *sp_token_index = config_entry_specific; sp_token_index->token;
+         ++sp_token_index) {
+        switch (check_long(*sp_token_index, sp_token_index[1])) {
         case 1:
             printf("  %s, %-25s    %-25s\n",
-                   config_entry_specific[sp_token_index].token,
-                   config_entry_specific[sp_token_index + 1].token,
-                   config_entry_specific[sp_token_index].name);
+                   sp_token_index->token,
+                   sp_token_index[1].token,
+                   sp_token_index->name);
             ++sp_token_index;
             break;
         default:
-            printf(*(config_entry_specific[sp_token_index].token + 1) == '-'
-                       ? "      %-25s    %-25s\n"
-                       : "      -%-25s   %-25s\n",
-                   config_entry_specific[sp_token_index].token,
-                   config_entry_specific[sp_token_index].name);
+            printf(sp_token_index->token[1] == '-' ? "      %-25s    %-25s\n"
+                                                   : "      -%-25s   %-25s\n",
+                   sp_token_index->token,
+                   sp_token_index->name);
         }
     }
     return 1;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1729,7 +1729,8 @@ static int32_t find_token(int32_t argc, char *const argv[], char const *token, c
 
     while ((argc > 0) && (return_error != 0)) {
         return_error = strcmp(argv[--argc], token);
-        if (return_error == 0) { strcpy_s(configStr, COMMAND_LINE_MAX_SIZE, argv[argc + 1]); }
+        if (return_error == 0 && configStr)
+            strcpy_s(configStr, COMMAND_LINE_MAX_SIZE, argv[argc + 1]);
     }
 
     return return_error;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2043,154 +2043,157 @@ uint32_t check_long(ConfigEntry cfg_entry, ConfigEntry cfg_entry_next) {
 
 uint32_t get_help(int32_t argc, char *const argv[]) {
     char config_string[COMMAND_LINE_MAX_SIZE];
-    if (find_token(argc, argv, HELP_TOKEN, config_string) == 0 ||
-        find_token(argc, argv, HELP_LONG_TOKEN, config_string) == 0) {
-        int32_t options_token_index        = -1;
-        int32_t global_options_token_index = -1;
-        int32_t rc_token_index             = -1;
-        int32_t two_p_token_index          = -1;
-        int32_t kf_token_index             = -1;
-        int32_t sp_token_index             = -1;
-        //fprintf(stderr, "\n%-25s\t%-25s\n", "TOKEN", "DESCRIPTION");
-        //fprintf(stderr, "%-25s\t%-25s\n", "-nch", "NumberOfChannels");
-        const char *empty_string         = "";
-        fprintf(stderr,
-                "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
-        fprintf(stderr, "\n%-25s\n", "Examples:");
-        fprintf(stderr, "\n%-25s", "Two passes encode:");
-        fprintf(stderr, "\n\t%s", "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename");
-        fprintf(stderr, "\n\t%s", "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename");
-        fprintf(stderr, "\n    Or a combined cli:");
-        fprintf(stderr, "\n\t%s\n", "SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i src_filename");
-        fprintf(stderr, "\n%-25s\n", "Options:");
-        while (config_entry_options[++options_token_index].token != NULL) {
-            uint32_t check = check_long(
-                config_entry_options[options_token_index],
-                config_entry_options
-                    [options_token_index +
-                     1]); // this only works if short and long token are one after another
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_options[options_token_index].token,
-                        config_entry_options[options_token_index + 1].token,
-                        config_entry_options[options_token_index].name);
-                options_token_index++;
-            } else
-                fprintf(stderr,
-                        *(config_entry_options[options_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_options[options_token_index].token,
-                        config_entry_options[options_token_index].name);
-        }
-        fprintf(stderr, "\n%-25s\n", "Encoder Global Options:");
-        while (config_entry_global_options[++global_options_token_index].token != NULL) {
-            uint32_t check =
-                check_long(config_entry_global_options[global_options_token_index],
-                           config_entry_global_options[global_options_token_index + 1]);
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_global_options[global_options_token_index].token,
-                        config_entry_global_options[global_options_token_index + 1].token,
-                        config_entry_global_options[global_options_token_index].name);
-                global_options_token_index++;
-            } else {
-                fprintf(stderr,
-                        *(config_entry_global_options[global_options_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_global_options[global_options_token_index].token,
-                        config_entry_global_options[global_options_token_index].name);
-            }
-        }
-        fprintf(stderr, "\n%-25s\n", "Rate Control Options:");
-        while (config_entry_rc[++rc_token_index].token != NULL) {
-            uint32_t check =
-                check_long(config_entry_rc[rc_token_index], config_entry_rc[rc_token_index + 1]);
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_rc[rc_token_index].token,
-                        config_entry_rc[rc_token_index + 1].token,
-                        config_entry_rc[rc_token_index].name);
-                rc_token_index++;
-            } else {
-                fprintf(stderr,
-                        *(config_entry_rc[rc_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_rc[rc_token_index].token,
-                        config_entry_rc[rc_token_index].name);
-            }
-        }
-        fprintf(stderr, "\n%-25s\n", "Twopass Options:");
-        while (config_entry_2p[++two_p_token_index].token != NULL) {
-            uint32_t check = check_long(config_entry_2p[two_p_token_index],
-                                        config_entry_2p[two_p_token_index + 1]);
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_2p[two_p_token_index].token,
-                        config_entry_2p[two_p_token_index + 1].token,
-                        config_entry_2p[two_p_token_index].name);
-                two_p_token_index++;
-            } else
-                fprintf(stderr,
-                        *(config_entry_2p[two_p_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_2p[two_p_token_index].token,
-                        config_entry_2p[two_p_token_index].name);
-        }
-        fprintf(stderr, "\n%-25s\n", "Keyframe Placement Options:");
-        while (config_entry_intra_refresh[++kf_token_index].token != NULL) {
-            uint32_t check = check_long(config_entry_intra_refresh[kf_token_index],
-                                        config_entry_intra_refresh[kf_token_index + 1]);
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_intra_refresh[kf_token_index].token,
-                        config_entry_intra_refresh[kf_token_index + 1].token,
-                        config_entry_intra_refresh[kf_token_index].name);
-                kf_token_index++;
-            } else
-                fprintf(stderr,
-                        *(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_intra_refresh[kf_token_index].token,
-                        config_entry_intra_refresh[kf_token_index].name);
-        }
-        fprintf(stderr, "\n%-25s\n", "AV1 Specific Options:");
-        while (config_entry_specific[++sp_token_index].token != NULL) {
-            uint32_t check = check_long(config_entry_specific[sp_token_index],
-                                        config_entry_specific[sp_token_index + 1]);
-            if (check == 1) {
-                fprintf(stderr,
-                        "\t%-5s\t%-25s\t%-25s\n",
-                        config_entry_specific[sp_token_index].token,
-                        config_entry_specific[sp_token_index + 1].token,
-                        config_entry_specific[sp_token_index].name);
-                sp_token_index++;
-            } else
-                fprintf(stderr,
-                        *(config_entry_specific[sp_token_index].token + 1) == '-'
-                            ? "\t%-5s\t%-25s\t%-25s\n"
-                            : "\t%-5s\t-%-25s\t%-25s\n",
-                        empty_string,
-                        config_entry_specific[sp_token_index].token,
-                        config_entry_specific[sp_token_index].name);
-        }
-        return 1;
-    } else
+    if (find_token(argc, argv, HELP_TOKEN, config_string) &&
+        find_token(argc, argv, HELP_LONG_TOKEN, config_string))
         return 0;
+    int32_t options_token_index        = -1;
+    int32_t global_options_token_index = -1;
+    int32_t rc_token_index             = -1;
+    int32_t two_p_token_index          = -1;
+    int32_t kf_token_index             = -1;
+    int32_t sp_token_index             = -1;
+    //fprintf(stderr, "\n%-25s\t%-25s\n", "TOKEN", "DESCRIPTION");
+    //fprintf(stderr, "%-25s\t%-25s\n", "-nch", "NumberOfChannels");
+    const char *empty_string = "";
+    fprintf(stderr, "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
+    fprintf(stderr, "\n%-25s\n", "Examples:");
+    fprintf(stderr, "\n%-25s", "Two passes encode:");
+    fprintf(stderr,
+            "\n\t%s",
+            "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename");
+    fprintf(stderr,
+            "\n\t%s",
+            "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename");
+    fprintf(stderr, "\n    Or a combined cli:");
+    fprintf(stderr,
+            "\n\t%s\n",
+            "SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i "
+            "src_filename");
+    fprintf(stderr, "\n%-25s\n", "Options:");
+    while (config_entry_options[++options_token_index].token != NULL) {
+        uint32_t check = check_long(
+            config_entry_options[options_token_index],
+            config_entry_options
+                [options_token_index +
+                 1]); // this only works if short and long token are one after another
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_options[options_token_index].token,
+                    config_entry_options[options_token_index + 1].token,
+                    config_entry_options[options_token_index].name);
+            options_token_index++;
+        } else
+            fprintf(stderr,
+                    *(config_entry_options[options_token_index].token + 1) == '-'
+                        ? "\t%-5s\t%-25s\t%-25s\n"
+                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_options[options_token_index].token,
+                    config_entry_options[options_token_index].name);
+    }
+    fprintf(stderr, "\n%-25s\n", "Encoder Global Options:");
+    while (config_entry_global_options[++global_options_token_index].token != NULL) {
+        uint32_t check = check_long(config_entry_global_options[global_options_token_index],
+                                    config_entry_global_options[global_options_token_index + 1]);
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_global_options[global_options_token_index].token,
+                    config_entry_global_options[global_options_token_index + 1].token,
+                    config_entry_global_options[global_options_token_index].name);
+            global_options_token_index++;
+        } else {
+            fprintf(stderr,
+                    *(config_entry_global_options[global_options_token_index].token + 1) == '-'
+                        ? "\t%-5s\t%-25s\t%-25s\n"
+                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_global_options[global_options_token_index].token,
+                    config_entry_global_options[global_options_token_index].name);
+        }
+    }
+    fprintf(stderr, "\n%-25s\n", "Rate Control Options:");
+    while (config_entry_rc[++rc_token_index].token != NULL) {
+        uint32_t check = check_long(config_entry_rc[rc_token_index],
+                                    config_entry_rc[rc_token_index + 1]);
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_rc[rc_token_index].token,
+                    config_entry_rc[rc_token_index + 1].token,
+                    config_entry_rc[rc_token_index].name);
+            rc_token_index++;
+        } else {
+            fprintf(stderr,
+                    *(config_entry_rc[rc_token_index].token + 1) == '-' ? "\t%-5s\t%-25s\t%-25s\n"
+                                                                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_rc[rc_token_index].token,
+                    config_entry_rc[rc_token_index].name);
+        }
+    }
+    fprintf(stderr, "\n%-25s\n", "Twopass Options:");
+    while (config_entry_2p[++two_p_token_index].token != NULL) {
+        uint32_t check = check_long(config_entry_2p[two_p_token_index],
+                                    config_entry_2p[two_p_token_index + 1]);
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_2p[two_p_token_index].token,
+                    config_entry_2p[two_p_token_index + 1].token,
+                    config_entry_2p[two_p_token_index].name);
+            two_p_token_index++;
+        } else
+            fprintf(stderr,
+                    *(config_entry_2p[two_p_token_index].token + 1) == '-'
+                        ? "\t%-5s\t%-25s\t%-25s\n"
+                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_2p[two_p_token_index].token,
+                    config_entry_2p[two_p_token_index].name);
+    }
+    fprintf(stderr, "\n%-25s\n", "Keyframe Placement Options:");
+    while (config_entry_intra_refresh[++kf_token_index].token != NULL) {
+        uint32_t check = check_long(config_entry_intra_refresh[kf_token_index],
+                                    config_entry_intra_refresh[kf_token_index + 1]);
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_intra_refresh[kf_token_index].token,
+                    config_entry_intra_refresh[kf_token_index + 1].token,
+                    config_entry_intra_refresh[kf_token_index].name);
+            kf_token_index++;
+        } else
+            fprintf(stderr,
+                    *(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
+                        ? "\t%-5s\t%-25s\t%-25s\n"
+                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_intra_refresh[kf_token_index].token,
+                    config_entry_intra_refresh[kf_token_index].name);
+    }
+    fprintf(stderr, "\n%-25s\n", "AV1 Specific Options:");
+    while (config_entry_specific[++sp_token_index].token != NULL) {
+        uint32_t check = check_long(config_entry_specific[sp_token_index],
+                                    config_entry_specific[sp_token_index + 1]);
+        if (check == 1) {
+            fprintf(stderr,
+                    "\t%-5s\t%-25s\t%-25s\n",
+                    config_entry_specific[sp_token_index].token,
+                    config_entry_specific[sp_token_index + 1].token,
+                    config_entry_specific[sp_token_index].name);
+            sp_token_index++;
+        } else
+            fprintf(stderr,
+                    *(config_entry_specific[sp_token_index].token + 1) == '-'
+                        ? "\t%-5s\t%-25s\t%-25s\n"
+                        : "\t%-5s\t-%-25s\t%-25s\n",
+                    empty_string,
+                    config_entry_specific[sp_token_index].token,
+                    config_entry_specific[sp_token_index].name);
+    }
+    return 1;
 }
 
 /******************************************************

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2046,137 +2046,128 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
     if (find_token(argc, argv, HELP_TOKEN, config_string) &&
         find_token(argc, argv, HELP_LONG_TOKEN, config_string))
         return 0;
-    int32_t options_token_index        = -1;
-    int32_t global_options_token_index = -1;
-    int32_t rc_token_index             = -1;
-    int32_t two_p_token_index          = -1;
-    int32_t kf_token_index             = -1;
-    int32_t sp_token_index             = -1;
-    //fprintf(stderr, "\n%-25s\t%-25s\n", "TOKEN", "DESCRIPTION");
-    //fprintf(stderr, "%-25s\t%-25s\n", "-nch", "NumberOfChannels");
-    const char *empty_string = "";
-    printf("Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
-    printf("\n%-25s\n", "Examples:");
-    printf("\n%-25s", "Two passes encode:");
-    printf("\n\t%s",
-           "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename");
-    printf("\n\t%s",
-           "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename");
-    printf("\n    Or a combined cli:");
-    printf("\n\t%s\n",
-           "SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i "
-           "src_filename");
-    printf("\n%-25s\n", "Options:");
-    while (config_entry_options[++options_token_index].token != NULL) {
-        uint32_t check = check_long(
-            config_entry_options[options_token_index],
-            config_entry_options
-                [options_token_index +
-                 1]); // this only works if short and long token are one after another
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+
+    printf(
+        "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n\n"
+        "Examples:\n"
+        "Two passes encode:\n"
+        "    SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename\n"
+        "    SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename\n"
+        "Or a combined cli:\n"
+        "    SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i src_filename\n"
+        "\nOptions:\n");
+    for (int options_token_index = -1; config_entry_options[++options_token_index].token;) {
+        // this only works if short and long token are one after another
+        switch (check_long(config_entry_options[options_token_index],
+                           config_entry_options[options_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_options[options_token_index].token,
                    config_entry_options[options_token_index + 1].token,
                    config_entry_options[options_token_index].name);
-            options_token_index++;
-        } else
+            ++options_token_index;
+            break;
+        default:
             printf(*(config_entry_options[options_token_index].token + 1) == '-'
-                       ? "\t%-5s\t%-25s\t%-25s\n"
-                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+                       ? "      %-25s    %-25s\n"
+                       : "      -%-25s   %-25s\n",
                    config_entry_options[options_token_index].token,
                    config_entry_options[options_token_index].name);
+        }
     }
-    printf("\n%-25s\n", "Encoder Global Options:");
-    while (config_entry_global_options[++global_options_token_index].token != NULL) {
-        uint32_t check = check_long(config_entry_global_options[global_options_token_index],
-                                    config_entry_global_options[global_options_token_index + 1]);
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+    printf("\nEncoder Global Options:\n");
+    for (int global_options_token_index = -1;
+         config_entry_global_options[++global_options_token_index].token;) {
+        switch (check_long(config_entry_global_options[global_options_token_index],
+                           config_entry_global_options[global_options_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_global_options[global_options_token_index].token,
                    config_entry_global_options[global_options_token_index + 1].token,
                    config_entry_global_options[global_options_token_index].name);
-            global_options_token_index++;
-        } else {
+            ++global_options_token_index;
+            break;
+        default:
             printf(*(config_entry_global_options[global_options_token_index].token + 1) == '-'
-                       ? "\t%-5s\t%-25s\t%-25s\n"
-                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+                       ? "      %-25s    %-25s\n"
+                       : "      -%-25s   %-25s\n",
                    config_entry_global_options[global_options_token_index].token,
                    config_entry_global_options[global_options_token_index].name);
         }
     }
-    printf("\n%-25s\n", "Rate Control Options:");
-    while (config_entry_rc[++rc_token_index].token != NULL) {
-        uint32_t check = check_long(config_entry_rc[rc_token_index],
-                                    config_entry_rc[rc_token_index + 1]);
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+    printf("\nRate Control Options:\n");
+    for (int rc_token_index = -1; config_entry_rc[++rc_token_index].token;) {
+        switch (check_long(config_entry_rc[rc_token_index], config_entry_rc[rc_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_rc[rc_token_index].token,
                    config_entry_rc[rc_token_index + 1].token,
                    config_entry_rc[rc_token_index].name);
-            rc_token_index++;
-        } else {
-            printf(*(config_entry_rc[rc_token_index].token + 1) == '-' ? "\t%-5s\t%-25s\t%-25s\n"
-                                                                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+            ++rc_token_index;
+            break;
+        default:
+            printf(*(config_entry_rc[rc_token_index].token + 1) == '-' ? "      %-25s    %-25s\n"
+                                                                       : "      -%-25s   %-25s\n",
                    config_entry_rc[rc_token_index].token,
                    config_entry_rc[rc_token_index].name);
         }
     }
-    printf("\n%-25s\n", "Twopass Options:");
-    while (config_entry_2p[++two_p_token_index].token != NULL) {
-        uint32_t check = check_long(config_entry_2p[two_p_token_index],
-                                    config_entry_2p[two_p_token_index + 1]);
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+    printf("\nTwopass Options:\n");
+    for (int two_p_token_index = -1; config_entry_2p[++two_p_token_index].token;) {
+        switch (check_long(config_entry_2p[two_p_token_index],
+                           config_entry_2p[two_p_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_2p[two_p_token_index].token,
                    config_entry_2p[two_p_token_index + 1].token,
                    config_entry_2p[two_p_token_index].name);
-            two_p_token_index++;
-        } else
+            ++two_p_token_index;
+            break;
+        default:
             printf(*(config_entry_2p[two_p_token_index].token + 1) == '-'
-                       ? "\t%-5s\t%-25s\t%-25s\n"
-                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+                       ? "      %-25s    %-25s\n"
+                       : "      -%-25s   %-25s\n",
                    config_entry_2p[two_p_token_index].token,
                    config_entry_2p[two_p_token_index].name);
+        }
     }
-    printf("\n%-25s\n", "Keyframe Placement Options:");
-    while (config_entry_intra_refresh[++kf_token_index].token != NULL) {
-        uint32_t check = check_long(config_entry_intra_refresh[kf_token_index],
-                                    config_entry_intra_refresh[kf_token_index + 1]);
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+    printf("\nKeyframe Placement Options:\n");
+    for (int kf_token_index = -1; config_entry_intra_refresh[++kf_token_index].token;) {
+        switch (check_long(config_entry_intra_refresh[kf_token_index],
+                           config_entry_intra_refresh[kf_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_intra_refresh[kf_token_index].token,
                    config_entry_intra_refresh[kf_token_index + 1].token,
                    config_entry_intra_refresh[kf_token_index].name);
-            kf_token_index++;
-        } else
+            ++kf_token_index;
+            break;
+        default:
             printf(*(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
-                       ? "\t%-5s\t%-25s\t%-25s\n"
-                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+                       ? "      %-25s    %-25s\n"
+                       : "      -%-25s   %-25s\n",
                    config_entry_intra_refresh[kf_token_index].token,
                    config_entry_intra_refresh[kf_token_index].name);
+        }
     }
-    printf("\n%-25s\n", "AV1 Specific Options:");
-    while (config_entry_specific[++sp_token_index].token != NULL) {
-        uint32_t check = check_long(config_entry_specific[sp_token_index],
-                                    config_entry_specific[sp_token_index + 1]);
-        if (check == 1) {
-            printf("\t%-5s\t%-25s\t%-25s\n",
+    printf("\nAV1 Specific Options:\n");
+    for (int sp_token_index = -1; config_entry_specific[++sp_token_index].token;) {
+        switch (check_long(config_entry_specific[sp_token_index],
+                           config_entry_specific[sp_token_index + 1])) {
+        case 1:
+            printf("  %s, %-25s    %-25s\n",
                    config_entry_specific[sp_token_index].token,
                    config_entry_specific[sp_token_index + 1].token,
                    config_entry_specific[sp_token_index].name);
-            sp_token_index++;
-        } else
+            ++sp_token_index;
+            break;
+        default:
             printf(*(config_entry_specific[sp_token_index].token + 1) == '-'
-                       ? "\t%-5s\t%-25s\t%-25s\n"
-                       : "\t%-5s\t-%-25s\t%-25s\n",
-                   empty_string,
+                       ? "      %-25s    %-25s\n"
+                       : "      -%-25s   %-25s\n",
                    config_entry_specific[sp_token_index].token,
                    config_entry_specific[sp_token_index].name);
+        }
     }
     return 1;
 }

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2055,21 +2055,18 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
     //fprintf(stderr, "\n%-25s\t%-25s\n", "TOKEN", "DESCRIPTION");
     //fprintf(stderr, "%-25s\t%-25s\n", "-nch", "NumberOfChannels");
     const char *empty_string = "";
-    fprintf(stderr, "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
-    fprintf(stderr, "\n%-25s\n", "Examples:");
-    fprintf(stderr, "\n%-25s", "Two passes encode:");
-    fprintf(stderr,
-            "\n\t%s",
-            "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename");
-    fprintf(stderr,
-            "\n\t%s",
-            "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename");
-    fprintf(stderr, "\n    Or a combined cli:");
-    fprintf(stderr,
-            "\n\t%s\n",
-            "SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i "
-            "src_filename");
-    fprintf(stderr, "\n%-25s\n", "Options:");
+    printf("Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
+    printf("\n%-25s\n", "Examples:");
+    printf("\n%-25s", "Two passes encode:");
+    printf("\n\t%s",
+           "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename");
+    printf("\n\t%s",
+           "SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename");
+    printf("\n    Or a combined cli:");
+    printf("\n\t%s\n",
+           "SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i "
+           "src_filename");
+    printf("\n%-25s\n", "Options:");
     while (config_entry_options[++options_token_index].token != NULL) {
         uint32_t check = check_long(
             config_entry_options[options_token_index],
@@ -2077,121 +2074,109 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
                 [options_token_index +
                  1]); // this only works if short and long token are one after another
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_options[options_token_index].token,
-                    config_entry_options[options_token_index + 1].token,
-                    config_entry_options[options_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_options[options_token_index].token,
+                   config_entry_options[options_token_index + 1].token,
+                   config_entry_options[options_token_index].name);
             options_token_index++;
         } else
-            fprintf(stderr,
-                    *(config_entry_options[options_token_index].token + 1) == '-'
-                        ? "\t%-5s\t%-25s\t%-25s\n"
-                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_options[options_token_index].token,
-                    config_entry_options[options_token_index].name);
+            printf(*(config_entry_options[options_token_index].token + 1) == '-'
+                       ? "\t%-5s\t%-25s\t%-25s\n"
+                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_options[options_token_index].token,
+                   config_entry_options[options_token_index].name);
     }
-    fprintf(stderr, "\n%-25s\n", "Encoder Global Options:");
+    printf("\n%-25s\n", "Encoder Global Options:");
     while (config_entry_global_options[++global_options_token_index].token != NULL) {
         uint32_t check = check_long(config_entry_global_options[global_options_token_index],
                                     config_entry_global_options[global_options_token_index + 1]);
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_global_options[global_options_token_index].token,
-                    config_entry_global_options[global_options_token_index + 1].token,
-                    config_entry_global_options[global_options_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_global_options[global_options_token_index].token,
+                   config_entry_global_options[global_options_token_index + 1].token,
+                   config_entry_global_options[global_options_token_index].name);
             global_options_token_index++;
         } else {
-            fprintf(stderr,
-                    *(config_entry_global_options[global_options_token_index].token + 1) == '-'
-                        ? "\t%-5s\t%-25s\t%-25s\n"
-                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_global_options[global_options_token_index].token,
-                    config_entry_global_options[global_options_token_index].name);
+            printf(*(config_entry_global_options[global_options_token_index].token + 1) == '-'
+                       ? "\t%-5s\t%-25s\t%-25s\n"
+                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_global_options[global_options_token_index].token,
+                   config_entry_global_options[global_options_token_index].name);
         }
     }
-    fprintf(stderr, "\n%-25s\n", "Rate Control Options:");
+    printf("\n%-25s\n", "Rate Control Options:");
     while (config_entry_rc[++rc_token_index].token != NULL) {
         uint32_t check = check_long(config_entry_rc[rc_token_index],
                                     config_entry_rc[rc_token_index + 1]);
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_rc[rc_token_index].token,
-                    config_entry_rc[rc_token_index + 1].token,
-                    config_entry_rc[rc_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_rc[rc_token_index].token,
+                   config_entry_rc[rc_token_index + 1].token,
+                   config_entry_rc[rc_token_index].name);
             rc_token_index++;
         } else {
-            fprintf(stderr,
-                    *(config_entry_rc[rc_token_index].token + 1) == '-' ? "\t%-5s\t%-25s\t%-25s\n"
-                                                                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_rc[rc_token_index].token,
-                    config_entry_rc[rc_token_index].name);
+            printf(*(config_entry_rc[rc_token_index].token + 1) == '-' ? "\t%-5s\t%-25s\t%-25s\n"
+                                                                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_rc[rc_token_index].token,
+                   config_entry_rc[rc_token_index].name);
         }
     }
-    fprintf(stderr, "\n%-25s\n", "Twopass Options:");
+    printf("\n%-25s\n", "Twopass Options:");
     while (config_entry_2p[++two_p_token_index].token != NULL) {
         uint32_t check = check_long(config_entry_2p[two_p_token_index],
                                     config_entry_2p[two_p_token_index + 1]);
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_2p[two_p_token_index].token,
-                    config_entry_2p[two_p_token_index + 1].token,
-                    config_entry_2p[two_p_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_2p[two_p_token_index].token,
+                   config_entry_2p[two_p_token_index + 1].token,
+                   config_entry_2p[two_p_token_index].name);
             two_p_token_index++;
         } else
-            fprintf(stderr,
-                    *(config_entry_2p[two_p_token_index].token + 1) == '-'
-                        ? "\t%-5s\t%-25s\t%-25s\n"
-                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_2p[two_p_token_index].token,
-                    config_entry_2p[two_p_token_index].name);
+            printf(*(config_entry_2p[two_p_token_index].token + 1) == '-'
+                       ? "\t%-5s\t%-25s\t%-25s\n"
+                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_2p[two_p_token_index].token,
+                   config_entry_2p[two_p_token_index].name);
     }
-    fprintf(stderr, "\n%-25s\n", "Keyframe Placement Options:");
+    printf("\n%-25s\n", "Keyframe Placement Options:");
     while (config_entry_intra_refresh[++kf_token_index].token != NULL) {
         uint32_t check = check_long(config_entry_intra_refresh[kf_token_index],
                                     config_entry_intra_refresh[kf_token_index + 1]);
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_intra_refresh[kf_token_index].token,
-                    config_entry_intra_refresh[kf_token_index + 1].token,
-                    config_entry_intra_refresh[kf_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_intra_refresh[kf_token_index].token,
+                   config_entry_intra_refresh[kf_token_index + 1].token,
+                   config_entry_intra_refresh[kf_token_index].name);
             kf_token_index++;
         } else
-            fprintf(stderr,
-                    *(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
-                        ? "\t%-5s\t%-25s\t%-25s\n"
-                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_intra_refresh[kf_token_index].token,
-                    config_entry_intra_refresh[kf_token_index].name);
+            printf(*(config_entry_intra_refresh[kf_token_index].token + 1) == '-'
+                       ? "\t%-5s\t%-25s\t%-25s\n"
+                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_intra_refresh[kf_token_index].token,
+                   config_entry_intra_refresh[kf_token_index].name);
     }
-    fprintf(stderr, "\n%-25s\n", "AV1 Specific Options:");
+    printf("\n%-25s\n", "AV1 Specific Options:");
     while (config_entry_specific[++sp_token_index].token != NULL) {
         uint32_t check = check_long(config_entry_specific[sp_token_index],
                                     config_entry_specific[sp_token_index + 1]);
         if (check == 1) {
-            fprintf(stderr,
-                    "\t%-5s\t%-25s\t%-25s\n",
-                    config_entry_specific[sp_token_index].token,
-                    config_entry_specific[sp_token_index + 1].token,
-                    config_entry_specific[sp_token_index].name);
+            printf("\t%-5s\t%-25s\t%-25s\n",
+                   config_entry_specific[sp_token_index].token,
+                   config_entry_specific[sp_token_index + 1].token,
+                   config_entry_specific[sp_token_index].name);
             sp_token_index++;
         } else
-            fprintf(stderr,
-                    *(config_entry_specific[sp_token_index].token + 1) == '-'
-                        ? "\t%-5s\t%-25s\t%-25s\n"
-                        : "\t%-5s\t-%-25s\t%-25s\n",
-                    empty_string,
-                    config_entry_specific[sp_token_index].token,
-                    config_entry_specific[sp_token_index].name);
+            printf(*(config_entry_specific[sp_token_index].token + 1) == '-'
+                       ? "\t%-5s\t%-25s\t%-25s\n"
+                       : "\t%-5s\t-%-25s\t%-25s\n",
+                   empty_string,
+                   config_entry_specific[sp_token_index].token,
+                   config_entry_specific[sp_token_index].name);
     }
     return 1;
 }


### PR DESCRIPTION
# Description

Uses printf instead of fprintf, which should be fine since we only switched to fprintf(stderr to leave stdout available for video output, but since we aren't actually sending out a video stream if get_help is called, we can use printf.

Switched to using spaces only instead of adding tabs along with some other readability improvements (I hope)

previously

```none
Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename

Examples:                

Two passes encode:       
	SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename
	SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename
    Or a combined cli:
	SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i src_filename

Options:                 
	     	--help                    	Show usage options and exit
	-i   	--input                  	Input filename           
	-b   	--output                 	Output filename          
	     	--errlog                  	Error filename           
	-o   	--recon                  	Recon filename           
	     	--stat-file               	Stat filename            

Encoder Global Options:  
	-w   	--width                  	Frame width              
	-h   	--height                 	Frame height             
	-n   	--frames                 	Stop encoding after n input frames
	     	--nb                      	Buffer n input frames    
	     	--progress               	Change verbosity of the output (0: no progress is printed, 1: default, 2: aomenc style machine parsable output)
	     	--no-progress            	Do not print out progress, if set to 1 it is equivalent to `--progress 0`, else  `--progress 1`
	     	--color-format            	Set encoder color format(EB_YUV400, EB_YUV420, EB_YUV422, EB_YUV444)
	     	--profile                 	Bitstream profile number to use(0: main profile[default], 1: high profile, 2: professional profile) 
	     	--fps                     	Stream frame rate (rate/scale)
	     	--fps-num                 	Stream frame rate numerator
	     	--fps-denom               	Stream frame rate denominator
	     	--input-depth            	Bit depth for codec(8 or 10)
	     	--16bit-pipeline          	Bit depth for enc-dec(0: lbd[default], 1: hbd)
	     	--hierarchical-levels     	Set hierarchical levels(3 or 4[default])
	     	--pred-struct             	Set prediction structure( 0: low delay P, 1: low delay B, 2: random access [default])
	     	--enable-hdr             	Enable high dynamic range(0: OFF[default], ON: 1)
	     	--asm                     	Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max], by default highest level supported by CPU
	     	--lp                      	number of logical processors to be used
	     	--unpin                   	Allows the execution to be pined/unpined to/from a specific number of cores 
The combinational use of --unpin with --lp results in memory reduction while allowing the execution to work on any of the cores and not restrict it to specific cores 
--unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF ,1: ON [default]) 
Example: 72 core machine: 
72 jobs x -- lp 1 -- unpin 1 
36 jobs x -- lp 2 -- unpin 1 
18 jobs x -- lp 4 -- unpin 1 
	     	--ss                      	Specify  which socket the encoder runs on--unpin is overwritten to 0 when --ss is set to 0 or 1

Rate Control Options:    
	     	--rc                      	Rate control mode(0 = CQP , 1 = VBR , 2 = CVBR)
	     	--tbr                     	Target Bitrate (kbps)    
	     	--use-q-file              	Overwrite QP assignment using qp values in QP file
	     	--qpfile                 	Path to Qp file          
	     	--max-qp                  	Maximum (worst) quantizer[0-63]
	     	--min-qp                  	Minimum (best) quantizer[0-63]
	     	--adaptive-quantization   	Set adaptive QP level(0: OFF ,1: variance base using segments ,2: Deltaq pred efficiency)
	     	--vbv-bufsize             	VBV buffer size          
	     	--undershoot-pct          	Datarate undershoot (min) target (%)
	     	--overshoot-pct           	Datarate overshoot (max) target (%)

Twopass Options:         
	     	--pass                   	Multipass bitrate control (1: first pass, generates stats file , 2: second pass, uses stats file)
	     	--stats                  	Filename for 2 pass stats("svtav1_2pass.log" : [Default])
	     	--passes                 	Number of passes (1: one pass encode, 2: two passes encode)
	     	--bias-pct                	CBR/VBR bias (0=CBR, 100=VBR)
	     	--minsection-pct          	GOP min bitrate (% of target)
	     	--maxsection-pct          	GOP max bitrate (% of target)

Keyframe Placement Options:
	     	--keyint                 	Intra period interval(frames) (-2: default intra period , -1: No intra update or [0 - 2^31-2]; [-2-255] if RateControlMode >= 1)
	     	--irefresh-type           	Intra refresh type (1: CRA (Open GOP)2: IDR (Closed GOP))

AV1 Specific Options:    
	     	--preset                 	Encoder mode/Preset used[-2,-1,0,..,8]
	     	--compressed-ten-bit-format	Offline packing of the 2bits: requires two bits packed input (0: OFF[default], 1: ON)
	     	--tile-rows               	Number of tile rows to use, log2[0-6]
	     	--tile-columns            	Number of tile columns to use, log2[0-4]
	-q   	--qp                     	Constant/Constrained Quality level
	     	--lookahead              	When RC is ON , it is best to set this parameter to be equal to the intra period value
	     	--disable-dlf            	Disable loop filter(0: loop filter enabled[default] ,1: loop filter disabled)
	     	--cdef-level              	CDEF Level, 0: OFF, 1-5: ON with 64,16,8,4,1 step refinement, -1: DEFAULT
	     	--enable-restoration-filtering	Enable the loop restoration filter(0: OFF ,1: ON ,-1:DEFAULT)
	     	--sg-filter-mode          	Self-guided filter mode (0:OFF, 1: step 0, 2: step 1, 3: step 4, 4: step 16, -1: DEFAULT)
	     	--wn-filter-mode          	Wiener filter mode (0:OFF, 1: 3-Tap luma/ 3-Tap chroma, 2: 5-Tap luma/ 5-Tap chroma, 3: 7-Tap luma/ 7-Tap chroma, -1: DEFAULT)
	     	--mrp-level              	Multi reference frame levels( 0: OFF, 1: FULL, 2: Level1 .. 9: Level8,  -1: DEFAULT)
	     	--lad                     	Set look ahead distance  
	     	--enable-tpl-la           	RDO based on frame temporal dependency (0: off, 1: backward source based)
	     	--enable-mfmv            	Enable motion field motion vector( 0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-redundant-blk   	Use the same md results(mode, residual , cost,etc..)as the previously processed identical block(0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-spatial-sse-full-loop-level	Enable spatial sse full loop(0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-over-bndry-blk  	Enable over boundary block mode (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-new-nrst-near-comb	Enable new nearest near comb injection (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-nsq-table-use   	Enable nsq table (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-framend-cdf-upd-mode	Enable frame end cdf update mode (0: OFF, 1: ON, -1: DEFAULT)
	     	--chroma-mode             	Select chroma mode([0-3], -1: DEFAULT)
	     	--disable-cfl            	Disable chroma from luma (CFL) flag (0: OFF (do not disable), 1: ON (disable), -1: DEFAULT)
	     	--enable-local-warp      	Enable warped motion use , 0 = OFF, 1 = ON, -1 = DEFAULT
	     	--enable-global-motion   	Enable global motion (0: OFF, 1: ON [default])
	     	--intra-angle-delta       	Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-interintra-comp 	Enable interintra compound (0: OFF, 1: ON (default))
	     	--enable-paeth           	Enable paeth (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-smooth          	Enable smooth (0: OFF, 1: ON, -1: DEFAULT)
	     	--obmc-level              	OBMC Level(0: OFF, 1: Fully ON, 2 and 3 are faster levels, -1: DEFAULT)
	     	--rdoq-level             	Enable RDOQ (0: OFF, 1: ON, -1: DEFAULT)
	     	--filter-intra-level     	Enable filter intra prediction mode (0: OFF, 1: ON [default])
	     	--enable-intra-edge-filter	Enable intra edge filter (0: OFF, 1: ON, -1: DEFAULT)
	     	--enable-pic-based-rate-est	Enable picture based rate estimation (0: OFF, 1: ON, -1: DEFAULT)
	     	--pred-me                 	Set predictive motion estimation level(-1: default, [0-5])
	     	--bipred-3x3              	Set bipred3x3 injection (0: OFF, 1: ON FULL, 2: Reduced set, -1: DEFAULT)
	     	--compound                	Enable compound mode(0: OFF, 1:ON[AVG/DIST/DIFF], 2: ON[AVG/DIST/DIFF/WEDGE], -1: default)
	     	--use-default-me-hme      	Use default motion estimation/hierarchical motion estimation settings(0: OFF, 1: ON[default])
	     	--hme                     	Enable hierarchical motion estimation(0: OFF, 1: ON)
	     	--hme-l0                  	Enable hierarchical motion estimation Level 0 (0: OFF, 1: ON)
	     	--hme-l1                  	Enable hierarchical motion estimation Level 1 (0: OFF, 1: ON)
	     	--hme-l2                  	Enable hierarchical motion estimation Level 2 (0: OFF, 1: ON)
	     	--ext-block               	Enable the rectangular and asymetric block (0: OFF, 1: ON)
	     	--search-w                	Set search area in width[1-256]
	     	--search-h                	Set search area in height[1-256]
	     	--scm                     	Set screen content detection level([0-2], 0: DEFAULT)
	     	--intrabc-mode            	Set intraBC mode (0: OFF, 1: ON slow, 2: ON faster, 3: ON fastest, -1: DEFAULT)
	     	--hbd-md                  	Enable high bit depth mode decision(0: OFF, 1: ON partially[default],2: fully ON)
	     	--palette-level           	Set palette prediction mode(-1: default or [0-6])
	     	--umv                     	Allow motion vectors to reach outside of the picture boundary(O: OFF, 1: ON[default])
	     	--inj                     	Inject pictures at defined frame rate(0: OFF[default],1: ON)
	     	--inj-frm-rt              	Set injector frame rate  
	     	--speed-ctrl              	Enable speed control(0: OFF[default], 1: ON)
	     	--film-grain              	Enable film grain(0: OFF[default], 1-50: ON, film-grain denoising strength)
	     	--tf-level                	Set altref level(-1: Default; 0: OFF; 1: ON; 2 and 3: Faster levels)
	     	--altref-strength         	AltRef filter strength([0-6], default: 5)
	     	--altref-nframes          	AltRef max frames([0-10], default: 7)
	     	--enable-overlays         	Enable the insertion of an extra picture called overlayer picture which will be used as an extra reference frame for the base-layer picture(0: OFF[default], 1: ON)
	     	--enable-stat-report     	Stat Report              
	     	--enable-intra-angle-delta	Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)

```

with this pr

```none
Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename

Examples:
Two passes encode:
    SvtAv1EncApp <--stats svtav1_2pass.log> --pass 1 -b dst_filename -i src_filename
    SvtAv1EncApp <--stats svtav1_2pass.log> --pass 2 -b dst_filename -i src_filename
Or a combined cli:
    SvtAv1EncApp <--stats svtav1_2pass.log> --passes 2 -b dst_filename -i src_filename

Options:
      --help                       Show usage options and exit
  -i, --input                      Input filename           
  -b, --output                     Output filename          
      --errlog                     Error filename           
  -o, --recon                      Recon filename           
      --stat-file                  Stat filename            

Encoder Global Options:
  -w, --width                      Frame width              
  -h, --height                     Frame height             
  -n, --frames                     Stop encoding after n input frames
      --nb                         Buffer n input frames    
      --progress                   Change verbosity of the output (0: no progress is printed, 1: default, 2: aomenc style machine parsable output)
      --no-progress                Do not print out progress, if set to 1 it is equivalent to `--progress 0`, else  `--progress 1`
      --color-format               Set encoder color format(EB_YUV400, EB_YUV420, EB_YUV422, EB_YUV444)
      --profile                    Bitstream profile number to use(0: main profile[default], 1: high profile, 2: professional profile) 
      --fps                        Stream frame rate (rate/scale)
      --fps-num                    Stream frame rate numerator
      --fps-denom                  Stream frame rate denominator
      --input-depth                Bit depth for codec(8 or 10)
      --16bit-pipeline             Bit depth for enc-dec(0: lbd[default], 1: hbd)
      --hierarchical-levels        Set hierarchical levels(3 or 4[default])
      --pred-struct                Set prediction structure( 0: low delay P, 1: low delay B, 2: random access [default])
      --enable-hdr                 Enable high dynamic range(0: OFF[default], ON: 1)
      --asm                        Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max], by default highest level supported by CPU
      --lp                         number of logical processors to be used
      --unpin                      Allows the execution to be pined/unpined to/from a specific number of cores 
The combinational use of --unpin with --lp results in memory reduction while allowing the execution to work on any of the cores and not restrict it to specific cores 
--unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF ,1: ON [default]) 
Example: 72 core machine: 
72 jobs x -- lp 1 -- unpin 1 
36 jobs x -- lp 2 -- unpin 1 
18 jobs x -- lp 4 -- unpin 1 
      --ss                         Specify  which socket the encoder runs on--unpin is overwritten to 0 when --ss is set to 0 or 1

Rate Control Options:
      --rc                         Rate control mode(0 = CQP , 1 = VBR , 2 = CVBR)
      --tbr                        Target Bitrate (kbps)    
      --use-q-file                 Overwrite QP assignment using qp values in QP file
      --qpfile                     Path to Qp file          
      --max-qp                     Maximum (worst) quantizer[0-63]
      --min-qp                     Minimum (best) quantizer[0-63]
      --adaptive-quantization      Set adaptive QP level(0: OFF ,1: variance base using segments ,2: Deltaq pred efficiency)
      --vbv-bufsize                VBV buffer size          
      --undershoot-pct             Datarate undershoot (min) target (%)
      --overshoot-pct              Datarate overshoot (max) target (%)

Twopass Options:
      --pass                       Multipass bitrate control (1: first pass, generates stats file , 2: second pass, uses stats file)
      --stats                      Filename for 2 pass stats("svtav1_2pass.log" : [Default])
      --passes                     Number of passes (1: one pass encode, 2: two passes encode)
      --bias-pct                   CBR/VBR bias (0=CBR, 100=VBR)
      --minsection-pct             GOP min bitrate (% of target)
      --maxsection-pct             GOP max bitrate (% of target)

Keyframe Placement Options:
      --keyint                     Intra period interval(frames) (-2: default intra period , -1: No intra update or [0 - 2^31-2]; [-2-255] if RateControlMode >= 1)
      --irefresh-type              Intra refresh type (1: CRA (Open GOP)2: IDR (Closed GOP))

AV1 Specific Options:
      --preset                     Encoder mode/Preset used[-2,-1,0,..,8]
      --compressed-ten-bit-format   Offline packing of the 2bits: requires two bits packed input (0: OFF[default], 1: ON)
      --tile-rows                  Number of tile rows to use, log2[0-6]
      --tile-columns               Number of tile columns to use, log2[0-4]
  -q, --qp                         Constant/Constrained Quality level
      --lookahead                  When RC is ON , it is best to set this parameter to be equal to the intra period value
      --disable-dlf                Disable loop filter(0: loop filter enabled[default] ,1: loop filter disabled)
      --cdef-level                 CDEF Level, 0: OFF, 1-5: ON with 64,16,8,4,1 step refinement, -1: DEFAULT
      --enable-restoration-filtering    Enable the loop restoration filter(0: OFF ,1: ON ,-1:DEFAULT)
      --sg-filter-mode             Self-guided filter mode (0:OFF, 1: step 0, 2: step 1, 3: step 4, 4: step 16, -1: DEFAULT)
      --wn-filter-mode             Wiener filter mode (0:OFF, 1: 3-Tap luma/ 3-Tap chroma, 2: 5-Tap luma/ 5-Tap chroma, 3: 7-Tap luma/ 7-Tap chroma, -1: DEFAULT)
      --mrp-level                  Multi reference frame levels( 0: OFF, 1: FULL, 2: Level1 .. 9: Level8,  -1: DEFAULT)
      --lad                        Set look ahead distance  
      --enable-tpl-la              RDO based on frame temporal dependency (0: off, 1: backward source based)
      --enable-mfmv                Enable motion field motion vector( 0: OFF, 1: ON, -1: DEFAULT)
      --enable-redundant-blk       Use the same md results(mode, residual , cost,etc..)as the previously processed identical block(0: OFF, 1: ON, -1: DEFAULT)
      --enable-spatial-sse-full-loop-level    Enable spatial sse full loop(0: OFF, 1: ON, -1: DEFAULT)
      --enable-over-bndry-blk      Enable over boundary block mode (0: OFF, 1: ON, -1: DEFAULT)
      --enable-new-nrst-near-comb    Enable new nearest near comb injection (0: OFF, 1: ON, -1: DEFAULT)
      --enable-nsq-table-use       Enable nsq table (0: OFF, 1: ON, -1: DEFAULT)
      --enable-framend-cdf-upd-mode    Enable frame end cdf update mode (0: OFF, 1: ON, -1: DEFAULT)
      --chroma-mode                Select chroma mode([0-3], -1: DEFAULT)
      --disable-cfl                Disable chroma from luma (CFL) flag (0: OFF (do not disable), 1: ON (disable), -1: DEFAULT)
      --enable-local-warp          Enable warped motion use , 0 = OFF, 1 = ON, -1 = DEFAULT
      --enable-global-motion       Enable global motion (0: OFF, 1: ON [default])
      --intra-angle-delta          Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)
      --enable-interintra-comp     Enable interintra compound (0: OFF, 1: ON (default))
      --enable-paeth               Enable paeth (0: OFF, 1: ON, -1: DEFAULT)
      --enable-smooth              Enable smooth (0: OFF, 1: ON, -1: DEFAULT)
      --obmc-level                 OBMC Level(0: OFF, 1: Fully ON, 2 and 3 are faster levels, -1: DEFAULT)
      --rdoq-level                 Enable RDOQ (0: OFF, 1: ON, -1: DEFAULT)
      --filter-intra-level         Enable filter intra prediction mode (0: OFF, 1: ON [default])
      --enable-intra-edge-filter    Enable intra edge filter (0: OFF, 1: ON, -1: DEFAULT)
      --enable-pic-based-rate-est    Enable picture based rate estimation (0: OFF, 1: ON, -1: DEFAULT)
      --pred-me                    Set predictive motion estimation level(-1: default, [0-5])
      --bipred-3x3                 Set bipred3x3 injection (0: OFF, 1: ON FULL, 2: Reduced set, -1: DEFAULT)
      --compound                   Enable compound mode(0: OFF, 1:ON[AVG/DIST/DIFF], 2: ON[AVG/DIST/DIFF/WEDGE], -1: default)
      --use-default-me-hme         Use default motion estimation/hierarchical motion estimation settings(0: OFF, 1: ON[default])
      --hme                        Enable hierarchical motion estimation(0: OFF, 1: ON)
      --hme-l0                     Enable hierarchical motion estimation Level 0 (0: OFF, 1: ON)
      --hme-l1                     Enable hierarchical motion estimation Level 1 (0: OFF, 1: ON)
      --hme-l2                     Enable hierarchical motion estimation Level 2 (0: OFF, 1: ON)
      --ext-block                  Enable the rectangular and asymetric block (0: OFF, 1: ON)
      --search-w                   Set search area in width[1-256]
      --search-h                   Set search area in height[1-256]
      --scm                        Set screen content detection level([0-2], 0: DEFAULT)
      --intrabc-mode               Set intraBC mode (0: OFF, 1: ON slow, 2: ON faster, 3: ON fastest, -1: DEFAULT)
      --hbd-md                     Enable high bit depth mode decision(0: OFF, 1: ON partially[default],2: fully ON)
      --palette-level              Set palette prediction mode(-1: default or [0-6])
      --umv                        Allow motion vectors to reach outside of the picture boundary(O: OFF, 1: ON[default])
      --inj                        Inject pictures at defined frame rate(0: OFF[default],1: ON)
      --inj-frm-rt                 Set injector frame rate  
      --speed-ctrl                 Enable speed control(0: OFF[default], 1: ON)
      --film-grain                 Enable film grain(0: OFF[default], 1-50: ON, film-grain denoising strength)
      --tf-level                   Set altref level(-1: Default; 0: OFF; 1: ON; 2 and 3: Faster levels)
      --altref-strength            AltRef filter strength([0-6], default: 5)
      --altref-nframes             AltRef max frames([0-10], default: 7)
      --enable-overlays            Enable the insertion of an extra picture called overlayer picture which will be used as an extra reference frame for the base-layer picture(0: OFF[default], 1: ON)
      --enable-stat-report         Stat Report              
      --enable-intra-angle-delta    Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)

```

the `unpin` argument description is a bit annoying since it's multi-lined, but that could be fixed at a later time.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

Closes #1518

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
