### PR TITLE
Inloop ME & TPL

### DIFF
--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -65,6 +65,15 @@ extern "C" {
 #endif
 
 
+#define FEATURE_IN_LOOP_TPL 1 // Moving TPL to in loop
+#if FEATURE_IN_LOOP_TPL
+#define ENABLE_TPL_ZERO_LAD 1 // Enable TPL in loop to work with zero LAD
+#define TUNE_TPL 1   // Tuning TPL algorithm for QP assignment
+#define ENABLE_TPL_TRAILING 1 //enable trailing pictures for TPL
+#define FIX_TPL_TRAILING_FRAME_BUG          1 // fix bug related to ENABLE_TPL_TRAILING
+#define FIX_GM_BUG                                   1 // FIX GM r2r difference
+
+#endif
 
 
 

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -43,36 +43,22 @@ extern "C" {
 
 #define FIX_PAD_CHROMA_AFTER_MCTF     1 // Padding chroma after altref
 #define FEATURE_NEW_DELAY             1 // Change delay some sorts of I in PicDecision
-#if FEATURE_NEW_DELAY
-#define FIX_LAD_DEADLOCK              1 // Fix deadlock when lad>0 + iperiod>0
-#endif
 #define FEATURE_INL_ME                1 //Enable in-loop ME
 #if FEATURE_INL_ME
 #define TUNE_IME_REUSE_TPL_RESULT     1 // Reuse TPL results for iLoopME
 #define TUNE_INL_TPL_ENHANCEMENT      1 // Refinement for TPL
-#define TUNE_INL_TPL_ME_DBG_MSG       0 // Turn off debug message
-#define TUNE_INL_ME_RECON_INPUT       1 // Perform ME on input/recon: 1 on input, 0 on recon
-#if TUNE_INL_ME_RECON_INPUT
-#define TUNE_INL_ME_ON_INPUT          1 // Perform ME on input
-#define TUNE_INL_GM_ON_INPUT          1 // Perform GM on input
-#define TUNE_INL_TPL_ON_INPUT         1 // Perform TPL on input
-#define TUNE_INL_ME_MEM_OPT           1 // Optimize memory usage when perform ME on input, only use 8bit luma
-#define TUNE_INL_ME_DECODE_ORDER      1 // Force decode order for inloopME
-#endif
+#define TUNE_INL_ME_RECON_INPUT       1 // Perform ME GM, TPL on input/recon: 1 on input, 0 on recon
 #if !TUNE_IME_REUSE_TPL_RESULT
 #define TUNE_SIGNAL_TPL_ME_OQ         1 // A separate signal_xxx_oq for TPL ME
 #endif
 #endif
 
-
 #define FEATURE_IN_LOOP_TPL 1 // Moving TPL to in loop
 #if FEATURE_IN_LOOP_TPL
-#define ENABLE_TPL_ZERO_LAD 1 // Enable TPL in loop to work with zero LAD
-#define TUNE_TPL 1   // Tuning TPL algorithm for QP assignment
-#define ENABLE_TPL_TRAILING 1 //enable trailing pictures for TPL
-#define FIX_TPL_TRAILING_FRAME_BUG          1 // fix bug related to ENABLE_TPL_TRAILING
-#define FIX_GM_BUG                                   1 // FIX GM r2r difference
-
+#define ENABLE_TPL_ZERO_LAD     1 // Enable TPL in loop to work with zero LAD
+#define TUNE_TPL                1   // Tuning TPL algorithm for QP assignment
+#define ENABLE_TPL_TRAILING     1 //enable trailing pictures for TPL
+#define FIX_GM_BUG              1 // FIX GM r2r difference
 #endif
 
 

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -41,7 +41,6 @@ extern "C" {
 #define FIX_10BIT     1 // fix 1st pass for 10bit input
 #define FIX_RC_TOKEN     1 // fix RC token check to include double dash
 
-#define FIX_PAD_CHROMA_AFTER_MCTF     1 // Padding chroma after altref
 #define FEATURE_NEW_DELAY             1 // Change delay some sorts of I in PicDecision
 #define FEATURE_INL_ME                1 //Enable in-loop ME
 #if FEATURE_INL_ME
@@ -58,7 +57,6 @@ extern "C" {
 #define ENABLE_TPL_ZERO_LAD     1 // Enable TPL in loop to work with zero LAD
 #define TUNE_TPL                1   // Tuning TPL algorithm for QP assignment
 #define ENABLE_TPL_TRAILING     1 //enable trailing pictures for TPL
-#define FIX_GM_BUG              1 // FIX GM r2r difference
 #endif
 
 

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -40,6 +40,17 @@ extern "C" {
 #define FIX_VBR_BUG 1 // Fix 1st pass bug (bug from rebasing the branch)
 #define FIX_10BIT     1 // fix 1st pass for 10bit input
 #define FIX_RC_TOKEN     1 // fix RC token check to include double dash
+
+#define FIX_PAD_CHROMA_AFTER_MCTF     1 // Padding chroma after altref
+#define FEATURE_NEW_DELAY             1 // Change delay some sorts of I in PicDecision
+#if FEATURE_NEW_DELAY
+#define FIX_LAD_DEADLOCK              1 // Fix deadlock when lad>0 + iperiod>0
+#endif
+
+
+
+
+
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -46,6 +46,23 @@ extern "C" {
 #if FEATURE_NEW_DELAY
 #define FIX_LAD_DEADLOCK              1 // Fix deadlock when lad>0 + iperiod>0
 #endif
+#define FEATURE_INL_ME                1 //Enable in-loop ME
+#if FEATURE_INL_ME
+#define TUNE_IME_REUSE_TPL_RESULT     1 // Reuse TPL results for iLoopME
+#define TUNE_INL_TPL_ENHANCEMENT      1 // Refinement for TPL
+#define TUNE_INL_TPL_ME_DBG_MSG       0 // Turn off debug message
+#define TUNE_INL_ME_RECON_INPUT       1 // Perform ME on input/recon: 1 on input, 0 on recon
+#if TUNE_INL_ME_RECON_INPUT
+#define TUNE_INL_ME_ON_INPUT          1 // Perform ME on input
+#define TUNE_INL_GM_ON_INPUT          1 // Perform GM on input
+#define TUNE_INL_TPL_ON_INPUT         1 // Perform TPL on input
+#define TUNE_INL_ME_MEM_OPT           1 // Optimize memory usage when perform ME on input, only use 8bit luma
+#define TUNE_INL_ME_DECODE_ORDER      1 // Force decode order for inloopME
+#endif
+#if !TUNE_IME_REUSE_TPL_RESULT
+#define TUNE_SIGNAL_TPL_ME_OQ         1 // A separate signal_xxx_oq for TPL ME
+#endif
+#endif
 
 
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -30,7 +30,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#if FEATURE_NEW_DELAY
+#define SCD_LAD                                             6  //number of future frames
+#define PD_WINDOW_SIZE                                      (SCD_LAD +2) //adding previous+current to future
+#define MAX_TPL_GROUP_SIZE                                  64 //enough to cover 6L gop
+#endif
 #define MAX_TX_WEIGHT 500
 #define MAX_TPL_LA_SW 60 // Max TPL look ahead sliding window size
 #define DEPTH_PROB_PRECISION 10000

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -35,6 +35,9 @@ extern "C" {
 #define PD_WINDOW_SIZE                                      (SCD_LAD +2) //adding previous+current to future
 #define MAX_TPL_GROUP_SIZE                                  64 //enough to cover 6L gop
 #endif
+#if FEATURE_IN_LOOP_TPL
+#define TPL_DEP_COST_SCALE_LOG2 4
+#endif
 #define MAX_TX_WEIGHT 500
 #define MAX_TPL_LA_SW 60 // Max TPL look ahead sliding window size
 #define DEPTH_PROB_PRECISION 10000

--- a/Source/Lib/Common/Codec/EbMcp.c
+++ b/Source/Lib/Common/Codec/EbMcp.c
@@ -13,6 +13,9 @@
 
 #include "EbPictureOperators.h"
 #include "common_dsp_rtcd.h"
+#if TUNE_INL_TPL_ENHANCEMENT
+#include "EbLog.h"
+#endif
 
 
 #if (InternalBitDepthIncrement == 0)
@@ -137,6 +140,13 @@ void generate_padding(
     EbByte   temp_src_pic2;
     EbByte   temp_src_pic3;
 
+#if TUNE_INL_TPL_ENHANCEMENT
+    if (!src_pic) {
+         SVT_ERROR("padding NULL pointers\n");
+         return;
+    }
+#endif
+
     temp_src_pic0 = src_pic + padding_width + padding_height * src_stride;
     while (vertical_idx) {
         // horizontal padding
@@ -240,6 +250,13 @@ void pad_input_picture(
 {
     uint32_t vertical_idx;
     EbByte   temp_src_pic0;
+
+#if TUNE_INL_TPL_ENHANCEMENT
+    if (!src_pic) {
+         SVT_ERROR("padding NULL pointers\n");
+         return;
+    }
+#endif
 
     if (pad_right) {
         // Add padding @ the right

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -24,6 +24,9 @@
 #include "EbRateDistortionCost.h"
 #include "EbPictureDecisionProcess.h"
 #include "firstpass.h"
+#if FEATURE_INL_ME
+#include "EbPictureAnalysisProcess.h"
+#endif
 
 #define FC_SKIP_TX_SR_TH025 125 // Fast cost skip tx search threshold.
 #define FC_SKIP_TX_SR_TH010 110 // Fast cost skip tx search threshold.
@@ -1597,6 +1600,57 @@ void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
             (ref_pic_16bit_ptr->width + (ref_pic_ptr->origin_x << 1)) >> 1,
             (ref_pic_16bit_ptr->height + (ref_pic_ptr->origin_y << 1)) >> 1);
     }
+#if FEATURE_INL_ME
+    // Save down scaled reference for HME
+    if (scs_ptr->in_loop_me) {
+        if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+            downsample_filtering_input_picture(
+                    pcs_ptr->parent_pcs_ptr,
+                    ref_pic_ptr,
+                    reference_object->quarter_reference_picture,
+                    reference_object->sixteenth_reference_picture);
+        } else {
+            downsample_decimation_input_picture(
+                    pcs_ptr->parent_pcs_ptr,
+                    ref_pic_ptr,
+                    reference_object->quarter_reference_picture,
+                    reference_object->sixteenth_reference_picture);
+        }
+#if TUNE_INL_ME_RECON_INPUT
+        // Copy original input to reference->input_picture
+        EbPictureBufferDesc *src_ptr = pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+        uint16_t luma_height = (uint16_t)(src_ptr->height - scs_ptr->max_input_pad_bottom);
+        uint32_t src_offset = (src_ptr->stride_y*src_ptr->origin_y + src_ptr->origin_x);
+        uint16_t src_stride = src_ptr->stride_y;
+        uint8_t *src = src_ptr->buffer_y + src_offset;
+
+        EbPictureBufferDesc *dst_ptr = reference_object->input_picture;
+        uint32_t dst_offset = (dst_ptr->stride_y*dst_ptr->origin_y + dst_ptr->origin_x);
+        uint16_t dst_stride = dst_ptr->stride_y;
+        uint8_t *dst = dst_ptr->buffer_y + dst_offset;
+        for (int i=0; i<luma_height; i++) {
+            EB_MEMCPY(dst, src, src_stride);
+            src += src_stride;
+            dst += dst_stride;
+        }
+        pad_input_pictures(scs_ptr, dst_ptr);
+        // Generate 1/4 and 1/16 for reference->quarter_input_picture and reference->sixteenth_input_picture
+        if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+            downsample_filtering_input_picture(
+                    pcs_ptr->parent_pcs_ptr,
+                    reference_object->input_picture,
+                    reference_object->quarter_input_picture,
+                    reference_object->sixteenth_input_picture);
+        } else {
+            downsample_decimation_input_picture(
+                    pcs_ptr->parent_pcs_ptr,
+                    reference_object->input_picture,
+                    reference_object->quarter_input_picture,
+                    reference_object->sixteenth_input_picture);
+        }
+#endif
+    }
+#endif
     // set up the ref POC
     reference_object->ref_poc = pcs_ptr->parent_pcs_ptr->picture_number;
 

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -189,8 +189,13 @@ typedef struct EncodeContext {
     EbBool  is_i_slice_in_last_mini_gop;
     uint64_t i_slice_picture_number_in_last_mini_gop;
     uint64_t poc_map_idx[MAX_TPL_LA_SW];
+#if FEATURE_IN_LOOP_TPL
+    EbPictureBufferDesc *mc_flow_rec_picture_buffer[MAX_TPL_LA_SW];
+    EbPictureBufferDesc *mc_flow_rec_picture_buffer_noref;
+#else
     EbByte  mc_flow_rec_picture_buffer[MAX_TPL_LA_SW];
     EbByte  mc_flow_rec_picture_buffer_saved;
+#endif
     FrameInfo      frame_info;
     TwoPassCfg     two_pass_cfg; // two pass datarate control
     RATE_CONTROL   rc;

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -90,6 +90,9 @@ typedef struct EncodeContext {
     // Picture Buffer Fifos
     EbFifo *reference_picture_pool_fifo_ptr;
     EbFifo *pa_reference_picture_pool_fifo_ptr;
+#if FEATURE_INL_ME
+    EbFifo *down_scaled_picture_pool_fifo_ptr;
+#endif
 
     // Picture Decision Reorder Queue
     PictureDecisionReorderEntry **picture_decision_reorder_queue;

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -156,6 +156,7 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
 }
 
 #if FEATURE_INL_ME
+// inloop global motion estimation
 #if FEATURE_GM_OPT
 void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr) {
 #else

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -157,12 +157,8 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
 
 #if FEATURE_INL_ME
 // inloop global motion estimation
-#if FEATURE_GM_OPT
-void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr) {
-#else
 void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
                               EbPictureBufferDesc *input_picture_ptr) {
-#endif
     EbDownScaledObject *ds_object =
         (EbDownScaledObject*)pcs_ptr->down_scaled_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *quarter_picture_ptr = ds_object->quarter_picture_ptr;
@@ -250,20 +246,12 @@ void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *c
                 ref_picture_ptr = reference_object->input_picture;
 #endif
             }
-#if FEATURE_GM_OPT
-            compute_global_motion(pcs_ptr, input_picture_ptr,
-#else
             compute_global_motion(input_picture_ptr,
-#endif
                                   ref_picture_ptr,
                                   &pcs_ptr->global_motion_estimation[list_index][ref_pic_index],
                                   pcs_ptr->frm_hdr.allow_high_precision_mv);
         }
-#if FEATURE_GM_OPT
-        if (pcs_ptr->gm_ctrls.identiy_exit) {
-#else
         if (context_ptr->gm_identiy_exit) {
-#endif
             if (list_index == 0) {
                 if (pcs_ptr->global_motion_estimation[0][0].wmtype == IDENTITY) {
                     break;

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -229,7 +229,7 @@ void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *c
             // Set the source and the reference picture to be used by the global motion search
             // based on the input search mode
             if (pcs_ptr->gm_level == GM_DOWN16) {
-#if !TUNE_INL_GM_ON_INPUT
+#if !TUNE_INL_ME_RECON_INPUT
                 ref_picture_ptr = reference_object->sixteenth_reference_picture;
 #else
                 ref_picture_ptr = reference_object->sixteenth_input_picture;
@@ -237,14 +237,14 @@ void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *c
                 input_picture_ptr = sixteenth_picture_ptr;
             }
             else if (pcs_ptr->gm_level == GM_DOWN) {
-#if !TUNE_INL_GM_ON_INPUT
+#if !TUNE_INL_ME_RECON_INPUT
                 ref_picture_ptr = reference_object->quarter_reference_picture;
 #else
                 ref_picture_ptr = reference_object->quarter_input_picture;
 #endif
                 input_picture_ptr = quarter_picture_ptr;
             } else {
-#if !TUNE_INL_GM_ON_INPUT
+#if !TUNE_INL_ME_RECON_INPUT
                 ref_picture_ptr = (EbPictureBufferDesc *)reference_object->reference_picture;
 #else
                 ref_picture_ptr = reference_object->input_picture;

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -155,6 +155,136 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
     }
 }
 
+#if FEATURE_INL_ME
+#if FEATURE_GM_OPT
+void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr) {
+#else
+void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
+                              EbPictureBufferDesc *input_picture_ptr) {
+#endif
+    EbDownScaledObject *ds_object =
+        (EbDownScaledObject*)pcs_ptr->down_scaled_picture_wrapper_ptr->object_ptr;
+    EbPictureBufferDesc *quarter_picture_ptr = ds_object->quarter_picture_ptr;
+    EbPictureBufferDesc *sixteenth_picture_ptr = ds_object->sixteenth_picture_ptr;
+    PictureControlSet *child_pcs_ptr = pcs_ptr->child_pcs;
+
+    uint32_t num_of_list_to_search =
+            (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+    // Initilize global motion to be OFF for all references frames.
+    memset(pcs_ptr->is_global_motion, EB_FALSE, MAX_NUM_OF_REF_PIC_LIST * REF_LIST_MAX_DEPTH);
+    // Initilize wmtype to be IDENTITY for all references frames
+    // Ref List Loop
+    for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint32_t num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+            ? pcs_ptr->ref_list0_count_try
+            : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count_try
+            : pcs_ptr->ref_list1_count_try;
+        // Ref Picture Loop
+        for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
+            pcs_ptr->global_motion_estimation[list_index][ref_pic_index].wmtype = IDENTITY;
+        }
+    }
+    // Derive total_me_sad
+    uint32_t total_me_sad = 0;
+    for (uint16_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
+        total_me_sad += pcs_ptr->rc_me_distortion[sb_index];
+    }
+    uint32_t average_me_sad = total_me_sad / (input_picture_ptr->width * input_picture_ptr->height);
+    // Derive global_motion_estimation level
+
+    uint8_t global_motion_estimation_level;
+    // 0: skip GMV params derivation
+    // 1: use up to 1 ref per list @ the GMV params derivation
+    // 2: use up to 2 ref per list @ the GMV params derivation
+    // 3: all refs @ the GMV params derivation
+    if (average_me_sad == GMV_ME_SAD_TH_0)
+        global_motion_estimation_level = 0;
+    else if (average_me_sad < GMV_ME_SAD_TH_1)
+        global_motion_estimation_level = 1;
+    else if (average_me_sad < GMV_ME_SAD_TH_2)
+        global_motion_estimation_level = 2;
+    else
+        global_motion_estimation_level = 3;
+
+    if (global_motion_estimation_level)
+    for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint32_t num_of_ref_pic_to_search;
+            num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+                                          ? pcs_ptr->ref_list0_count_try
+                                          : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count_try
+                                          : pcs_ptr->ref_list1_count_try;
+        if (global_motion_estimation_level == 1)
+            num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 1);
+        else if (global_motion_estimation_level == 2)
+            num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 2);
+        // Ref Picture Loop
+        for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search;
+             ++ref_pic_index) {
+            EbReferenceObject *reference_object =
+                    (EbReferenceObject *)child_pcs_ptr->ref_pic_ptr_array[list_index][ref_pic_index]
+                        ->object_ptr;
+            EbPictureBufferDesc *ref_picture_ptr;
+
+            // Set the source and the reference picture to be used by the global motion search
+            // based on the input search mode
+            if (pcs_ptr->gm_level == GM_DOWN16) {
+                ref_picture_ptr = reference_object->sixteenth_reference_picture;
+#if TUNE_INL_GM_ON_INPUT
+                ref_picture_ptr = reference_object->sixteenth_input_picture;
+#endif
+                input_picture_ptr = sixteenth_picture_ptr;
+            }
+            else if (pcs_ptr->gm_level == GM_DOWN) {
+                ref_picture_ptr = reference_object->quarter_reference_picture;
+#if TUNE_INL_GM_ON_INPUT
+                ref_picture_ptr = reference_object->quarter_input_picture;
+#endif
+                input_picture_ptr = quarter_picture_ptr;
+            } else {
+                ref_picture_ptr = (EbPictureBufferDesc *)reference_object->reference_picture;
+#if TUNE_INL_GM_ON_INPUT
+                ref_picture_ptr = reference_object->input_picture;
+#endif
+            }
+#if FEATURE_GM_OPT
+            compute_global_motion(pcs_ptr, input_picture_ptr,
+#else
+            compute_global_motion(input_picture_ptr,
+#endif
+                                  ref_picture_ptr,
+                                  &pcs_ptr->global_motion_estimation[list_index][ref_pic_index],
+                                  pcs_ptr->frm_hdr.allow_high_precision_mv);
+        }
+#if FEATURE_GM_OPT
+        if (pcs_ptr->gm_ctrls.identiy_exit) {
+#else
+        if (context_ptr->gm_identiy_exit) {
+#endif
+            if (list_index == 0) {
+                if (pcs_ptr->global_motion_estimation[0][0].wmtype == IDENTITY) {
+                    break;
+                }
+            }
+        }
+    }
+    for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint32_t num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+            ? pcs_ptr->ref_list0_count
+            : list_index == REF_LIST_0
+            ? pcs_ptr->ref_list0_count
+            : pcs_ptr->ref_list1_count;
+
+        // Ref Picture Loop
+        for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search;
+            ++ref_pic_index) {
+            pcs_ptr->is_global_motion[list_index][ref_pic_index] = EB_FALSE;
+            if (pcs_ptr->global_motion_estimation[list_index][ref_pic_index].wmtype >
+                TRANSLATION)
+                pcs_ptr->is_global_motion[list_index][ref_pic_index] = EB_TRUE;
+        }
+    }
+}
+#endif
 static INLINE int convert_to_trans_prec(int allow_hp, int coor) {
     if (allow_hp)
         return ROUND_POWER_OF_TWO_SIGNED(coor, WARPEDMODEL_PREC_BITS - 3);

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -228,21 +228,24 @@ void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *c
             // Set the source and the reference picture to be used by the global motion search
             // based on the input search mode
             if (pcs_ptr->gm_level == GM_DOWN16) {
+#if !TUNE_INL_GM_ON_INPUT
                 ref_picture_ptr = reference_object->sixteenth_reference_picture;
-#if TUNE_INL_GM_ON_INPUT
+#else
                 ref_picture_ptr = reference_object->sixteenth_input_picture;
 #endif
                 input_picture_ptr = sixteenth_picture_ptr;
             }
             else if (pcs_ptr->gm_level == GM_DOWN) {
+#if !TUNE_INL_GM_ON_INPUT
                 ref_picture_ptr = reference_object->quarter_reference_picture;
-#if TUNE_INL_GM_ON_INPUT
+#else
                 ref_picture_ptr = reference_object->quarter_input_picture;
 #endif
                 input_picture_ptr = quarter_picture_ptr;
             } else {
+#if !TUNE_INL_GM_ON_INPUT
                 ref_picture_ptr = (EbPictureBufferDesc *)reference_object->reference_picture;
-#if TUNE_INL_GM_ON_INPUT
+#else
                 ref_picture_ptr = reference_object->input_picture;
 #endif
             }

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.h
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.h
@@ -16,9 +16,21 @@
 #include "EbPictureBufferDesc.h"
 #include "EbMotionEstimationContext.h"
 
+#if FEATURE_GM_OPT
+void global_motion_estimation(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr);
+void compute_global_motion(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_pic, EbPictureBufferDesc *ref_pic, EbWarpedMotionParams *bestWarpedMotion, int allow_high_precision_mv);
+#if FEATURE_INL_ME
+void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr);
+#endif
+#else
 void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
                               EbPictureBufferDesc *input_picture_ptr);
 void compute_global_motion(EbPictureBufferDesc *input_pic, EbPictureBufferDesc *ref_pic,
                            EbWarpedMotionParams *bestWarpedMotion, int allow_high_precision_mv);
+#if FEATURE_INL_ME
+void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
+                                  EbPictureBufferDesc *input_picture_ptr);
+#endif
+#endif
 
 #endif // EbGlobalMotionEstimation_h

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.h
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.h
@@ -16,13 +16,6 @@
 #include "EbPictureBufferDesc.h"
 #include "EbMotionEstimationContext.h"
 
-#if FEATURE_GM_OPT
-void global_motion_estimation(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr);
-void compute_global_motion(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_pic, EbPictureBufferDesc *ref_pic, EbWarpedMotionParams *bestWarpedMotion, int allow_high_precision_mv);
-#if FEATURE_INL_ME
-void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, EbPictureBufferDesc *input_picture_ptr);
-#endif
-#else
 void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
                               EbPictureBufferDesc *input_picture_ptr);
 void compute_global_motion(EbPictureBufferDesc *input_pic, EbPictureBufferDesc *ref_pic,
@@ -30,7 +23,6 @@ void compute_global_motion(EbPictureBufferDesc *input_pic, EbPictureBufferDesc *
 #if FEATURE_INL_ME
 void global_motion_estimation_inl(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
                                   EbPictureBufferDesc *input_picture_ptr);
-#endif
 #endif
 
 #endif // EbGlobalMotionEstimation_h

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1311,11 +1311,6 @@ EbErrorType tpl_mc_flow(
     return EB_ErrorNone;
 }
 #endif
-#if FIX_OPTIMIZE_BUILD_QUANTIZER
-void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q, int32_t u_dc_delta_q,
-    int32_t u_ac_delta_q, int32_t v_dc_delta_q, int32_t v_ac_delta_q,
-    Quants *const quants, Dequants *const deq);
-#endif
 /* Initial Rate Control Kernel */
 
 /*********************************************************************************

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -61,6 +61,7 @@ EbErrorType initial_rate_control_context_ctor(EbThreadContext *  thread_context_
     return EB_ErrorNone;
 }
 
+#if !FEATURE_INL_ME
 /************************************************
 * Release Pa Reference Objects
 ** Check if reference pictures are needed
@@ -96,7 +97,7 @@ void release_pa_reference_objects(SequenceControlSet *scs_ptr, PictureParentCont
 
     return;
 }
-
+#endif
 /************************************************
 * Update BEA Information Based on Lookahead
 ** Average zzCost of Collocated SB throughout lookahead frames
@@ -1367,7 +1368,13 @@ void *initial_rate_control_kernel(void *input_ptr) {
             EncodeContext *encode_context_ptr = (EncodeContext *)scs_ptr->encode_context_ptr;
             if (scs_ptr->static_config.look_ahead_distance == 0 || scs_ptr->static_config.enable_tpl_la == 0) {
                 // Release Pa Ref pictures when not needed
+#if FEATURE_INL_ME
+                // Release Pa ref after TPL
+                if (!scs_ptr->in_loop_me)
+                    release_pa_reference_objects(scs_ptr, pcs_ptr);
+#else
                 release_pa_reference_objects(scs_ptr, pcs_ptr);
+#endif
             }
             /*In case Look-Ahead is zero there is no need to place pictures in the
               re-order queue. this will cause an artificial delay since pictures come in dec-order*/

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1449,6 +1449,18 @@ void *initial_rate_control_kernel(void *input_ptr) {
                         ? queue_entry_index_temp - INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH
                         : queue_entry_index_temp;
 
+#if FIX_LAD_DEADLOCK
+                    if (encode_context_ptr->initial_rate_control_reorder_queue[queue_entry_index_temp2]->parent_pcs_wrapper_ptr != NULL) {
+                        PictureParentControlSet* pcs =
+                            (PictureParentControlSet*)(encode_context_ptr
+                                                           ->initial_rate_control_reorder_queue
+                                                               [queue_entry_index_temp]
+                                                               ->parent_pcs_wrapper_ptr)->object_ptr;
+                        if (pcs->is_next_frame_intra)
+                            break;
+                    }
+#endif
+
                     move_slide_window_flag =
                         (EbBool)(move_slide_window_flag &&
                                  (encode_context_ptr
@@ -1498,6 +1510,13 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                 ? queue_entry_index_temp -
                                     INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH
                                 : queue_entry_index_temp;
+#if FIX_LAD_DEADLOCK
+                            //exit if we hit a non valid entry
+                            if (encode_context_ptr
+                                    ->initial_rate_control_reorder_queue[queue_entry_index_temp2]
+                                    ->parent_pcs_wrapper_ptr == NULL)
+                                break;
+#endif
                             PictureParentControlSet *pcs_ptr_temp =
                                 ((PictureParentControlSet
                                       *)(encode_context_ptr

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1465,7 +1465,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                         ? queue_entry_index_temp - INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH
                         : queue_entry_index_temp;
 
-#if FIX_LAD_DEADLOCK
+#if FEATURE_NEW_DELAY
                     if (encode_context_ptr->initial_rate_control_reorder_queue[queue_entry_index_temp2]->parent_pcs_wrapper_ptr != NULL) {
                         PictureParentControlSet* pcs =
                             (PictureParentControlSet*)(encode_context_ptr
@@ -1526,7 +1526,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                 ? queue_entry_index_temp -
                                     INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH
                                 : queue_entry_index_temp;
-#if FIX_LAD_DEADLOCK
+#if FEATURE_NEW_DELAY
                             //exit if we hit a non valid entry
                             if (encode_context_ptr
                                     ->initial_rate_control_reorder_queue[queue_entry_index_temp2]

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -20,12 +20,14 @@
 #include "EbReferenceObject.h"
 #include "EbResize.h"
 #include "common_dsp_rtcd.h"
+#if !FEATURE_IN_LOOP_TPL
 #include "EbTransforms.h"
 #include "aom_dsp_rtcd.h"
 #include "EbRateDistortionCost.h"
 #include "EbLog.h"
 #include "EbIntraPrediction.h"
 #include "EbMotionEstimation.h"
+#endif
 /**************************************
  * Context
  **************************************/
@@ -334,6 +336,7 @@ void update_histogram_queue_entry(SequenceControlSet *scs_ptr, EncodeContext *en
     return;
 }
 
+#if !FEATURE_IN_LOOP_TPL
 static void generate_lambda_scaling_factor(PictureParentControlSet         *pcs_ptr, int64_t mc_dep_cost_base)
 {
     Av1Common *cm = pcs_ptr->av1_cm;
@@ -1307,6 +1310,12 @@ EbErrorType tpl_mc_flow(
 
     return EB_ErrorNone;
 }
+#endif
+#if FIX_OPTIMIZE_BUILD_QUANTIZER
+void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q, int32_t u_dc_delta_q,
+    int32_t u_ac_delta_q, int32_t v_dc_delta_q, int32_t v_ac_delta_q,
+    Quants *const quants, Dequants *const deq);
+#endif
 /* Initial Rate Control Kernel */
 
 /*********************************************************************************
@@ -1600,11 +1609,13 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                     ->reference_picture_wrapper_ptr,
                                 1);
                         }
+#if !FEATURE_IN_LOOP_TPL
                         if (scs_ptr->static_config.look_ahead_distance != 0 &&
                             scs_ptr->static_config.enable_tpl_la &&
                             pcs_ptr->temporal_layer_index == 0) {
                             tpl_mc_flow(encode_context_ptr, scs_ptr, pcs_ptr);
                         }
+#endif
                         // Get Empty Results Object
                         eb_get_empty_object(
                             context_ptr->initialrate_control_results_output_fifo_ptr,

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -3487,7 +3487,7 @@ EbErrorType open_loop_intra_search_mb(
             EbBool   enable_paeth                = pcs_ptr->scs_ptr->static_config.enable_paeth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_paeth;
             EbBool   enable_smooth               = pcs_ptr->scs_ptr->static_config.enable_smooth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_smooth;
             uint8_t intra_mode_end =
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
                 pcs_ptr->tpl_data.tpl_opt_flag
 #else
                 pcs_ptr->tpl_opt_flag

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -1844,6 +1844,7 @@ void swap_me_candidate(MePredUnit *a, MePredUnit *b) {
     *b       = temp_ptr;
 }
 #if FEATURE_INL_ME
+// get ME references based on level:
 // level: 0 => sixteenth, 1 => quarter, 2 => original
 static EbPictureBufferDesc* get_me_reference(
     PictureParentControlSet   *pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -2187,15 +2187,11 @@ void integer_search_sb(
   using previous stage ME results (Integer Search) for each reference
   frame. keep only the references that are close to the best reference.
 */
-#if FEATURE_INTER_INTRA_LEVELS
-void me_prune_ref(MeContext* context_ptr) {
-#else
 void me_prune_ref(
     PictureParentControlSet   *pcs_ptr,
     uint32_t                   sb_index,
     MeContext                 *context_ptr)
 {
-#endif
     HmeResults sorted[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     uint32_t num_of_cand_to_sort = MAX_NUM_OF_REF_PIC_LIST * REF_LIST_MAX_DEPTH;
     uint8_t list_index, ref_pic_index;
@@ -2263,13 +2259,10 @@ void me_prune_ref(
         }
     }
     uint64_t best = sorted[0][0].hme_sad;//is this always the best?
-#if !FEATURE_INTER_INTRA_LEVELS
     uint8_t counter = 0;
 #define NUMBER_REF_INTER_COMP   2
-#endif
     for (uint32_t li = 0; li < MAX_NUM_OF_REF_PIC_LIST; li++) {
         for (uint32_t ri = 0; ri < REF_LIST_MAX_DEPTH; ri++){
-#if !FEATURE_INTER_INTRA_LEVELS
 #if FEATURE_INL_ME
             if (context_ptr->me_type != ME_MCTF)
 #else
@@ -2285,7 +2278,6 @@ void me_prune_ref(
                 counter++;
 
             }
-#endif
             // Prune references based on ME sad
             uint16_t prune_ref_th = context_ptr->me_hme_prune_ctrls.prune_ref_if_me_sad_dev_bigger_than_th;
             if (context_ptr->me_hme_prune_ctrls.enable_me_hme_ref_pruning &&
@@ -3285,9 +3277,7 @@ EbErrorType motion_estimate_sb(
             if(context_ptr->me_type != ME_MCTF && context_ptr->me_type != ME_TPL)
 #endif
 #endif
-#if !FEATURE_INTER_INTRA_LEVELS
                 pcs_ptr->pa_me_data->me_results[sb_index]->do_comp[li][ri] = 1;
-#endif
             context_ptr->hme_results[li][ri].list_i   = li;
             context_ptr->hme_results[li][ri].ref_i    = ri;
             context_ptr->hme_results[li][ri].do_ref   = 1;
@@ -3311,11 +3301,7 @@ EbErrorType motion_estimate_sb(
     integer_search_sb(pcs_ptr, sb_index, sb_origin_x, sb_origin_y, context_ptr, input_ptr);
     // prune the refrence frames
     if (prune_ref && context_ptr->me_hme_prune_ctrls.enable_me_hme_ref_pruning) {
-#if FEATURE_INTER_INTRA_LEVELS
-        me_prune_ref(context_ptr);
-#else
         me_prune_ref(pcs_ptr, sb_index, context_ptr);
-#endif
     }
 
 #if !FEATURE_INL_ME

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -2824,9 +2824,6 @@ void set_final_seach_centre_sb(
     uint64_t best_cost = (uint64_t)~0;
     context_ptr->best_list_idx = 0;
     context_ptr->best_ref_idx = 0;
-
-
-
 #if !FEATURE_INL_ME
     num_of_list_to_search = (pcs_ptr->slice_type == P_SLICE)
         ? (uint32_t)REF_LIST_0

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -3486,7 +3486,11 @@ EbErrorType open_loop_intra_search_mb(
             EbBool   enable_paeth                = pcs_ptr->scs_ptr->static_config.enable_paeth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_paeth;
             EbBool   enable_smooth               = pcs_ptr->scs_ptr->static_config.enable_smooth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_smooth;
             uint8_t intra_mode_end =
+#if FIX_TPL_TRAILING_FRAME_BUG
+                pcs_ptr->tpl_data.tpl_opt_flag
+#else
                 pcs_ptr->tpl_opt_flag
+#endif
                     ? DC_PRED
                     : enable_paeth ? PAETH_PRED : enable_smooth ? SMOOTH_H_PRED : D67_PRED;
             PredictionMode best_mode       = DC_PRED;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationContext.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationContext.c
@@ -65,7 +65,14 @@ EbErrorType me_context_ctor(MeContext *object_ptr) {
                     8 * 16); //16= 16 16x16 blocks in a SB.       8=8search points
 
     // Initialize Alt-Ref parameters
+#if !FEATURE_INL_ME
     object_ptr->me_alt_ref = EB_FALSE;
+#else
+    object_ptr->me_type = ME_CLOSE_LOOP;
+    object_ptr->num_of_list_to_search = 0;
+    object_ptr->num_of_ref_pic_to_search[0] = 0;
+    object_ptr->num_of_ref_pic_to_search[1] = 0;
+#endif
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
@@ -405,13 +405,8 @@ typedef struct MeContext {
     int16_t adjust_hme_l1_factor[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     int16_t adjust_hme_l2_factor[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     int16_t hme_factor;
-#if !FEATURE_GM_OPT // GmControls
     //exit gm search if first reference detection is identity
     uint8_t gm_identiy_exit;
-#if FEATURE_GM_OPT
-    uint8_t gm_rotzoom_model_only;
-#endif
-#endif
     // ------- Context for Alt-Ref ME ------
     uint16_t adj_search_area_width;
     uint16_t adj_search_area_height;
@@ -431,15 +426,7 @@ typedef struct MeContext {
     EbDownScaledBufDescPtrArray me_ds_ref_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
 #endif
     // tf
-#if FEATURE_OPT_TF
-    uint8_t tf_hp;
-    uint8_t tf_chroma;
-#if FEATURE_OPT_TF
-    uint64_t tf_block_32x32_16x16_th;
-#endif
-#else
     uint8_t high_precision;
-#endif
     int tf_frame_index;
     int tf_index_center;
     signed short tf_16x16_mv_x[16];

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
@@ -41,6 +41,14 @@ typedef struct MePredictionUnit {
     uint32_t sub_pel_direction;
 } MePredictionUnit;
 
+#if FEATURE_INL_ME
+typedef enum EbMeType {
+    ME_CLOSE_LOOP  = 0,
+    ME_MCTF = 1,
+    ME_TPL = 2,
+    ME_OPEN_LOOP = 3
+} EbMeType;
+#endif
 typedef enum EbMeTierZeroPu {
     // 2Nx2N [85 partitions]
     ME_TIER_ZERO_PU_64x64    = 0,
@@ -397,15 +405,41 @@ typedef struct MeContext {
     int16_t adjust_hme_l1_factor[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     int16_t adjust_hme_l2_factor[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     int16_t hme_factor;
+#if !FEATURE_GM_OPT // GmControls
     //exit gm search if first reference detection is identity
     uint8_t gm_identiy_exit;
+#if FEATURE_GM_OPT
+    uint8_t gm_rotzoom_model_only;
+#endif
+#endif
     // ------- Context for Alt-Ref ME ------
     uint16_t adj_search_area_width;
     uint16_t adj_search_area_height;
+#if !FEATURE_INL_ME
     EbBool   me_alt_ref;
+#endif
     void *   alt_ref_reference_ptr;
+#if FEATURE_INL_ME
+    // Open Loop ME
+    EbMeType me_type;
+    EbDownScaledBufDescPtrArray mctf_ref_desc_ptr_array;
+
+    uint8_t num_of_list_to_search;
+    uint8_t num_of_ref_pic_to_search[2];
+    uint8_t temporal_layer_index;
+    EbBool  is_used_as_reference_flag;
+    EbDownScaledBufDescPtrArray me_ds_ref_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
+#endif
     // tf
+#if FEATURE_OPT_TF
+    uint8_t tf_hp;
+    uint8_t tf_chroma;
+#if FEATURE_OPT_TF
+    uint64_t tf_block_32x32_16x16_th;
+#endif
+#else
     uint8_t high_precision;
+#endif
     int tf_frame_index;
     int tf_index_center;
     signed short tf_16x16_mv_x[16];

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -1571,7 +1571,7 @@ void *inloop_me_kernel(void *input_ptr) {
                         context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_number =
                             ppcs_ptr->ref_pic_poc_array[i][j];
 
-#if TUNE_INL_ME_ON_INPUT
+#if TUNE_INL_ME_RECON_INPUT
                         context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_ptr =
                             inl_reference_object->input_picture;
                         context_ptr->me_context_ptr->me_ds_ref_array[i][j].sixteenth_picture_ptr =

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -990,7 +990,7 @@ void *motion_estimation_kernel(void *input_ptr) {
                                            sb_origin_y,
                                            context_ptr->me_context_ptr,
                                            input_picture_ptr);
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
                         eb_block_on_mutex(pcs_ptr->me_processed_sb_mutex);
                         pcs_ptr->me_processed_sb_count++;
                         eb_release_mutex(pcs_ptr->me_processed_sb_mutex);
@@ -1005,7 +1005,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 #else
             if (context_ptr->me_context_ptr->compute_global_motion &&
 #endif
-#if FIX_GM_BUG
+#if FEATURE_IN_LOOP_TPL
                 segment_index == 0) {
 #else
                 // Compute only when ME of all 64x64 SBs is performed
@@ -1630,7 +1630,7 @@ void *inloop_me_kernel(void *input_ptr) {
                                 sb_origin_y,
                                 context_ptr->me_context_ptr,
                                 input_picture_ptr);
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
 #if TUNE_IME_REUSE_TPL_RESULT
                         {
 #else
@@ -1653,7 +1653,7 @@ void *inloop_me_kernel(void *input_ptr) {
                 if (context_ptr->me_context_ptr->compute_global_motion &&
 #endif
                         ppcs_ptr->slice_type != I_SLICE &&
-#if FIX_GM_BUG
+#if FEATURE_IN_LOOP_TPL
                         segment_index== 0) {
 #else
                         // Compute only when ME of all 64x64 SBs is performed

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -352,7 +352,10 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
     return return_error;
 };
 #if TUNE_SIGNAL_TPL_ME_OQ
-EbErrorType signal_tpl_me_kernel_oq(SequenceControlSet *       scs_ptr,
+/******************************************************
+* Derive ME Settings for TPL
+******************************************************/
+EbErrorType signal_tpl_me_kernel(SequenceControlSet *       scs_ptr,
                                            PictureParentControlSet *  pcs_ptr,
                                            MotionEstimationContext_t *context_ptr) {
     EbErrorType return_error = EB_ErrorNone;
@@ -1513,7 +1516,7 @@ void *inloop_me_kernel(void *input_ptr) {
 
             if (task_type != 0) {
 #if TUNE_SIGNAL_TPL_ME_OQ
-                signal_tpl_me_kernel_oq(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
+                signal_tpl_me_kernel(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
 #else
                 signal_derivation_me_kernel_oq(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
 #endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -1000,11 +1000,7 @@ void *motion_estimation_kernel(void *input_ptr) {
             }
             // Global motion estimation
             // TODO: create an other kernel ?
-#if FEATURE_GM_OPT
-            if (pcs_ptr->gm_ctrls.enabled &&
-#else
             if (context_ptr->me_context_ptr->compute_global_motion &&
-#endif
 #if FEATURE_IN_LOOP_TPL
                 segment_index == 0) {
 #else
@@ -1014,22 +1010,14 @@ void *motion_estimation_kernel(void *input_ptr) {
 
 #if FEATURE_INL_ME
                 if (!scs_ptr->in_loop_me)
-#if FEATURE_GM_OPT
-                    global_motion_estimation(
-                        pcs_ptr, input_picture_ptr);
-#else
                     global_motion_estimation(
                         pcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
-#endif
 #else
                 global_motion_estimation(
                     pcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
 #endif
             }
             if (
-#if TUNE_TPL_OIS
-                scs_ptr->in_loop_ois == 0 &&
-#endif
 #if !ENABLE_TPL_ZERO_LAD
                 scs_ptr->static_config.look_ahead_distance != 0 &&
 #endif
@@ -1647,11 +1635,7 @@ void *inloop_me_kernel(void *input_ptr) {
             if (task_type == 0) {
                 // Global motion estimation
                 // TODO: create an other kernel ?
-#if FEATURE_GM_OPT
-                if (ppcs_ptr->gm_ctrls.enabled &&
-#else
                 if (context_ptr->me_context_ptr->compute_global_motion &&
-#endif
                         ppcs_ptr->slice_type != I_SLICE &&
 #if FEATURE_IN_LOOP_TPL
                         segment_index== 0) {
@@ -1659,13 +1643,8 @@ void *inloop_me_kernel(void *input_ptr) {
                         // Compute only when ME of all 64x64 SBs is performed
                         ppcs_ptr->me_processed_sb_count == ppcs_ptr->sb_total_count) {
 #endif
-#if FEATURE_GM_OPT
-                    global_motion_estimation_inl(
-                        ppcs_ptr, input_picture_ptr);
-#else
                     global_motion_estimation_inl(
                             ppcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
-#endif
                 }
                 eb_get_empty_object(context_ptr->output_fifo_ptr,
                         &out_results_wrapper_ptr);
@@ -1684,9 +1663,6 @@ void *inloop_me_kernel(void *input_ptr) {
                 // TPL ME
 #if TUNE_INL_TPL_ENHANCEMENT
                 // Doing OIS search for TPL
-#if TUNE_TPL_OIS
-                if (scs_ptr->in_loop_ois == 0)
-#endif
                 if (scs_ptr->static_config.enable_tpl_la) {
                     for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
                             ++y_sb_index) {

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -28,6 +28,10 @@
 #include "EbGlobalMotionEstimation.h"
 
 #include "EbResize.h"
+#if FEATURE_INL_ME
+#include "EbPictureDemuxResults.h"
+#include "EbRateControlTasks.h"
+#endif
 
 /* --32x32-
 |00||01|
@@ -347,6 +351,85 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
         set_me_sr_adjustment_ctrls(context_ptr->me_context_ptr, 2);
     return return_error;
 };
+#if TUNE_SIGNAL_TPL_ME_OQ
+EbErrorType signal_tpl_me_kernel_oq(SequenceControlSet *       scs_ptr,
+                                           PictureParentControlSet *  pcs_ptr,
+                                           MotionEstimationContext_t *context_ptr) {
+    EbErrorType return_error = EB_ErrorNone;
+
+    //EbEncMode enc_mode = pcs_ptr->enc_mode;
+    EbInputResolution input_resolution = scs_ptr->input_resolution;
+    MeContext *me_context_ptr = context_ptr->me_context_ptr;
+
+    // Set ME/HME search regions
+    me_context_ptr->number_hme_search_region_in_width  = 2;
+    me_context_ptr->number_hme_search_region_in_height = 2;
+
+    // Set the minimum ME search area
+    me_context_ptr->search_area_width = me_context_ptr->search_area_height = 16;
+    me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 64;
+
+    me_context_ptr->hme_level0_total_search_area_width =
+        me_context_ptr->hme_level0_total_search_area_height = 32;
+    me_context_ptr->hme_level0_max_total_search_area_width =
+        me_context_ptr->hme_level0_max_total_search_area_height = 164;
+
+    me_context_ptr->hme_level0_max_search_area_in_width_array[0] =
+        me_context_ptr->hme_level0_max_search_area_in_width_array[1] =
+        me_context_ptr->hme_level0_max_total_search_area_width / me_context_ptr->number_hme_search_region_in_width;
+    me_context_ptr->hme_level0_max_search_area_in_height_array[0] =
+        me_context_ptr->hme_level0_max_search_area_in_height_array[1] =
+        me_context_ptr->hme_level0_max_total_search_area_height / me_context_ptr->number_hme_search_region_in_height;
+    me_context_ptr->hme_level0_search_area_in_width_array[0] =
+        me_context_ptr->hme_level0_search_area_in_width_array[1] =
+        me_context_ptr->hme_level0_total_search_area_width / me_context_ptr->number_hme_search_region_in_width;
+    me_context_ptr->hme_level0_search_area_in_height_array[0] =
+        me_context_ptr->hme_level0_search_area_in_height_array[1] =
+        me_context_ptr->hme_level0_total_search_area_height / me_context_ptr->number_hme_search_region_in_height;
+
+    me_context_ptr->hme_level1_search_area_in_width_array[0] =
+        me_context_ptr->hme_level1_search_area_in_width_array[1] =
+        me_context_ptr->hme_level1_search_area_in_height_array[0] =
+        me_context_ptr->hme_level1_search_area_in_height_array[1] = 16;
+
+    me_context_ptr->hme_level2_search_area_in_width_array[0] =
+        me_context_ptr->hme_level2_search_area_in_width_array[1] =
+        me_context_ptr->hme_level2_search_area_in_height_array[0] =
+        me_context_ptr->hme_level2_search_area_in_height_array[1] = 16;
+    me_context_ptr->hme_decimation = TWO_DECIMATION_HME;
+
+    // Scale up the MIN ME area if low frame rate
+    uint8_t  low_frame_rate_flag = (scs_ptr->static_config.frame_rate >> 16) < 50 ? 1 : 0;
+    if (low_frame_rate_flag) {
+        me_context_ptr->search_area_width = (me_context_ptr->search_area_width * 3) / 2;
+        me_context_ptr->search_area_height = (me_context_ptr->search_area_height * 3) / 2;
+    }
+
+    me_context_ptr->update_hme_search_center_flag = 1;
+
+    if (input_resolution <= INPUT_SIZE_480p_RANGE)
+        me_context_ptr->update_hme_search_center_flag = 0;
+
+
+    // Set HME flags
+    me_context_ptr->enable_hme_flag        = pcs_ptr->enable_hme_flag;
+    me_context_ptr->enable_hme_level0_flag = pcs_ptr->enable_hme_level0_flag;
+    me_context_ptr->enable_hme_level1_flag = pcs_ptr->enable_hme_level1_flag;
+    me_context_ptr->enable_hme_level2_flag = pcs_ptr->enable_hme_level2_flag;
+    // HME Search Method
+    me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
+    me_context_ptr->me_search_method = SUB_SAD_SEARCH;
+    me_context_ptr->compute_global_motion = EB_FALSE;
+
+    // Set hme/me based reference pruning level (0-4)
+    set_me_hme_ref_prune_ctrls(me_context_ptr, 4);
+
+    // Set hme-based me sr adjustment level
+    set_me_sr_adjustment_ctrls(me_context_ptr, 2);
+    return return_error;
+};
+#endif
+
 /******************************************************
 * Derive ME Settings for first pass
   Input   : encoder mode and tune
@@ -680,6 +763,7 @@ void *motion_estimation_kernel(void *input_ptr) {
         PictureParentControlSet *pcs_ptr = (PictureParentControlSet *)
                                                in_results_ptr->pcs_wrapper_ptr->object_ptr;
         SequenceControlSet * scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
+#if !FEATURE_INL_ME
         EbPaReferenceObject *pa_ref_obj_ =
             (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
         // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
@@ -697,6 +781,10 @@ void *motion_estimation_kernel(void *input_ptr) {
         EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
 
         context_ptr->me_context_ptr->me_alt_ref = in_results_ptr->task_type == 1;
+#else
+        context_ptr->me_context_ptr->me_type =
+            in_results_ptr->task_type == 1 ? ME_MCTF: ME_OPEN_LOOP;
+#endif
 
         // Lambda Assignement
         if (scs_ptr->static_config.pred_structure == EB_PRED_RANDOM_ACCESS) {
@@ -723,6 +811,28 @@ void *motion_estimation_kernel(void *input_ptr) {
                 first_pass_signal_derivation_me_kernel(scs_ptr, pcs_ptr, context_ptr);
             else
                 signal_derivation_me_kernel_oq(scs_ptr, pcs_ptr, context_ptr);
+#if FEATURE_INL_ME
+            EbPictureBufferDesc *sixteenth_picture_ptr = NULL;
+            EbPictureBufferDesc *quarter_picture_ptr = NULL;
+            EbPictureBufferDesc *input_padded_picture_ptr = NULL;
+            EbPictureBufferDesc *input_picture_ptr = NULL;
+            EbPaReferenceObject *pa_ref_obj_ = NULL;
+            if (!scs_ptr->in_loop_me) {
+                pa_ref_obj_ = (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+                // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
+                quarter_picture_ptr =
+                    (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+                    ? (EbPictureBufferDesc *)pa_ref_obj_->quarter_filtered_picture_ptr
+                    : (EbPictureBufferDesc *)pa_ref_obj_->quarter_decimated_picture_ptr;
+
+                sixteenth_picture_ptr =
+                    (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+                    ? (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_filtered_picture_ptr
+                    : (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_decimated_picture_ptr;
+                input_padded_picture_ptr = (EbPictureBufferDesc *)pa_ref_obj_->input_padded_picture_ptr;
+            }
+            input_picture_ptr = pcs_ptr->enhanced_unscaled_picture_ptr;
+#endif
             // Segments
             uint32_t segment_index   = in_results_ptr->segment_index;
             uint32_t pic_width_in_sb = (pcs_ptr->aligned_width + scs_ptr->sb_sz - 1) /
@@ -742,7 +852,11 @@ void *motion_estimation_kernel(void *input_ptr) {
             uint32_t y_sb_end_index = SEGMENT_END_IDX(
                 y_segment_index, picture_height_in_sb, pcs_ptr->me_segments_row_count);
             // *** MOTION ESTIMATION CODE ***
+#if FEATURE_INL_ME
+            if (pcs_ptr->slice_type != I_SLICE && !scs_ptr->in_loop_me) {
+#else
             if (pcs_ptr->slice_type != I_SLICE) {
+#endif
                 // Use scaled source references if resolution of the reference is different that of the input
                 use_scaled_source_refs_if_needed(pcs_ptr,
                                                  input_picture_ptr,
@@ -832,7 +946,40 @@ void *motion_estimation_kernel(void *input_ptr) {
                                         FULL_SAD_SEARCH);
                             }
                         }
+#if !FEATURE_INL_ME
                         context_ptr->me_context_ptr->me_alt_ref = EB_FALSE;
+#else
+                        context_ptr->me_context_ptr->me_type = ME_OPEN_LOOP;
+                        context_ptr->me_context_ptr->num_of_list_to_search =
+                            (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+
+                        context_ptr->me_context_ptr->num_of_ref_pic_to_search[0] = pcs_ptr->ref_list0_count_try;
+                        if (pcs_ptr->slice_type == B_SLICE)
+                            context_ptr->me_context_ptr->num_of_ref_pic_to_search[1] = pcs_ptr->ref_list1_count_try;
+                        context_ptr->me_context_ptr->temporal_layer_index = pcs_ptr->temporal_layer_index;
+                        context_ptr->me_context_ptr->is_used_as_reference_flag = pcs_ptr->is_used_as_reference_flag;
+
+                        for (int i = 0; i<= context_ptr->me_context_ptr->num_of_list_to_search; i++) {
+                            for (int j=0; j< context_ptr->me_context_ptr->num_of_ref_pic_to_search[i];j++) {
+                                EbPaReferenceObject* reference_object =
+                                    (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[i][j]->object_ptr;
+                                context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_ptr =
+                                    reference_object->input_padded_picture_ptr;
+                                if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+                                    context_ptr->me_context_ptr->me_ds_ref_array[i][j].quarter_picture_ptr =
+                                        reference_object->quarter_filtered_picture_ptr;
+                                    context_ptr->me_context_ptr->me_ds_ref_array[i][j].sixteenth_picture_ptr =
+                                        reference_object->sixteenth_filtered_picture_ptr;
+                                } else {
+                                    context_ptr->me_context_ptr->me_ds_ref_array[i][j].quarter_picture_ptr =
+                                        reference_object->quarter_decimated_picture_ptr;
+                                    context_ptr->me_context_ptr->me_ds_ref_array[i][j].sixteenth_picture_ptr =
+                                        reference_object->sixteenth_decimated_picture_ptr;
+                                }
+                                context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_number = reference_object->picture_number;
+                            }
+                        }
+#endif
 
                         motion_estimate_sb(pcs_ptr,
                                            sb_index,
@@ -840,22 +987,52 @@ void *motion_estimation_kernel(void *input_ptr) {
                                            sb_origin_y,
                                            context_ptr->me_context_ptr,
                                            input_picture_ptr);
+#if !FIX_GM_BUG
                         eb_block_on_mutex(pcs_ptr->me_processed_sb_mutex);
                         pcs_ptr->me_processed_sb_count++;
                         eb_release_mutex(pcs_ptr->me_processed_sb_mutex);
+#endif
                     }
                 }
             }
             // Global motion estimation
             // TODO: create an other kernel ?
+#if FEATURE_GM_OPT
+            if (pcs_ptr->gm_ctrls.enabled &&
+#else
             if (context_ptr->me_context_ptr->compute_global_motion &&
+#endif
+#if FIX_GM_BUG
+                segment_index == 0) {
+#else
                 // Compute only when ME of all 64x64 SBs is performed
                 pcs_ptr->me_processed_sb_count == pcs_ptr->sb_total_count) {
+#endif
 
+#if FEATURE_INL_ME
+                if (!scs_ptr->in_loop_me)
+#if FEATURE_GM_OPT
+                    global_motion_estimation(
+                        pcs_ptr, input_picture_ptr);
+#else
+                    global_motion_estimation(
+                        pcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
+#endif
+#else
                 global_motion_estimation(
                     pcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
+#endif
             }
-            if (scs_ptr->static_config.look_ahead_distance != 0 &&
+            if (
+#if TUNE_TPL_OIS
+                scs_ptr->in_loop_ois == 0 &&
+#endif
+#if !ENABLE_TPL_ZERO_LAD
+                scs_ptr->static_config.look_ahead_distance != 0 &&
+#endif
+#if FEATURE_IN_LOOP_TPL
+                (!scs_ptr->in_loop_me || pcs_ptr->slice_type == I_SLICE) &&
+#endif
                 scs_ptr->static_config.enable_tpl_la)
                 for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
                      ++y_sb_index)
@@ -866,7 +1043,13 @@ void *motion_estimation_kernel(void *input_ptr) {
                     }
             // ZZ SADs Computation
             // 1 lookahead frame is needed to get valid (0,0) SAD
+#if FEATURE_INL_ME
+            if (scs_ptr->static_config.look_ahead_distance != 0 &&
+                    pcs_ptr->picture_number > 0 &&
+                    !scs_ptr->in_loop_me)
+#else
             if (scs_ptr->static_config.look_ahead_distance != 0 && pcs_ptr->picture_number > 0)
+#endif
                 // when DG is ON, the ZZ SADs are computed @ the PD process
                 // ZZ SADs Computation using decimated picture
                 compute_decimated_zz_sad(
@@ -878,6 +1061,20 @@ void *motion_estimation_kernel(void *input_ptr) {
                     x_sb_end_index,
                     y_sb_start_index,
                     y_sb_end_index);
+
+#if TUNE_INL_TPL_ENHANCEMENT
+            if (scs_ptr->static_config.look_ahead_distance != 0 &&
+                    pcs_ptr->picture_number > 0 &&
+                    scs_ptr->in_loop_me)
+                compute_decimated_zz_sad(
+                    context_ptr,
+                    pcs_ptr,
+                    pcs_ptr->ds_pics.sixteenth_picture_ptr,
+                    x_sb_start_index,
+                    x_sb_end_index,
+                    y_sb_start_index,
+                    y_sb_end_index);
+#endif
 
             // ZZ SSDs Computation
             // 1 lookahead frame is needed to get valid (0,0) SAD
@@ -897,6 +1094,9 @@ void *motion_estimation_kernel(void *input_ptr) {
 
             eb_block_on_mutex(pcs_ptr->rc_distortion_histogram_mutex);
 
+
+
+#if !FEATURE_INL_ME
             if (scs_ptr->static_config.rate_control_mode
                 && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
                 ) {
@@ -1013,6 +1213,77 @@ void *motion_estimation_kernel(void *input_ptr) {
                             }
                         }
             }
+#else
+            if (scs_ptr->static_config.rate_control_mode
+                && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
+                ) {
+                    for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
+                         ++y_sb_index)
+                        for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
+                             ++x_sb_index) {
+                            uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
+                            uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
+                            uint32_t sb_width    = (pcs_ptr->aligned_width - sb_origin_x) <
+                                    BLOCK_SIZE_64
+                                ? pcs_ptr->aligned_width - sb_origin_x
+                                : BLOCK_SIZE_64;
+                            uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
+                                    BLOCK_SIZE_64
+                                ? pcs_ptr->aligned_height - sb_origin_y
+                                : BLOCK_SIZE_64;
+
+                            uint32_t sb_index = (uint16_t)(x_sb_index +
+                                                           y_sb_index * pic_width_in_sb);
+                            pcs_ptr->inter_sad_interval_index[sb_index] = 0;
+                            pcs_ptr->intra_sad_interval_index[sb_index] = 0;
+
+                            if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
+                                if (pcs_ptr->slice_type != I_SLICE && !scs_ptr->in_loop_me) {
+                                    uint16_t sad_interval_index = (uint16_t)(
+                                            pcs_ptr->rc_me_distortion[sb_index] >>
+                                            (12 - SAD_PRECISION_INTERVAL)); //change 12 to 2*log2(64)
+
+                                    sad_interval_index = (uint16_t)(sad_interval_index >> 2);
+                                    if (sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
+                                        uint16_t sad_interval_index_temp = sad_interval_index -
+                                            ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
+
+                                        sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) - 1) +
+                                            (sad_interval_index_temp >> 3);
+                                    }
+                                    if (sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
+                                        sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
+
+                                    pcs_ptr->inter_sad_interval_index[sb_index] = sad_interval_index;
+
+                                    pcs_ptr->me_distortion_histogram[sad_interval_index]++;
+                                }
+
+                                uint32_t intra_sad_interval_index =
+                                    pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
+                                intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
+                                                                      2);
+                                if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
+                                    uint32_t sad_interval_index_temp = intra_sad_interval_index -
+                                        ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
+
+                                    intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
+                                                                1) +
+                                        (sad_interval_index_temp >> 3);
+                                }
+                                if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
+                                    intra_sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
+
+                                pcs_ptr->intra_sad_interval_index[sb_index] =
+                                    intra_sad_interval_index;
+
+                                pcs_ptr->ois_distortion_histogram[intra_sad_interval_index]++;
+
+                                ++pcs_ptr->full_sb_count;
+                            }
+                        }
+                }
+#endif
 
             eb_release_mutex(pcs_ptr->rc_distortion_histogram_mutex);
 
@@ -1035,7 +1306,11 @@ void *motion_estimation_kernel(void *input_ptr) {
             tf_signal_derivation_me_kernel_oq(scs_ptr, pcs_ptr, context_ptr);
 
             // temporal filtering start
+#if !FEATURE_INL_ME
             context_ptr->me_context_ptr->me_alt_ref = EB_TRUE;
+#else
+            context_ptr->me_context_ptr->me_type = ME_MCTF;
+#endif
             svt_av1_init_temporal_filtering(
                 pcs_ptr->temp_filt_pcs_list, pcs_ptr, context_ptr, in_results_ptr->segment_index);
 
@@ -1046,3 +1321,414 @@ void *motion_estimation_kernel(void *input_ptr) {
 
     return NULL;
 }
+#if FEATURE_INL_ME
+EbErrorType ime_context_ctor(EbThreadContext *  thread_context_ptr,
+        const EbEncHandle *enc_handle_ptr, int index) {
+    InLoopMeContext *context_ptr;
+    EB_CALLOC_ARRAY(context_ptr, 1);
+    thread_context_ptr->priv = context_ptr;
+    thread_context_ptr->dctor = motion_estimation_context_dctor;
+    context_ptr->input_fifo_ptr = eb_system_resource_get_consumer_fifo(
+            enc_handle_ptr->pic_mgr_res_srm, index);
+
+    context_ptr->output_fifo_ptr = eb_system_resource_get_producer_fifo(
+            enc_handle_ptr->rate_control_tasks_resource_ptr, index);
+
+    EB_NEW(context_ptr->me_context_ptr,
+            me_context_ctor);
+    return EB_ErrorNone;
+}
+
+static void init_lambda(InLoopMeContext *context_ptr,
+    SequenceControlSet *scs_ptr,
+    PictureParentControlSet *ppcs_ptr) {
+    uint8_t temporal_layer_index = context_ptr->me_context_ptr->temporal_layer_index;
+    if (scs_ptr->static_config.pred_structure == EB_PRED_RANDOM_ACCESS) {
+        if (temporal_layer_index == 0)
+            context_ptr->me_context_ptr->lambda =
+                lambda_mode_decision_ra_sad[ppcs_ptr->picture_qp];
+        else if (temporal_layer_index < 3)
+            context_ptr->me_context_ptr->lambda =
+                lambda_mode_decision_ra_sad_qp_scaling_l1[ppcs_ptr->picture_qp];
+        else
+            context_ptr->me_context_ptr->lambda =
+                lambda_mode_decision_ra_sad_qp_scaling_l3[ppcs_ptr->picture_qp];
+    } else {
+        if (temporal_layer_index == 0)
+            context_ptr->me_context_ptr->lambda =
+                lambda_mode_decision_ld_sad[ppcs_ptr->picture_qp];
+        else
+            context_ptr->me_context_ptr->lambda =
+                lambda_mode_decision_ld_sad_qp_scaling[ppcs_ptr->picture_qp];
+    }
+}
+static void prepare_sb_me_buffer(InLoopMeContext *context_ptr,
+    PictureParentControlSet *ppcs_ptr,
+    uint32_t sb_origin_x, uint32_t sb_origin_y) {
+
+    // Get 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+    EbDownScaledObject *src_ds_object =
+        (EbDownScaledObject*)
+        ppcs_ptr->down_scaled_picture_wrapper_ptr->object_ptr;
+    EbPictureBufferDesc *quarter_picture_ptr = src_ds_object->quarter_picture_ptr;
+    EbPictureBufferDesc *sixteenth_picture_ptr = src_ds_object->sixteenth_picture_ptr;
+    EbPictureBufferDesc *input_picture_ptr = ppcs_ptr->enhanced_picture_ptr;
+
+    uint32_t sb_width =
+        (ppcs_ptr->aligned_width - sb_origin_x) < BLOCK_SIZE_64
+        ? ppcs_ptr->aligned_width - sb_origin_x
+        : BLOCK_SIZE_64;
+
+    // Load the SB from the input to the intermediate SB buffer
+    uint32_t buffer_index = (input_picture_ptr->origin_y + sb_origin_y) *
+        input_picture_ptr->stride_y +
+        input_picture_ptr->origin_x + sb_origin_x;
+
+#ifdef ARCH_X86
+    uint8_t *src_ptr = &input_picture_ptr->buffer_y[buffer_index];
+    uint32_t sb_height =
+        (ppcs_ptr->aligned_height - sb_origin_y) < BLOCK_SIZE_64
+        ? ppcs_ptr->aligned_height  - sb_origin_y
+        : BLOCK_SIZE_64;
+
+    //_MM_HINT_T0     //_MM_HINT_T1    //_MM_HINT_T2//_MM_HINT_NTA
+    uint32_t i;
+    for (i = 0; i < sb_height; i++) {
+        char const *p =
+            (char const *)(src_ptr +
+                    i * input_picture_ptr->stride_y);
+        _mm_prefetch(p, _MM_HINT_T2);
+    }
+#endif
+    context_ptr->me_context_ptr->sb_src_ptr =
+        &input_picture_ptr->buffer_y[buffer_index];
+    context_ptr->me_context_ptr->sb_src_stride =
+        input_picture_ptr->stride_y;
+
+    // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
+    if (context_ptr->me_context_ptr->enable_hme_level1_flag) {
+        buffer_index = (quarter_picture_ptr->origin_y + (sb_origin_y >> 1)) *
+            quarter_picture_ptr->stride_y +
+            quarter_picture_ptr->origin_x + (sb_origin_x >> 1);
+        for (uint32_t sb_row = 0; sb_row < (BLOCK_SIZE_64 >> 1); sb_row++) {
+            EB_MEMCPY(
+                    (&(context_ptr->me_context_ptr
+                       ->quarter_sb_buffer[sb_row *
+                       context_ptr->me_context_ptr
+                       ->quarter_sb_buffer_stride])),
+                    (&(quarter_picture_ptr
+                       ->buffer_y[buffer_index +
+                       sb_row * quarter_picture_ptr->stride_y])),
+                    (sb_width >> 1) * sizeof(uint8_t));
+        }
+    }
+
+    // Load the 1/16 decimated SB from the 1/16 decimated input to the 1/16 intermediate SB buffer
+    if (context_ptr->me_context_ptr->enable_hme_level0_flag) {
+        buffer_index = (sixteenth_picture_ptr->origin_y + (sb_origin_y >> 2)) *
+            sixteenth_picture_ptr->stride_y +
+            sixteenth_picture_ptr->origin_x + (sb_origin_x >> 2);
+
+        uint8_t *frame_ptr = &sixteenth_picture_ptr->buffer_y[buffer_index];
+        uint8_t *local_ptr =
+            context_ptr->me_context_ptr->sixteenth_sb_buffer;
+        if (context_ptr->me_context_ptr->hme_search_method ==
+                FULL_SAD_SEARCH) {
+            for (uint32_t sb_row = 0; sb_row < (BLOCK_SIZE_64 >> 2); sb_row++) {
+                EB_MEMCPY(local_ptr,
+                        frame_ptr,
+                        (sb_width >> 2) * sizeof(uint8_t));
+                local_ptr += 16;
+                frame_ptr += sixteenth_picture_ptr->stride_y;
+            }
+        } else {
+            for (uint32_t sb_row = 0; sb_row < (BLOCK_SIZE_64 >> 2); sb_row += 2) {
+                EB_MEMCPY(local_ptr,
+                        frame_ptr,
+                        (sb_width >> 2) * sizeof(uint8_t));
+                local_ptr += 16;
+                frame_ptr += sixteenth_picture_ptr->stride_y << 1;
+            }
+        }
+    }
+}
+void *inloop_me_kernel(void *input_ptr) {
+    EbThreadContext *          thread_context_ptr = (EbThreadContext *)input_ptr;
+    InLoopMeContext *context_ptr = (InLoopMeContext *)thread_context_ptr->priv;
+
+
+    EbObjectWrapper *       in_results_wrapper_ptr;
+    PictureManagerResults   *in_results_ptr;
+
+    EbObjectWrapper *        out_results_wrapper_ptr;
+
+    EbPictureBufferDesc *input_picture_ptr;
+
+    uint32_t pic_width_in_sb;
+    uint32_t picture_height_in_sb;
+    uint32_t sb_origin_x;
+    uint32_t sb_origin_y;
+
+    // Segments
+    uint32_t segment_index = 0;
+    uint32_t x_segment_index;
+    uint32_t y_segment_index;
+    uint32_t x_sb_start_index;
+    uint32_t x_sb_end_index;
+    uint32_t y_sb_start_index;
+    uint32_t y_sb_end_index;
+    uint32_t segment_col_count = 0;
+    uint32_t segment_row_count = 0;
+
+#if TUNE_IME_REUSE_TPL_RESULT
+    EbBool skip_me = EB_FALSE;
+#endif
+    for (;;) {
+        // Get Input Full Object
+        EB_GET_FULL_OBJECT(context_ptr->input_fifo_ptr,
+                &in_results_wrapper_ptr);
+
+        in_results_ptr = (PictureManagerResults *)in_results_wrapper_ptr->object_ptr;
+        PictureParentControlSet* ppcs_ptr = (PictureParentControlSet*)in_results_ptr->pcs_wrapper_ptr->object_ptr;
+        SequenceControlSet* scs_ptr =
+            (SequenceControlSet *)ppcs_ptr->scs_wrapper_ptr->object_ptr;
+        uint8_t task_type = in_results_ptr->task_type;
+
+        // iME get ppcs input, and output pcs to RC kernel
+
+        //printf("iME-IN  POC:%ld, segment %d/%d\n",
+        //        ppcs_ptr->picture_number,
+        //        in_results_ptr->segment_index,
+        //        ppcs_ptr->inloop_me_segments_total_count);
+        if (scs_ptr->in_loop_me) {
+            input_picture_ptr = ppcs_ptr->enhanced_picture_ptr;
+
+            segment_col_count = ppcs_ptr->inloop_me_segments_column_count;
+            segment_row_count = ppcs_ptr->inloop_me_segments_row_count;
+
+            if (task_type != 0) {
+#if TUNE_SIGNAL_TPL_ME_OQ
+                signal_tpl_me_kernel_oq(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
+#else
+                signal_derivation_me_kernel_oq(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
+#endif
+
+                // TPL ME
+                segment_col_count = ppcs_ptr->tpl_me_segments_column_count;
+                segment_row_count = ppcs_ptr->tpl_me_segments_row_count;
+                context_ptr->me_context_ptr->me_type = ME_TPL;
+                context_ptr->me_context_ptr->num_of_list_to_search = (in_results_ptr->tpl_ref_list1_count > 0) ?
+                    REF_LIST_1 : REF_LIST_0;
+                context_ptr->me_context_ptr->num_of_ref_pic_to_search[0] = in_results_ptr->tpl_ref_list0_count;
+                context_ptr->me_context_ptr->num_of_ref_pic_to_search[1] = in_results_ptr->tpl_ref_list1_count;
+                context_ptr->me_context_ptr->temporal_layer_index = in_results_ptr->temporal_layer_index;
+                context_ptr->me_context_ptr->is_used_as_reference_flag = in_results_ptr->is_used_as_reference_flag;
+                for (int i = 0; i<= context_ptr->me_context_ptr->num_of_list_to_search; i++) {
+                    for (int j=0; j< context_ptr->me_context_ptr->num_of_ref_pic_to_search[i];j++) {
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j] =
+#if TUNE_INL_TPL_ENHANCEMENT
+                            ppcs_ptr->tpl_data.tpl_ref_ds_ptr_array[i][j];
+#else
+                            ppcs_ptr->tpl_ref_ds_ptr_array[i][j];
+#endif
+                    }
+                }
+#if TUNE_IME_REUSE_TPL_RESULT
+                skip_me = EB_FALSE;
+#endif
+            } else if (ppcs_ptr->slice_type != I_SLICE) {
+                // ME Kernel Signal(s) derivation
+                signal_derivation_me_kernel_oq(scs_ptr, ppcs_ptr, (MotionEstimationContext_t*)context_ptr);
+
+                context_ptr->me_context_ptr->me_type = ME_CLOSE_LOOP;
+                context_ptr->me_context_ptr->num_of_list_to_search =
+                    (ppcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+                context_ptr->me_context_ptr->num_of_ref_pic_to_search[0] = ppcs_ptr->ref_list0_count_try;
+                if (ppcs_ptr->slice_type == B_SLICE)
+                    context_ptr->me_context_ptr->num_of_ref_pic_to_search[1] = ppcs_ptr->ref_list1_count_try;
+                context_ptr->me_context_ptr->temporal_layer_index = ppcs_ptr->temporal_layer_index;
+                context_ptr->me_context_ptr->is_used_as_reference_flag = ppcs_ptr->is_used_as_reference_flag;
+
+                for (int i = 0; i<= context_ptr->me_context_ptr->num_of_list_to_search; i++) {
+                    for (int j=0; j< context_ptr->me_context_ptr->num_of_ref_pic_to_search[i];j++) {
+                        EbReferenceObject* inl_reference_object =
+                            ppcs_ptr->child_pcs->ref_pic_ptr_array[i][j]->object_ptr;
+
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_ptr =
+                            inl_reference_object->reference_picture;
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].sixteenth_picture_ptr =
+                            inl_reference_object->sixteenth_reference_picture;
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].quarter_picture_ptr =
+                            inl_reference_object->quarter_reference_picture;
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_number =
+                            ppcs_ptr->ref_pic_poc_array[i][j];
+
+#if TUNE_INL_ME_ON_INPUT
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].picture_ptr =
+                            inl_reference_object->input_picture;
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].sixteenth_picture_ptr =
+                            inl_reference_object->sixteenth_input_picture;
+                        context_ptr->me_context_ptr->me_ds_ref_array[i][j].quarter_picture_ptr =
+                            inl_reference_object->quarter_input_picture;
+#endif
+                    }
+                }
+#if TUNE_IME_REUSE_TPL_RESULT
+                skip_me = ppcs_ptr->tpl_me_done;
+                //if (skip_me)
+                //    printf("[%ld]: skip iME\n", ppcs_ptr->picture_number);
+#endif
+            }
+
+            // Segments
+            segment_index = in_results_ptr->segment_index;
+
+#if TUNE_IME_REUSE_TPL_RESULT
+            // case TPL ON , trailing frames ON
+            // 1. trailing pic, task_type == 2 (tplME) ,skip_me == 0 , slice_type not set
+            // 2. non-trailing pic, task_type == 2 (tplME) ,skip_me == 0, slice_type set
+            // 3. non-trailing pic, task_type == 0 (iME) ,skip_me == 1, slice_type set
+            if (!skip_me && (ppcs_ptr->slice_type != I_SLICE || task_type != 0)) {
+#else
+            if (ppcs_ptr->slice_type != I_SLICE || task_type != 0) {
+#endif
+                // Lambda Assignement
+                init_lambda(context_ptr, scs_ptr, ppcs_ptr);
+
+                pic_width_in_sb =
+                    (ppcs_ptr->aligned_width + scs_ptr->sb_sz - 1) / scs_ptr->sb_sz;
+                picture_height_in_sb =
+                    (ppcs_ptr->aligned_height + scs_ptr->sb_sz - 1) / scs_ptr->sb_sz;
+                SEGMENT_CONVERT_IDX_TO_XY(
+                        segment_index, x_segment_index, y_segment_index, segment_col_count);
+                x_sb_start_index = SEGMENT_START_IDX(
+                        x_segment_index, pic_width_in_sb, segment_col_count);
+                x_sb_end_index = SEGMENT_END_IDX(
+                        x_segment_index, pic_width_in_sb, segment_col_count);
+                y_sb_start_index = SEGMENT_START_IDX(
+                        y_segment_index, picture_height_in_sb, segment_row_count);
+                y_sb_end_index = SEGMENT_END_IDX(
+                        y_segment_index, picture_height_in_sb, segment_row_count);
+
+                // SB Loop
+                for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index; ++y_sb_index) {
+                    for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index; ++x_sb_index) {
+                        uint32_t sb_index = x_sb_index + y_sb_index * pic_width_in_sb;
+                        sb_origin_x = x_sb_index * scs_ptr->sb_sz;
+                        sb_origin_y = y_sb_index * scs_ptr->sb_sz;
+                        prepare_sb_me_buffer(context_ptr, ppcs_ptr, sb_origin_x, sb_origin_y);
+
+                        motion_estimate_sb(ppcs_ptr,
+                                sb_index,
+                                sb_origin_x,
+                                sb_origin_y,
+                                context_ptr->me_context_ptr,
+                                input_picture_ptr);
+#if !FIX_GM_BUG
+#if TUNE_IME_REUSE_TPL_RESULT
+                        {
+#else
+                        if (task_type == 0) {
+#endif
+                            eb_block_on_mutex(ppcs_ptr->me_processed_sb_mutex);
+                            ppcs_ptr->me_processed_sb_count++;
+                            eb_release_mutex(ppcs_ptr->me_processed_sb_mutex);
+                        }
+#endif
+                    }
+                }
+            }
+            if (task_type == 0) {
+                // Global motion estimation
+                // TODO: create an other kernel ?
+#if FEATURE_GM_OPT
+                if (ppcs_ptr->gm_ctrls.enabled &&
+#else
+                if (context_ptr->me_context_ptr->compute_global_motion &&
+#endif
+                        ppcs_ptr->slice_type != I_SLICE &&
+#if FIX_GM_BUG
+                        segment_index== 0) {
+#else
+                        // Compute only when ME of all 64x64 SBs is performed
+                        ppcs_ptr->me_processed_sb_count == ppcs_ptr->sb_total_count) {
+#endif
+#if FEATURE_GM_OPT
+                    global_motion_estimation_inl(
+                        ppcs_ptr, input_picture_ptr);
+#else
+                    global_motion_estimation_inl(
+                            ppcs_ptr, context_ptr->me_context_ptr, input_picture_ptr);
+#endif
+                }
+
+                //printf("[%ld]: iME, sending to RC kernel\n",
+                //        ppcs_ptr->picture_number);
+                eb_get_empty_object(context_ptr->output_fifo_ptr,
+                        &out_results_wrapper_ptr);
+
+                RateControlTasks * rate_control_tasks_ptr = (RateControlTasks *)out_results_wrapper_ptr->object_ptr;
+                rate_control_tasks_ptr->pcs_wrapper_ptr = ppcs_ptr->child_pcs->c_pcs_wrapper_ptr;
+                rate_control_tasks_ptr->task_type = RC_INPUT;
+                rate_control_tasks_ptr->segment_index = segment_index;
+
+                // Release the Input Results
+                eb_release_object(in_results_wrapper_ptr);
+
+                // Post the Full Results Object
+                eb_post_full_object(out_results_wrapper_ptr);
+            } else {
+                // TPL ME
+#if TUNE_INL_TPL_ENHANCEMENT
+                // Doing OIS search for TPL
+#if TUNE_TPL_OIS
+                if (scs_ptr->in_loop_ois == 0)
+#endif
+                if (scs_ptr->static_config.enable_tpl_la) {
+                    //printf("[%ld]: Doing open loop intra search for TPL, (%d, %d) => (%d, %d)\n",
+                    //        ppcs_ptr->picture_number,
+                    //        x_sb_start_index, y_sb_start_index,
+                    //        x_sb_end_index, y_sb_end_index);
+                    for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
+                            ++y_sb_index) {
+                        for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
+                                ++x_sb_index) {
+                            uint32_t sb_index = x_sb_index + y_sb_index * pic_width_in_sb;
+                            open_loop_intra_search_mb(ppcs_ptr, sb_index, input_picture_ptr);
+                        }
+                    }
+                }
+#endif
+                eb_block_on_mutex(ppcs_ptr->tpl_me_mutex);
+                ppcs_ptr->tpl_me_seg_acc++;
+
+                if (ppcs_ptr->tpl_me_seg_acc ==
+                        ppcs_ptr->tpl_me_segments_total_count) {
+
+                    //printf("[%ld]: tpl_segment %d, tpl done\n", ppcs_ptr->picture_number, ppcs_ptr->tpl_me_seg_acc);
+                    eb_post_semaphore(ppcs_ptr->tpl_me_done_semaphore);
+                }
+                eb_release_mutex(ppcs_ptr->tpl_me_mutex);
+                eb_release_object(in_results_wrapper_ptr);
+            }
+        } else {
+            // Dummy in loop kernel
+            eb_get_empty_object(context_ptr->output_fifo_ptr,
+                    &out_results_wrapper_ptr);
+
+            RateControlTasks * rate_control_tasks_ptr = (RateControlTasks *)out_results_wrapper_ptr->object_ptr;
+            rate_control_tasks_ptr->pcs_wrapper_ptr = ppcs_ptr->child_pcs->c_pcs_wrapper_ptr;
+            rate_control_tasks_ptr->task_type = RC_INPUT;
+            rate_control_tasks_ptr->segment_index = segment_index;
+
+            // Release the Input Results
+            eb_release_object(in_results_wrapper_ptr);
+
+            // Post the Full Results Object
+            eb_post_full_object(out_results_wrapper_ptr);
+        }
+    }
+
+    return NULL;
+}
+#endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.h
@@ -28,6 +28,16 @@ typedef struct MotionEstimationContext {
     uint8_t *index_table1;
 } MotionEstimationContext_t;
 
+#if FEATURE_INL_ME
+typedef struct InLoopMeContext {
+    EbFifo *   input_fifo_ptr;
+    EbFifo *   output_fifo_ptr;
+    MeContext *me_context_ptr;
+
+    uint8_t *index_table0;
+    uint8_t *index_table1;
+} InLoopMeContext;
+#endif
 /***************************************
  * Extern Function Declaration
  ***************************************/
@@ -36,6 +46,11 @@ EbErrorType motion_estimation_context_ctor(EbThreadContext *  thread_context_ptr
 
 extern void *motion_estimation_kernel(void *input_ptr);
 
+#if FEATURE_INL_ME
+EbErrorType ime_context_ctor(EbThreadContext *thread_context_ptr,
+                             const EbEncHandle *enc_handle_ptr, int index);
+extern void *inloop_me_kernel(void *input_ptr);
+#endif
 EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
                                            PictureParentControlSet *  pcs_ptr,
                                            MotionEstimationContext_t *context_ptr);

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationResults.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationResults.h
@@ -36,6 +36,10 @@ typedef struct MotionEstimationResultsInitData {
      **************************************/
 extern EbErrorType motion_estimation_results_creator(EbPtr *object_dbl_ptr,
                                                      EbPtr  object_init_data_ptr);
+#if FEATURE_INL_ME
+extern EbErrorType ime_results_creator(EbPtr *object_dbl_ptr,
+    EbPtr  object_init_data_ptr);
+#endif
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -700,7 +700,7 @@ void *packetization_kernel(void *input_ptr) {
         rate_control_tasks_ptr->task_type       = RC_PACKETIZATION_FEEDBACK_RESULT;
 
         if(use_input_stat(scs_ptr) ||
-#if TUNE_INL_ME_DECODE_ORDER
+#if TUNE_INL_ME_RECON_INPUT
             (scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la) ||
 #endif
             (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
@@ -805,7 +805,7 @@ void *packetization_kernel(void *input_ptr) {
         // Post Rate Control Taks
         eb_post_full_object(rate_control_tasks_wrapper_ptr);
         if (use_input_stat(scs_ptr) ||
-#if TUNE_INL_ME_DECODE_ORDER
+#if TUNE_INL_ME_RECON_INPUT
             (scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la) ||
 #endif
             (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -700,6 +700,9 @@ void *packetization_kernel(void *input_ptr) {
         rate_control_tasks_ptr->task_type       = RC_PACKETIZATION_FEEDBACK_RESULT;
 
         if(use_input_stat(scs_ptr) ||
+#if TUNE_INL_ME_DECODE_ORDER
+            (scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la) ||
+#endif
             (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr)) {
             if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
@@ -801,7 +804,11 @@ void *packetization_kernel(void *input_ptr) {
 
         // Post Rate Control Taks
         eb_post_full_object(rate_control_tasks_wrapper_ptr);
-        if (use_input_stat(scs_ptr) || (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
+        if (use_input_stat(scs_ptr) ||
+#if TUNE_INL_ME_DECODE_ORDER
+            (scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la) ||
+#endif
+            (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr))
             // Post the Full Results Object
             eb_post_full_object(picture_manager_results_wrapper_ptr);

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2740,6 +2740,8 @@ void sub_sample_luma_generate_pixel_intensity_histogram_bins(
 }
 
 #ifdef FEATURE_INL_ME
+    // Histogram bins
+    // Luma for Histogram generation
 void sub_sample_luma_generate_pixel_intensity_histogram_bins_ex(
     SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
     EbPictureBufferDesc *input_picture_ptr, uint64_t *sum_avg_intensity_ttl_regions_luma,
@@ -3010,6 +3012,7 @@ void compute_picture_spatial_statistics(SequenceControlSet *     scs_ptr,
 }
 
 #if FEATURE_INL_ME
+// compute mean & variance
 void compute_picture_spatial_statistics_ex(SequenceControlSet *     scs_ptr,
                                         PictureParentControlSet *pcs_ptr,
                                         EbPictureBufferDesc *    input_picture_ptr) {
@@ -3166,6 +3169,8 @@ void gathering_picture_statistics(SequenceControlSet *scs_ptr, PictureParentCont
 }
 
 #if FEATURE_INL_ME
+// calculate picture statistics
+// mean , variance , Luma intensity, Histogram
 static void gathering_picture_statistics_ex(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
                                   EbPictureBufferDesc *input_picture_ptr) {
  uint64_t sum_avg_intensity_ttl_regions_luma = 0;

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2739,7 +2739,7 @@ void sub_sample_luma_generate_pixel_intensity_histogram_bins(
     return;
 }
 
-#ifdef FEATURE_INL_ME
+#if FEATURE_INL_ME
     // Histogram bins
     // Luma for Histogram generation
 void sub_sample_luma_generate_pixel_intensity_histogram_bins_ime(

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -3791,7 +3791,9 @@ void downsample_filtering_input_picture_ime(
                 sixteenth_picture_ptr->origin_y);
     }
 }
-
+/************************************************
+* 1/4 & 1/16 input picture decimation
+************************************************/
 void downsample_decimation_input_picture_ime(
                                          EbPictureBufferDesc *    input_padded_picture_ptr,
                                          EbPictureBufferDesc *    quarter_decimated_picture_ptr,
@@ -4181,7 +4183,6 @@ void *picture_analysis_kernel(void *input_ptr) {
                         scs_ptr, pcs_ptr,
                         pcs_ptr->chroma_downsampled_picture_ptr);
 
-#if 1
                 // Save pointer of raw input to PA
                 // TODO: This is just to make it work for current TPL in iRC
                 // When moving the TPL logic from iRC to RC, should use input picture directly and remove the codes here
@@ -4189,7 +4190,7 @@ void *picture_analysis_kernel(void *input_ptr) {
                 pa_ref_obj_->input_padded_picture_ptr = input_picture_ptr;
                 pa_ref_obj_->quarter_decimated_picture_ptr = pa_ref_obj_->quarter_filtered_picture_ptr = ds_obj->quarter_picture_ptr;
                 pa_ref_obj_->sixteenth_decimated_picture_ptr = pa_ref_obj_->sixteenth_filtered_picture_ptr = ds_obj->sixteenth_picture_ptr;
-#endif
+
             } else {
                 // Original path
                 // Get PA ref, copy 8bit luma to pa_ref->input_padded_picture_ptr

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2623,6 +2623,21 @@ void set_picture_parameters_for_statistics_gathering(SequenceControlSet *scs_ptr
  ***** Borders preprocessing
  ***** Denoising
  ************************************************/
+#if FEATURE_INL_ME
+void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
+                                       SequenceControlSet *scs_ptr) {
+    if (scs_ptr->film_grain_denoise_strength) {
+        denoise_estimate_film_grain(scs_ptr, pcs_ptr);
+    } else {
+        //Reset the flat noise flag array to False for both RealTime/HighComplexity Modes
+        for (uint32_t sb_coding_order = 0; sb_coding_order < pcs_ptr->sb_total_count; ++sb_coding_order)
+            pcs_ptr->sb_flat_noise_array[sb_coding_order] = 0;
+        pcs_ptr->pic_noise_class =
+            PIC_NOISE_CLASS_INV; //this init is for both REAL-TIME and BEST-QUALITY
+    }
+    return;
+}
+#else
 void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
                                        SequenceControlSet *scs_ptr, uint32_t sb_total_count) {
     if (scs_ptr->film_grain_denoise_strength) {
@@ -2636,6 +2651,7 @@ void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
     }
     return;
 }
+#endif
 
 /**************************************************************
 * Generate picture histogram bins for YUV pixel intensity *
@@ -2723,10 +2739,97 @@ void sub_sample_luma_generate_pixel_intensity_histogram_bins(
     return;
 }
 
+#ifdef FEATURE_INL_ME
+void sub_sample_luma_generate_pixel_intensity_histogram_bins_ex(
+    SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
+    EbPictureBufferDesc *input_picture_ptr, uint64_t *sum_avg_intensity_ttl_regions_luma,
+    uint8_t decim_step) {
+    uint32_t region_width;
+    uint32_t region_height;
+    uint32_t region_width_offset;
+    uint32_t region_height_offset;
+    uint32_t region_in_picture_width_index;
+    uint32_t region_in_picture_height_index;
+    uint32_t histogram_bin;
+    uint64_t sum;
+
+    region_width = input_picture_ptr->width / scs_ptr->picture_analysis_number_of_regions_per_width;
+    region_height =
+        input_picture_ptr->height / scs_ptr->picture_analysis_number_of_regions_per_height;
+
+    // Loop over regions inside the picture
+    for (region_in_picture_width_index = 0;
+         region_in_picture_width_index < scs_ptr->picture_analysis_number_of_regions_per_width;
+         region_in_picture_width_index++) { // loop over horizontal regions
+        for (region_in_picture_height_index = 0;
+             region_in_picture_height_index <
+             scs_ptr->picture_analysis_number_of_regions_per_height;
+             region_in_picture_height_index++) { // loop over vertical regions
+
+            // Initialize bins to 1
+            svt_initialize_buffer_32bits(pcs_ptr->picture_histogram[region_in_picture_width_index]
+                                                               [region_in_picture_height_index][0],
+                                     64,
+                                     0,
+                                     1);
+
+            region_width_offset =
+                (region_in_picture_width_index ==
+                 scs_ptr->picture_analysis_number_of_regions_per_width - 1)
+                    ? input_picture_ptr->width -
+                          (scs_ptr->picture_analysis_number_of_regions_per_width * region_width)
+                    : 0;
+            region_height_offset =
+                (region_in_picture_height_index ==
+                 scs_ptr->picture_analysis_number_of_regions_per_height - 1)
+                    ? input_picture_ptr->height -
+                          (scs_ptr->picture_analysis_number_of_regions_per_height * region_height)
+                    : 0;
+
+            // Y Histogram
+            calculate_histogram(
+                &input_picture_ptr->buffer_y[(input_picture_ptr->origin_x +
+                                              region_in_picture_width_index * region_width) +
+                                             ((input_picture_ptr->origin_y +
+                                               region_in_picture_height_index * region_height) *
+                                              input_picture_ptr->stride_y)],
+                region_width + region_width_offset,
+                region_height + region_height_offset,
+                input_picture_ptr->stride_y,
+                decim_step,
+                pcs_ptr->picture_histogram[region_in_picture_width_index]
+                                          [region_in_picture_height_index][0],
+                &sum);
+
+            pcs_ptr->average_intensity_per_region[region_in_picture_width_index]
+                                                 [region_in_picture_height_index][0] = (uint8_t)(
+                (sum +
+                 (((region_width + region_width_offset) * (region_height + region_height_offset)) >>
+                  1)) /
+                ((region_width + region_width_offset) * (region_height + region_height_offset)));
+            (*sum_avg_intensity_ttl_regions_luma) += (sum << decim_step);
+            for (histogram_bin = 0; histogram_bin < HISTOGRAM_NUMBER_OF_BINS;
+                 histogram_bin++) { // Loop over the histogram bins
+                pcs_ptr->picture_histogram[region_in_picture_width_index]
+                                          [region_in_picture_height_index][0][histogram_bin] =
+                    pcs_ptr->picture_histogram[region_in_picture_width_index]
+                                              [region_in_picture_height_index][0][histogram_bin]
+                    << decim_step;
+            }
+        }
+    }
+
+    return;
+}
+#endif
 void sub_sample_chroma_generate_pixel_intensity_histogram_bins(
     SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
     EbPictureBufferDesc *input_picture_ptr, uint64_t *sum_avg_intensity_ttl_regions_cb,
+#if FEATURE_INL_ME
+    uint64_t *sum_avg_intensity_ttl_regions_cr, uint8_t decim_step) {
+#else
     uint64_t *sum_avg_intensity_ttl_regions_cr) {
+#endif
     uint64_t sum;
     uint32_t region_width;
     uint32_t region_height;
@@ -2736,7 +2839,9 @@ void sub_sample_chroma_generate_pixel_intensity_histogram_bins(
     uint32_t region_in_picture_height_index;
 
     uint16_t histogram_bin;
+#if !FEATURE_INL_ME
     uint8_t  decim_step = 4;
+#endif
 
     region_width = input_picture_ptr->width / scs_ptr->picture_analysis_number_of_regions_per_width;
     region_height =
@@ -2904,6 +3009,54 @@ void compute_picture_spatial_statistics(SequenceControlSet *     scs_ptr,
     return;
 }
 
+#if FEATURE_INL_ME
+void compute_picture_spatial_statistics_ex(SequenceControlSet *     scs_ptr,
+                                        PictureParentControlSet *pcs_ptr,
+                                        EbPictureBufferDesc *    input_picture_ptr) {
+    uint64_t pic_tot_variance;
+
+    // Variance
+    pic_tot_variance = 0;
+
+    for (uint16_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
+        SbParams *sb_params = &pcs_ptr->sb_params_array[sb_index];
+
+        uint16_t sb_origin_x             = sb_params->origin_x;
+        uint16_t sb_origin_y             = sb_params->origin_y;
+        uint32_t input_luma_origin_index = (input_picture_ptr->origin_y + sb_origin_y) *
+                                      input_picture_ptr->stride_y +
+                                  input_picture_ptr->origin_x + sb_origin_x;
+
+        uint32_t input_cb_origin_index =
+            ((input_picture_ptr->origin_y + sb_origin_y) >> 1) * input_picture_ptr->stride_cb +
+            ((input_picture_ptr->origin_x + sb_origin_x) >> 1);
+        uint32_t input_cr_origin_index =
+            ((input_picture_ptr->origin_y + sb_origin_y) >> 1) * input_picture_ptr->stride_cr +
+            ((input_picture_ptr->origin_x + sb_origin_x) >> 1);
+
+        compute_block_mean_compute_variance(
+            scs_ptr, pcs_ptr, input_picture_ptr, sb_index, input_luma_origin_index);
+
+        if (sb_params->is_complete_sb) {
+            compute_chroma_block_mean(scs_ptr,
+                                      pcs_ptr,
+                                      input_picture_ptr,
+                                      sb_index,
+                                      input_cb_origin_index,
+                                      input_cr_origin_index);
+        } else {
+            zero_out_chroma_block_mean(pcs_ptr, sb_index);
+        }
+
+        pic_tot_variance += (pcs_ptr->variance[sb_index][RASTER_SCAN_CU_INDEX_64x64]);
+    }
+
+    pcs_ptr->pic_avg_variance = (uint16_t)(pic_tot_variance / pcs_ptr->sb_total_count);
+
+    return;
+}
+#endif
+
 void calculate_input_average_intensity(SequenceControlSet *     scs_ptr,
                                        PictureParentControlSet *pcs_ptr,
                                        EbPictureBufferDesc *    input_picture_ptr,
@@ -2991,7 +3144,12 @@ void gathering_picture_statistics(SequenceControlSet *scs_ptr, PictureParentCont
                                                               pcs_ptr,
                                                               input_picture_ptr,
                                                               &sum_avg_intensity_ttl_regions_cb,
+#if FEATURE_INL_ME
+                                                              &sum_avg_intensity_ttl_regions_cr,
+                                                              4);
+#else
                                                               &sum_avg_intensity_ttl_regions_cr);
+#endif
     //
     // Calculate the LUMA average intensity
     calculate_input_average_intensity(scs_ptr,
@@ -3006,6 +3164,40 @@ void gathering_picture_statistics(SequenceControlSet *scs_ptr, PictureParentCont
 
     return;
 }
+
+#if FEATURE_INL_ME
+static void gathering_picture_statistics_ex(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
+                                  EbPictureBufferDesc *input_picture_ptr) {
+ uint64_t sum_avg_intensity_ttl_regions_luma = 0;
+    uint64_t sum_avg_intensity_ttl_regions_cb   = 0;
+    uint64_t sum_avg_intensity_ttl_regions_cr   = 0;
+
+    // Histogram bins
+    // Use 1/16 Luma for Histogram generation
+    sub_sample_luma_generate_pixel_intensity_histogram_bins_ex(
+        scs_ptr, pcs_ptr,input_picture_ptr, &sum_avg_intensity_ttl_regions_luma, 4);
+
+    // Use 1/16 Chroma for Histogram generation
+    sub_sample_chroma_generate_pixel_intensity_histogram_bins(scs_ptr,
+                                                              pcs_ptr,
+                                                              input_picture_ptr,
+                                                              &sum_avg_intensity_ttl_regions_cb,
+                                                              &sum_avg_intensity_ttl_regions_cr,
+                                                              4);
+
+     // Calculate the LUMA average intensity
+    calculate_input_average_intensity(scs_ptr,
+                                      pcs_ptr,
+                                      input_picture_ptr,
+                                      sum_avg_intensity_ttl_regions_luma,
+                                      sum_avg_intensity_ttl_regions_cb,
+                                      sum_avg_intensity_ttl_regions_cr);
+
+    compute_picture_spatial_statistics_ex(
+        scs_ptr, pcs_ptr, input_picture_ptr);
+
+}
+#endif
 
 /************************************************
  * Pad Picture at the right and bottom sides
@@ -3029,6 +3221,9 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
         scs_ptr->pad_right,
         scs_ptr->pad_bottom);
 
+#if TUNE_INL_TPL_ENHANCEMENT
+    if (input_picture_ptr->buffer_cb)
+#endif
     pad_input_picture(
         &input_picture_ptr->buffer_cb[(input_picture_ptr->origin_x >> subsampling_x) +
                                       ((input_picture_ptr->origin_y >> subsampling_y) *
@@ -3039,6 +3234,9 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
         scs_ptr->pad_right >> subsampling_x,
         scs_ptr->pad_bottom >> subsampling_y);
 
+#if TUNE_INL_TPL_ENHANCEMENT
+    if (input_picture_ptr->buffer_cr)
+#endif
     pad_input_picture(
         &input_picture_ptr->buffer_cr[(input_picture_ptr->origin_x >> subsampling_x) +
                                       ((input_picture_ptr->origin_y >> subsampling_y) *
@@ -3050,6 +3248,9 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
         scs_ptr->pad_bottom >> subsampling_y);
 
     if (is16_bit_input) {
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_y)
+#endif
         pad_input_picture(
             &input_picture_ptr->buffer_bit_inc_y[input_picture_ptr->origin_x +
                                                  (input_picture_ptr->origin_y *
@@ -3060,6 +3261,9 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
             scs_ptr->pad_right,
             scs_ptr->pad_bottom);
 
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_cb)
+#endif
         pad_input_picture(
             &input_picture_ptr->buffer_bit_inc_cb[(input_picture_ptr->origin_x >> subsampling_x) +
                                                   ((input_picture_ptr->origin_y >> subsampling_y) *
@@ -3070,6 +3274,9 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
             scs_ptr->pad_right >> subsampling_x,
             scs_ptr->pad_bottom >> subsampling_y);
 
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_cr)
+#endif
         pad_input_picture(
             &input_picture_ptr->buffer_bit_inc_cr[(input_picture_ptr->origin_x >> subsampling_x) +
                                                   ((input_picture_ptr->origin_y >> subsampling_y) *
@@ -3514,6 +3721,184 @@ void downsample_filtering_input_picture(PictureParentControlSet *pcs_ptr,
     }
 }
 
+#if FEATURE_INL_ME
+// Current down sampled input is not used for HME, but mainly used for GM
+// So don't do the unnecessary check here
+void downsample_filtering_input_picture_ex(
+                                        EbPictureBufferDesc *    input_padded_picture_ptr,
+                                        EbPictureBufferDesc *    quarter_picture_ptr,
+                                        EbPictureBufferDesc *    sixteenth_picture_ptr) {
+    if (quarter_picture_ptr) {
+        downsample_2d(
+                &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x +
+                input_padded_picture_ptr->origin_y *
+                input_padded_picture_ptr->stride_y],
+                input_padded_picture_ptr->stride_y,
+                input_padded_picture_ptr->width,
+                input_padded_picture_ptr->height,
+                &quarter_picture_ptr
+                ->buffer_y[quarter_picture_ptr->origin_x +
+                quarter_picture_ptr->origin_x * quarter_picture_ptr->stride_y],
+                quarter_picture_ptr->stride_y,
+                2);
+        generate_padding(&quarter_picture_ptr->buffer_y[0],
+                quarter_picture_ptr->stride_y,
+                quarter_picture_ptr->width,
+                quarter_picture_ptr->height,
+                quarter_picture_ptr->origin_x,
+                quarter_picture_ptr->origin_y);
+    }
+
+    if (sixteenth_picture_ptr) {
+        // Sixteenth Input Picture Downsampling
+        if (quarter_picture_ptr)
+            downsample_2d(
+                    &quarter_picture_ptr
+                    ->buffer_y[quarter_picture_ptr->origin_x +
+                    quarter_picture_ptr->origin_y * quarter_picture_ptr->stride_y],
+                    quarter_picture_ptr->stride_y,
+                    quarter_picture_ptr->width,
+                    quarter_picture_ptr->height,
+                    &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x +
+                    sixteenth_picture_ptr->origin_x *
+                    sixteenth_picture_ptr->stride_y],
+                    sixteenth_picture_ptr->stride_y,
+                    2);
+        else
+            downsample_2d(
+                    &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x +
+                    input_padded_picture_ptr->origin_y *
+                    input_padded_picture_ptr->stride_y],
+                    input_padded_picture_ptr->stride_y,
+                    input_padded_picture_ptr->width,
+                    input_padded_picture_ptr->height,
+                    &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x +
+                    sixteenth_picture_ptr->origin_x *
+                    sixteenth_picture_ptr->stride_y],
+                    sixteenth_picture_ptr->stride_y,
+                    4);
+
+        generate_padding(&sixteenth_picture_ptr->buffer_y[0],
+                sixteenth_picture_ptr->stride_y,
+                sixteenth_picture_ptr->width,
+                sixteenth_picture_ptr->height,
+                sixteenth_picture_ptr->origin_x,
+                sixteenth_picture_ptr->origin_y);
+    }
+}
+
+void downsample_decimation_input_picture_ex(
+                                         EbPictureBufferDesc *    input_padded_picture_ptr,
+                                         EbPictureBufferDesc *    quarter_decimated_picture_ptr,
+                                         EbPictureBufferDesc *    sixteenth_decimated_picture_ptr) {
+    if (quarter_decimated_picture_ptr) {
+        decimation_2d(
+                &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x +
+                input_padded_picture_ptr->origin_y *
+                input_padded_picture_ptr->stride_y],
+                input_padded_picture_ptr->stride_y,
+                input_padded_picture_ptr->width,
+                input_padded_picture_ptr->height,
+                &quarter_decimated_picture_ptr->buffer_y[quarter_decimated_picture_ptr->origin_x +
+                quarter_decimated_picture_ptr->origin_x *
+                quarter_decimated_picture_ptr->stride_y],
+                quarter_decimated_picture_ptr->stride_y,
+                2);
+        generate_padding(&quarter_decimated_picture_ptr->buffer_y[0],
+                quarter_decimated_picture_ptr->stride_y,
+                quarter_decimated_picture_ptr->width,
+                quarter_decimated_picture_ptr->height,
+                quarter_decimated_picture_ptr->origin_x,
+                quarter_decimated_picture_ptr->origin_y);
+    }
+
+    if (sixteenth_decimated_picture_ptr) {
+        decimation_2d(
+                &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x +
+                input_padded_picture_ptr->origin_y *
+                input_padded_picture_ptr->stride_y],
+                input_padded_picture_ptr->stride_y,
+                input_padded_picture_ptr->width,
+                input_padded_picture_ptr->height,
+                &sixteenth_decimated_picture_ptr->buffer_y[sixteenth_decimated_picture_ptr->origin_x +
+                sixteenth_decimated_picture_ptr->origin_x *
+                sixteenth_decimated_picture_ptr->stride_y],
+                sixteenth_decimated_picture_ptr->stride_y,
+                4);
+
+        generate_padding(&sixteenth_decimated_picture_ptr->buffer_y[0],
+                sixteenth_decimated_picture_ptr->stride_y,
+                sixteenth_decimated_picture_ptr->width,
+                sixteenth_decimated_picture_ptr->height,
+                sixteenth_decimated_picture_ptr->origin_x,
+                sixteenth_decimated_picture_ptr->origin_y);
+    }
+}
+
+void pad_input_pictures(SequenceControlSet *scs_ptr,
+                               EbPictureBufferDesc *input_picture_ptr) {
+    // Pad pictures to multiple min cu size
+    // For non-8 aligned case, like 426x240, padding to 432x240 first
+    pad_picture_to_multiple_of_min_blk_size_dimensions(scs_ptr, input_picture_ptr);
+    generate_padding(input_picture_ptr->buffer_y,
+            input_picture_ptr->stride_y,
+            input_picture_ptr->width,
+            input_picture_ptr->height,
+            input_picture_ptr->origin_x,
+            input_picture_ptr->origin_y);
+
+    // PAD the bit inc buffer in 10bit
+    if (scs_ptr->static_config.encoder_bit_depth > EB_8BIT)
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_y)
+#endif
+        generate_padding(input_picture_ptr->buffer_bit_inc_y,
+                input_picture_ptr->stride_bit_inc_y,
+                input_picture_ptr->width,
+                input_picture_ptr->height,
+                input_picture_ptr->origin_x,
+                input_picture_ptr->origin_y);
+
+    if (input_picture_ptr->buffer_cb)
+        generate_padding(input_picture_ptr->buffer_cb,
+                input_picture_ptr->stride_cb,
+                input_picture_ptr->width >> scs_ptr->subsampling_x,
+                input_picture_ptr->height >> scs_ptr->subsampling_y,
+                input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+
+    if (input_picture_ptr->buffer_cr)
+        generate_padding(input_picture_ptr->buffer_cr,
+                input_picture_ptr->stride_cr,
+                input_picture_ptr->width >> scs_ptr->subsampling_x,
+                input_picture_ptr->height >> scs_ptr->subsampling_y,
+                input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+    // PAD the bit inc buffer in 10bit
+    if (scs_ptr->static_config.encoder_bit_depth > EB_8BIT) {
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_cb)
+#endif
+        generate_padding(input_picture_ptr->buffer_bit_inc_cb,
+                input_picture_ptr->stride_bit_inc_cb,
+                input_picture_ptr->width >> scs_ptr->subsampling_x,
+                input_picture_ptr->height >> scs_ptr->subsampling_y,
+                input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (input_picture_ptr->buffer_bit_inc_cr)
+#endif
+        generate_padding(input_picture_ptr->buffer_bit_inc_cr,
+                input_picture_ptr->stride_bit_inc_cr,
+                input_picture_ptr->width >> scs_ptr->subsampling_x,
+                input_picture_ptr->height >> scs_ptr->subsampling_y,
+                input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+    }
+}
+#endif
+
 /* Picture Analysis Kernel */
 
 /*********************************************************************************
@@ -3537,7 +3922,7 @@ void downsample_filtering_input_picture(PictureParentControlSet *pcs_ptr,
 *  n-bin histogram is created to gather 1st and 2nd moment statistics for each 8x8 block which is then used to compute statistics
 *
 ********************************************************************************/
-
+#if !FEATURE_INL_ME
 void *picture_analysis_kernel(void *input_ptr) {
     EbThreadContext *        thread_context_ptr = (EbThreadContext *)input_ptr;
     PictureAnalysisContext * context_ptr = (PictureAnalysisContext *)thread_context_ptr->priv;
@@ -3707,3 +4092,162 @@ void *picture_analysis_kernel(void *input_ptr) {
     }
     return NULL;
 }
+#else
+void *picture_analysis_kernel(void *input_ptr) {
+    EbThreadContext *        thread_context_ptr = (EbThreadContext *)input_ptr;
+    PictureAnalysisContext * context_ptr = (PictureAnalysisContext *)thread_context_ptr->priv;
+    PictureParentControlSet *pcs_ptr;
+    SequenceControlSet *     scs_ptr;
+
+    EbObjectWrapper *            in_results_wrapper_ptr;
+    ResourceCoordinationResults *in_results_ptr;
+    EbObjectWrapper *            out_results_wrapper_ptr;
+    EbPaReferenceObject *        pa_ref_obj_;
+    EbDownScaledObject*          ds_obj;
+
+    EbPictureBufferDesc *input_padded_picture_ptr;
+    EbPictureBufferDesc *input_picture_ptr;
+
+
+    for (;;) {
+        // Get Input Full Object
+        EB_GET_FULL_OBJECT(context_ptr->resource_coordination_results_input_fifo_ptr,
+                           &in_results_wrapper_ptr);
+
+        in_results_ptr = (ResourceCoordinationResults *)in_results_wrapper_ptr->object_ptr;
+        pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;
+
+        // Mariana : save enhanced picture ptr, move this from here
+        pcs_ptr->enhanced_unscaled_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+
+        // There is no need to do processing for overlay picture. Overlay and AltRef share the same results.
+        if (!pcs_ptr->is_overlay) {
+            scs_ptr           = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
+            input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+
+            // Padding for input pictures
+            pad_input_pictures(scs_ptr, input_picture_ptr);
+
+            // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
+            set_picture_parameters_for_statistics_gathering(scs_ptr);
+
+            // Pre processing operations performed on the input picture
+            picture_pre_processing_operations(pcs_ptr, scs_ptr);
+
+            if (input_picture_ptr->color_format >= EB_YUV422) {
+                // Jing: Do the conversion of 422/444=>420 here since it's multi-threaded kernel
+                //       Reuse the Y, only add cb/cr in the newly created buffer desc
+                //       NOTE: since denoise may change the src, so this part is after picture_pre_processing_operations()
+                pcs_ptr->chroma_downsampled_picture_ptr->buffer_y = input_picture_ptr->buffer_y;
+                down_sample_chroma(input_picture_ptr, pcs_ptr->chroma_downsampled_picture_ptr);
+            } else
+                pcs_ptr->chroma_downsampled_picture_ptr = input_picture_ptr;
+
+            if (scs_ptr->in_loop_me) {
+                ds_obj =
+                    (EbDownScaledObject*)pcs_ptr->down_scaled_picture_wrapper_ptr->object_ptr;
+
+                //ds_obj->picture_ptr = input_picture_ptr; // Save original picture pointer
+                //ds_obj->picture_number = pcs_ptr->picture_number;
+                //pcs_ptr->downscaled_input_pic = ds_obj;
+
+                pcs_ptr->ds_pics.picture_ptr = input_picture_ptr;
+                pcs_ptr->ds_pics.quarter_picture_ptr = ds_obj->quarter_picture_ptr;
+                pcs_ptr->ds_pics.sixteenth_picture_ptr = ds_obj->sixteenth_picture_ptr;
+                pcs_ptr->ds_pics.picture_number = pcs_ptr->picture_number;
+
+                // Get the 1/2, 1/4 of input picture, only used for global motion
+                // TODO: Check for global motion whether we need these
+                if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+                    downsample_filtering_input_picture_ex(
+                            input_picture_ptr,
+                            (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
+                            (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
+                } else {
+                    downsample_decimation_input_picture_ex(
+                            input_picture_ptr,
+                            (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
+                            (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
+                }
+
+                // TODO: Refine this function
+                // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
+                gathering_picture_statistics_ex(
+                        scs_ptr, pcs_ptr,
+                        pcs_ptr->chroma_downsampled_picture_ptr);
+
+#if 1
+                // Save pointer of raw input to PA
+                // TODO: This is just to make it work for current TPL in iRC
+                // When moving the TPL logic from iRC to RC, should use input picture directly and remove the codes here
+                pa_ref_obj_ = (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+                pa_ref_obj_->input_padded_picture_ptr = input_picture_ptr;
+                pa_ref_obj_->quarter_decimated_picture_ptr = pa_ref_obj_->quarter_filtered_picture_ptr = ds_obj->quarter_picture_ptr;
+                pa_ref_obj_->sixteenth_decimated_picture_ptr = pa_ref_obj_->sixteenth_filtered_picture_ptr = ds_obj->sixteenth_picture_ptr;
+#endif
+            } else {
+                // Original path
+                // Get PA ref, copy 8bit luma to pa_ref->input_padded_picture_ptr
+                pa_ref_obj_ =
+                    (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+                pa_ref_obj_->picture_number = pcs_ptr->picture_number;
+                input_padded_picture_ptr = (EbPictureBufferDesc *)pa_ref_obj_->input_padded_picture_ptr;
+                uint8_t *pa =
+                    input_padded_picture_ptr->buffer_y + input_padded_picture_ptr->origin_x +
+                    input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y;
+                uint8_t *in = input_picture_ptr->buffer_y + input_picture_ptr->origin_x +
+                              input_picture_ptr->origin_y * input_picture_ptr->stride_y;
+                for (uint32_t row = 0; row < input_picture_ptr->height; row++)
+                    EB_MEMCPY(pa + row * input_padded_picture_ptr->stride_y,
+                              in + row * input_picture_ptr->stride_y,
+                              sizeof(uint8_t) * input_picture_ptr->width);
+                // Pad input picture to complete border SBs
+                pad_picture_to_multiple_of_sb_dimensions(input_padded_picture_ptr);
+                // 1/4 & 1/16 input picture decimation
+                downsample_decimation_input_picture(
+                        pcs_ptr,
+                        input_padded_picture_ptr,
+                        (EbPictureBufferDesc *)pa_ref_obj_->quarter_decimated_picture_ptr,
+                        (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_decimated_picture_ptr);
+
+                // 1/4 & 1/16 input picture downsampling through filtering
+                if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+                    downsample_filtering_input_picture(
+                            pcs_ptr,
+                            input_padded_picture_ptr,
+                            (EbPictureBufferDesc *)pa_ref_obj_->quarter_filtered_picture_ptr,
+                            (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_filtered_picture_ptr);
+                }
+                // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
+                gathering_picture_statistics(
+                        scs_ptr,
+                        pcs_ptr,
+                        pcs_ptr->chroma_downsampled_picture_ptr, //420 input_picture_ptr
+                        input_padded_picture_ptr,
+                        (EbPictureBufferDesc *)pa_ref_obj_
+                        ->sixteenth_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs
+                        pcs_ptr->sb_total_count);
+            }
+
+            if (scs_ptr->static_config.screen_content_mode == 2) { // auto detect
+                is_screen_content(pcs_ptr,
+                                  scs_ptr->static_config.encoder_bit_depth);
+            } else // off / on
+                pcs_ptr->sc_content_detected = scs_ptr->static_config.screen_content_mode;
+        }
+        // Get Empty Results Object
+        eb_get_empty_object(context_ptr->picture_analysis_results_output_fifo_ptr,
+                            &out_results_wrapper_ptr);
+
+        PictureAnalysisResults* out_results_ptr = (PictureAnalysisResults *)out_results_wrapper_ptr->object_ptr;
+        out_results_ptr->pcs_wrapper_ptr = in_results_ptr->pcs_wrapper_ptr;
+
+        // Release the Input Results
+        eb_release_object(in_results_wrapper_ptr);
+
+        // Post the Full Results Object
+        eb_post_full_object(out_results_wrapper_ptr);
+    }
+    return NULL;
+}
+#endif

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2742,7 +2742,7 @@ void sub_sample_luma_generate_pixel_intensity_histogram_bins(
 #ifdef FEATURE_INL_ME
     // Histogram bins
     // Luma for Histogram generation
-void sub_sample_luma_generate_pixel_intensity_histogram_bins_ex(
+void sub_sample_luma_generate_pixel_intensity_histogram_bins_ime(
     SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
     EbPictureBufferDesc *input_picture_ptr, uint64_t *sum_avg_intensity_ttl_regions_luma,
     uint8_t decim_step) {
@@ -3013,7 +3013,7 @@ void compute_picture_spatial_statistics(SequenceControlSet *     scs_ptr,
 
 #if FEATURE_INL_ME
 // compute mean & variance
-void compute_picture_spatial_statistics_ex(SequenceControlSet *     scs_ptr,
+void compute_picture_spatial_statistics_ime(SequenceControlSet *     scs_ptr,
                                         PictureParentControlSet *pcs_ptr,
                                         EbPictureBufferDesc *    input_picture_ptr) {
     uint64_t pic_tot_variance;
@@ -3171,7 +3171,7 @@ void gathering_picture_statistics(SequenceControlSet *scs_ptr, PictureParentCont
 #if FEATURE_INL_ME
 // calculate picture statistics
 // mean , variance , Luma intensity, Histogram
-static void gathering_picture_statistics_ex(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
+static void gathering_picture_statistics_ime(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
                                   EbPictureBufferDesc *input_picture_ptr) {
  uint64_t sum_avg_intensity_ttl_regions_luma = 0;
     uint64_t sum_avg_intensity_ttl_regions_cb   = 0;
@@ -3179,7 +3179,7 @@ static void gathering_picture_statistics_ex(SequenceControlSet *scs_ptr, Picture
 
     // Histogram bins
     // Use 1/16 Luma for Histogram generation
-    sub_sample_luma_generate_pixel_intensity_histogram_bins_ex(
+    sub_sample_luma_generate_pixel_intensity_histogram_bins_ime(
         scs_ptr, pcs_ptr,input_picture_ptr, &sum_avg_intensity_ttl_regions_luma, 4);
 
     // Use 1/16 Chroma for Histogram generation
@@ -3198,7 +3198,7 @@ static void gathering_picture_statistics_ex(SequenceControlSet *scs_ptr, Picture
                                       sum_avg_intensity_ttl_regions_cb,
                                       sum_avg_intensity_ttl_regions_cr);
 
-    compute_picture_spatial_statistics_ex(
+    compute_picture_spatial_statistics_ime(
         scs_ptr, pcs_ptr, input_picture_ptr);
 
 }
@@ -3729,7 +3729,7 @@ void downsample_filtering_input_picture(PictureParentControlSet *pcs_ptr,
 #if FEATURE_INL_ME
 // Current down sampled input is not used for HME, but mainly used for GM
 // So don't do the unnecessary check here
-void downsample_filtering_input_picture_ex(
+void downsample_filtering_input_picture_ime(
                                         EbPictureBufferDesc *    input_padded_picture_ptr,
                                         EbPictureBufferDesc *    quarter_picture_ptr,
                                         EbPictureBufferDesc *    sixteenth_picture_ptr) {
@@ -3792,7 +3792,7 @@ void downsample_filtering_input_picture_ex(
     }
 }
 
-void downsample_decimation_input_picture_ex(
+void downsample_decimation_input_picture_ime(
                                          EbPictureBufferDesc *    input_padded_picture_ptr,
                                          EbPictureBufferDesc *    quarter_decimated_picture_ptr,
                                          EbPictureBufferDesc *    sixteenth_decimated_picture_ptr) {
@@ -4164,12 +4164,12 @@ void *picture_analysis_kernel(void *input_ptr) {
                 // Get the 1/2, 1/4 of input picture, only used for global motion
                 // TODO: Check for global motion whether we need these
                 if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
-                    downsample_filtering_input_picture_ex(
+                    downsample_filtering_input_picture_ime(
                             input_picture_ptr,
                             (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
                             (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
                 } else {
-                    downsample_decimation_input_picture_ex(
+                    downsample_decimation_input_picture_ime(
                             input_picture_ptr,
                             (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
                             (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
@@ -4177,7 +4177,7 @@ void *picture_analysis_kernel(void *input_ptr) {
 
                 // TODO: Refine this function
                 // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
-                gathering_picture_statistics_ex(
+                gathering_picture_statistics_ime(
                         scs_ptr, pcs_ptr,
                         pcs_ptr->chroma_downsampled_picture_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.h
@@ -15,6 +15,9 @@
 #include "EbDefinitions.h"
 
 #include "EbPictureControlSet.h"
+#if FEATURE_INL_ME
+#include "EbSequenceControlSet.h"
+#endif
 
 /***************************************
  * Extern Function Declaration
@@ -29,5 +32,10 @@ void downsample_filtering_input_picture(PictureParentControlSet *pcs_ptr,
                                         EbPictureBufferDesc *    input_padded_picture_ptr,
                                         EbPictureBufferDesc *    quarter_picture_ptr,
                                         EbPictureBufferDesc *    sixteenth_picture_ptr);
+
+#if FEATURE_INL_ME
+void pad_input_pictures(SequenceControlSet *scs_ptr,
+                               EbPictureBufferDesc *input_picture_ptr);
+#endif
 
 #endif // EbPictureAnalysis_h

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1167,7 +1167,7 @@ static void picture_parent_control_set_dctor(EbPtr ptr) {
     EB_FREE_ARRAY(obj->rusi_picture[2]);
 
     EB_FREE_ARRAY(obj->av1x);
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
     EB_DESTROY_MUTEX(obj->me_processed_sb_mutex);
 #endif
     EB_DESTROY_MUTEX(obj->rc_distortion_histogram_mutex);
@@ -1295,7 +1295,7 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     EB_MALLOC_ARRAY(object_ptr->non_moving_index_array, object_ptr->sb_total_count);
     // SB noise variance array
     EB_MALLOC_ARRAY(object_ptr->sb_flat_noise_array, object_ptr->sb_total_count);
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
     EB_CREATE_MUTEX(object_ptr->me_processed_sb_mutex);
 #endif
     EB_CREATE_MUTEX(object_ptr->rc_distortion_histogram_mutex);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1167,12 +1167,18 @@ static void picture_parent_control_set_dctor(EbPtr ptr) {
     EB_FREE_ARRAY(obj->rusi_picture[2]);
 
     EB_FREE_ARRAY(obj->av1x);
+#if !FIX_GM_BUG
     EB_DESTROY_MUTEX(obj->me_processed_sb_mutex);
+#endif
     EB_DESTROY_MUTEX(obj->rc_distortion_histogram_mutex);
     EB_DESTROY_SEMAPHORE(obj->temp_filt_done_semaphore);
     EB_DESTROY_MUTEX(obj->temp_filt_mutex);
     EB_DESTROY_MUTEX(obj->debug_mutex);
     EB_FREE_ARRAY(obj->tile_group_info);
+#if FEATURE_INL_ME
+    EB_DESTROY_SEMAPHORE(obj->tpl_me_done_semaphore);
+    EB_DESTROY_MUTEX(obj->tpl_me_mutex);
+#endif
     if(obj->frame_superres_enabled){
         eb_pcs_sb_structs_dctor(obj);
         EB_DELETE(obj->enhanced_picture_ptr);
@@ -1289,7 +1295,9 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     EB_MALLOC_ARRAY(object_ptr->non_moving_index_array, object_ptr->sb_total_count);
     // SB noise variance array
     EB_MALLOC_ARRAY(object_ptr->sb_flat_noise_array, object_ptr->sb_total_count);
+#if !FIX_GM_BUG
     EB_CREATE_MUTEX(object_ptr->me_processed_sb_mutex);
+#endif
     EB_CREATE_MUTEX(object_ptr->rc_distortion_histogram_mutex);
     EB_MALLOC_ARRAY(object_ptr->sb_depth_mode_array, object_ptr->sb_total_count);
     EB_CREATE_SEMAPHORE(object_ptr->temp_filt_done_semaphore, 0, 1);
@@ -1297,6 +1305,10 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     EB_CREATE_MUTEX(object_ptr->debug_mutex);
     EB_MALLOC_ARRAY(object_ptr->av1_cm, 1);
 
+#if FEATURE_INL_ME
+    EB_CREATE_SEMAPHORE(object_ptr->tpl_me_done_semaphore, 0, 1);
+    EB_CREATE_MUTEX(object_ptr->tpl_me_mutex);
+#endif
     object_ptr->av1_cm->interp_filter = SWITCHABLE;
 
     object_ptr->av1_cm->mi_stride = picture_sb_width * (BLOCK_SIZE_64 / 4);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -674,8 +674,10 @@ typedef struct PictureParentControlSet {
     uint16_t *ois_distortion_histogram;
     uint32_t *intra_sad_interval_index;
     uint32_t *inter_sad_interval_index;
+#if !FIX_GM_BUG
     uint16_t me_processed_sb_count;
     EbHandle me_processed_sb_mutex;
+#endif
     EbHandle  rc_distortion_histogram_mutex;
     FirstPassData firstpass_data;
     RefreshFrameFlagsInfo refresh_frame;
@@ -690,7 +692,9 @@ typedef struct PictureParentControlSet {
     double       *tpl_rdmult_scaling_factors;
     double       *tpl_sb_rdmult_scaling_factors;
     EbBool       blk_lambda_tuning;
+#if !FIX_TPL_TRAILING_FRAME_BUG
     uint8_t       tpl_opt_flag;
+#endif
     // Dynamic GOP
     EbPred   pred_structure;
     uint8_t  hierarchical_levels;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -674,7 +674,7 @@ typedef struct PictureParentControlSet {
     uint16_t *ois_distortion_histogram;
     uint32_t *intra_sad_interval_index;
     uint32_t *inter_sad_interval_index;
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
     uint16_t me_processed_sb_count;
     EbHandle me_processed_sb_mutex;
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -490,26 +490,6 @@ typedef struct {
 #endif
 } TPLData;
 #endif
-#if FEATURE_OPT_TF
-typedef struct  TfControls {
-    uint8_t enabled;
-    uint8_t window_size;                 // 3, 5, 7
-    uint8_t noise_based_window_adjust;   // add an offset to default window_size based on the noise level; higher the noise, smaller is the offset
-    uint8_t hp;                          // w/o 1/16 pel MV refinement
-    uint8_t chroma;                      // use chroma
-#if FEATURE_OPT_TF
-    uint64_t block_32x32_16x16_th;       // control tf_16x16 using tf_32x32 pred error
-#endif
-}TfControls;
-#endif
-#if FEATURE_GM_OPT // GmControls
-typedef struct  GmControls {
-    uint8_t enabled;
-    uint8_t identiy_exit;       // 0: generate GM params for both list_0 and list_1, 1: do not generate GM params for list_1 if list_0/ref_idx_0 is id
-    uint8_t rotzoom_model_only; // 0: use both rotzoom and affine models, 1:use rotzoom model only
-    uint8_t bipred_only;        // 0: test both unipred and bipred, 1: test bipred only
-} GmControls;
-#endif
 //CHKN
 // Add the concept of PictureParentControlSet which is a subset of the old PictureControlSet.
 // It actually holds only high level Picture based control data:(GOP management,when to start a picture, when to release the PCS, ....).
@@ -909,19 +889,9 @@ typedef struct PictureParentControlSet {
     // when used in RC there is a risk of race condition to access the PCS data. To prevent the problem, TplData should be used instead of PCS.
     uint8_t tpl_trailing_frame_count;
 #endif
-#if TUNE_TPL_TOWARD_CHROMA
-    // Tune TPL for better chroma.Only for 240P
-    uint8_t tune_tpl_for_chroma;
-#endif
 #if FEATURE_NEW_DELAY
     uint8_t is_next_frame_intra;
 #endif
-#endif
-#if FEATURE_OPT_TF
-    TfControls tf_ctrls;
-#endif
-#if FEATURE_GM_OPT
-    GmControls gm_ctrls;
 #endif
 } PictureParentControlSet;
 

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -485,7 +485,7 @@ typedef struct {
     EbBool      ref_in_slide_window[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
     EbBool      is_used_as_reference_flag;
     EbDownScaledBufDescPtrArray tpl_ref_ds_ptr_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
     uint8_t       tpl_opt_flag;
 #endif
 } TPLData;
@@ -692,7 +692,7 @@ typedef struct PictureParentControlSet {
     double       *tpl_rdmult_scaling_factors;
     double       *tpl_sb_rdmult_scaling_factors;
     EbBool       blk_lambda_tuning;
-#if !FIX_TPL_TRAILING_FRAME_BUG
+#if !ENABLE_TPL_TRAILING
     uint8_t       tpl_opt_flag;
 #endif
     // Dynamic GOP
@@ -913,7 +913,7 @@ typedef struct PictureParentControlSet {
     // Tune TPL for better chroma.Only for 240P
     uint8_t tune_tpl_for_chroma;
 #endif
-#if FIX_LAD_DEADLOCK
+#if FEATURE_NEW_DELAY
     uint8_t is_next_frame_intra;
 #endif
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -794,6 +794,33 @@ typedef struct PictureParentControlSet {
     EbObjectWrapper *me_data_wrapper_ptr;
     MotionEstimationData *pa_me_data;
     unsigned char gf_group_index;
+#if FEATURE_NEW_DELAY
+    struct PictureParentControlSet* tpl_group[MAX_TPL_GROUP_SIZE]; //stores pcs pictures needed for tpl algorithm
+    uint32_t tpl_group_size;             //size of above buffer
+    void* pd_window[PD_WINDOW_SIZE]; //stores previous, current, future pictures from pd-reord-queue. empty for first I.
+#if TUNE_TPL
+    uint8_t pd_window_count;
+#endif
+#if ENABLE_TPL_TRAILING
+    // For TPL, in addition to frames in the minigop size, we might process extra frames from the next minigop. These frames are
+    // called trailing frames. Trailing frames are available because of TF and their minigop is not determined yet. As a result,
+    // when used in RC there is a risk of race condition to access the PCS data. To prevent the problem, TplData should be used instead of PCS.
+    uint8_t tpl_trailing_frame_count;
+#endif
+#if TUNE_TPL_TOWARD_CHROMA
+    // Tune TPL for better chroma.Only for 240P
+    uint8_t tune_tpl_for_chroma;
+#endif
+#if FIX_LAD_DEADLOCK
+    uint8_t is_next_frame_intra;
+#endif
+#endif
+#if FEATURE_OPT_TF
+    TfControls tf_ctrls;
+#endif
+#if FEATURE_GM_OPT
+    GmControls gm_ctrls;
+#endif
 } PictureParentControlSet;
 
 typedef struct PictureControlSetInitData {

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1103,14 +1103,6 @@ EbErrorType signal_derivation_multi_processes_oq(
 
     pcs_ptr->tpl_trailing_frame_count = MIN(pcs_ptr->tpl_trailing_frame_count, SCD_LAD);
 #endif
-#if TUNE_TPL_TOWARD_CHROMA
-    // Tune TPL for better chroma.Only for 240P. 0 is OFF
-#if TUNE_CHROMA_SSIM
-    pcs_ptr->tune_tpl_for_chroma = 1;
-#else
-    pcs_ptr->tune_tpl_for_chroma = 0;
-#endif
-#endif
     return return_error;
 }
 
@@ -3844,44 +3836,12 @@ void mctf_frame(
             else
                 context_ptr->tf_level = 0;
         }
-#if FEATURE_OPT_TF
-#if TUNE_NEW_PRESETS
-        else if (pcs_ptr->enc_mode <= ENC_M6) {
-#else
-        else if (pcs_ptr->enc_mode <= ENC_M5) {
-#endif
-            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
-                context_ptr->tf_level = 2;
-            else
-                context_ptr->tf_level = 0;
-        }
-#if !TUNE_NEW_PRESETS
-        else if (pcs_ptr->enc_mode <= ENC_M7) {
-            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
-                context_ptr->tf_level = 3;
-            else
-                context_ptr->tf_level = 0;
-        }
-#endif
-        else {
-#if FEATURE_OPT_TF
-            if (pcs_ptr->temporal_layer_index == 0)
-#else
-            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
-#endif
-                context_ptr->tf_level = 4;
-            else
-                context_ptr->tf_level = 0;
-
-        }
-#else
         else {
             if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
                 context_ptr->tf_level = 2;
             else
                 context_ptr->tf_level = 0;
         }
-#endif
         }
         else {
             if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
@@ -3892,14 +3852,9 @@ void mctf_frame(
     }
     else
         context_ptr->tf_level = 0;
-#if FEATURE_OPT_TF
-    set_tf_controls(pcs_ptr, context_ptr->tf_level);
-    if (pcs_ptr->tf_ctrls.enabled) {
-#else
     set_tf_controls(context_ptr, context_ptr->tf_level);
 
     if (context_ptr->tf_ctrls.enabled) {
-#endif
         derive_tf_window_params(
             scs_ptr,
             scs_ptr->encode_context_ptr,
@@ -4239,11 +4194,7 @@ EbErrorType derive_tf_window_params(
         adjust_num = 2;
     }
     }
-#if FEATURE_OPT_TF
-    int altref_nframes = MIN(scs_ptr->static_config.altref_nframes, pcs_ptr->tf_ctrls.window_size + adjust_num);
-#else
     int altref_nframes = MIN(scs_ptr->static_config.altref_nframes, context_ptr->tf_ctrls.window_size + adjust_num);
-    #endif
 #if FEATURE_NEW_DELAY
     (void)out_stride_diff64;
     if (is_delayed_intra(pcs_ptr)) {

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -5553,7 +5553,7 @@ void* picture_decision_kernel(void *input_ptr)
                             pcs_ptr->inloop_me_segments_total_count =
                                 (uint16_t)(pcs_ptr->inloop_me_segments_column_count * pcs_ptr->inloop_me_segments_row_count);
 #endif
-#if !FIX_GM_BUG
+#if !FEATURE_IN_LOOP_TPL
                             pcs_ptr->me_processed_sb_count = 0;
 #endif
                             //****************************************************

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -208,7 +208,16 @@ uint8_t  circ_inc(uint8_t max, uint8_t off, uint8_t input)
 #define POC_CIRCULAR_ADD(base, offset/*, bits*/)             (/*(((int32_t) (base)) + ((int32_t) (offset)) > ((int32_t) (1 << (bits))))   ? ((base) + (offset) - (1 << (bits))) : \
                                                              (((int32_t) (base)) + ((int32_t) (offset)) < 0)                           ? ((base) + (offset) + (1 << (bits))) : \
                                                                                                                                        */((base) + (offset)))
+#if FEATURE_NEW_DELAY
+EbErrorType derive_tf_window_params(
+    SequenceControlSet *scs_ptr,
+    EncodeContext *encode_context_ptr,
+    PictureParentControlSet *pcs_ptr,
+    PictureDecisionContext *context_ptr,
+    uint32_t out_stride_diff64);
+#else
 #define FUTURE_WINDOW_WIDTH                 12
+#endif
 #define FLASH_TH                            5
 #define FADE_TH                             3
 #define SCENE_TH                            3000
@@ -1024,6 +1033,9 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0: OFF
         // 1: ON
     pcs_ptr->tx_size_early_exit = 1;
+#if FEATURE_NEW_DELAY
+    (void)context_ptr;
+#else
         //Prune reference and reduce ME SR based on HME/ME distortion
         // 0: OFF
         // 1: ON
@@ -1073,11 +1085,30 @@ EbErrorType signal_derivation_multi_processes_oq(
     else
         context_ptr->tf_level = 0;
     set_tf_controls(context_ptr, context_ptr->tf_level);
-
+#endif
+#if !FIX_TPL_TRAILING_FRAME_BUG
     if (pcs_ptr->enc_mode <= ENC_M4)
         pcs_ptr->tpl_opt_flag = 0;
     else
         pcs_ptr->tpl_opt_flag = 1;
+#endif
+#if ENABLE_TPL_TRAILING
+    // Suggested values are 6 and 0. To go beyond 6, SCD_LAD must be updated too (might cause stablity issues to go beyong 6)
+    if (pcs_ptr->enc_mode <= ENC_M6)
+        pcs_ptr->tpl_trailing_frame_count = 6;
+    else
+        pcs_ptr->tpl_trailing_frame_count = 0;
+
+    pcs_ptr->tpl_trailing_frame_count = MIN(pcs_ptr->tpl_trailing_frame_count, SCD_LAD);
+#endif
+#if TUNE_TPL_TOWARD_CHROMA
+    // Tune TPL for better chroma.Only for 240P. 0 is OFF
+#if TUNE_CHROMA_SSIM
+    pcs_ptr->tune_tpl_for_chroma = 1;
+#else
+    pcs_ptr->tune_tpl_for_chroma = 0;
+#endif
+#endif
     return return_error;
 }
 
@@ -3718,6 +3749,339 @@ void initialize_overlay_frame(PictureParentControlSet     *pcs_ptr) {
     perform_simple_picture_analysis_for_overlay(pcs_ptr);
  }
 
+#if FEATURE_NEW_DELAY
+/*
+  ret number of past picture(not including current) in mg buffer.
+
+*/
+int32_t avail_past_pictures(PictureParentControlSet**buf, uint32_t buf_size, uint64_t input_pic)
+{
+    //buffer has at least curr picture
+    int32_t tot_past = 0;
+    for (uint32_t pic = 0; pic < buf_size; pic++) {
+        if (buf[pic]->picture_number < input_pic) {
+            tot_past++;
+        }
+    }
+    return tot_past;
+}
+
+
+/*
+  searches a picture in a given pcs buffer
+*/
+int32_t search_this_pic(PictureParentControlSet**buf, uint32_t buf_size, uint64_t input_pic)
+{
+    int32_t index = -1;
+    for (uint32_t pic = 0; pic < buf_size; pic++) {
+        if (buf[pic]->picture_number == input_pic) {
+            index = (int32_t)pic;
+            break;
+        }
+    }
+    return index;
+}
+/*
+  Tells if an Intra picture should be delayed to get next mini-gop
+*/
+EbBool is_delayed_intra(PictureParentControlSet *pcs) {
+    if (pcs->idr_flag || pcs->cra_flag) {
+        if (pcs->scs_ptr->static_config.intra_period_length == 0 || pcs->end_of_sequence_flag)
+            return 0;
+        else if (pcs->idr_flag || (pcs->cra_flag && pcs->pre_assignment_buffer_count < pcs->pred_struct_ptr->pred_struct_period))
+            return 1;
+        else
+            return 0;
+    }
+    else
+        return 0;
+}
+
+/*
+  Performs Motion Compensated Temporal Filtering in ME process
+*/
+void mctf_frame(
+    SequenceControlSet      *scs_ptr,
+    PictureParentControlSet *pcs_ptr,
+    PictureDecisionContext  *context_ptr,
+    uint32_t               out_stride_diff64
+)
+{
+    uint8_t perform_filtering =
+        (scs_ptr->tf_level && scs_ptr->static_config.pred_structure == EB_PRED_RANDOM_ACCESS && scs_ptr->static_config.hierarchical_levels >= 1)
+        ? 1 : 0;
+
+    // tf_level is used to indicate whether temporal filtering is to be used,
+    // and if so, what level of the feature to consider.
+
+    // tf_level controls through the function set_tf_controls whether the feature is enabled or not,
+    // and the total number of pictures (window_size) to consider in temporal filtering, including the current frame,
+    // and whether to adjust the window size based on noise characteristics.
+    // Level 0 corresponds to temporal filtering being OFF.
+    // Levels 1, 2 and 3 correspond to feature active with fewer pictures considered in the temporal filtering operations.
+
+    // In the table below, ON refers to temporal filtering performed for temporal layer 0 pictures
+    // and (for pictures in temporal layer 1 in at least a 4-layer prediction structure)
+
+    //    tf_level   |                  Default Encoder Settings                   |  Command Line Settings
+    //       0       | OFF subject to possible constraints                         |  OFF
+    //       1       | ON subject to possible constraints                          |  ON
+    //       2       | ON with smaller window_size subject to possible constraints |  ON with smaller window_size
+    //       3       | ON with smaller window_size subject to possible constraints |  ON with even smaller window_size
+    if (perform_filtering) {
+        if (scs_ptr->static_config.tf_level == DEFAULT) {
+        if (pcs_ptr->enc_mode <= ENC_M4) {
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+                context_ptr->tf_level = 1;
+            else
+                context_ptr->tf_level = 0;
+        }
+#if FEATURE_OPT_TF
+#if TUNE_NEW_PRESETS
+        else if (pcs_ptr->enc_mode <= ENC_M6) {
+#else
+        else if (pcs_ptr->enc_mode <= ENC_M5) {
+#endif
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+                context_ptr->tf_level = 2;
+            else
+                context_ptr->tf_level = 0;
+        }
+#if !TUNE_NEW_PRESETS
+        else if (pcs_ptr->enc_mode <= ENC_M7) {
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+                context_ptr->tf_level = 3;
+            else
+                context_ptr->tf_level = 0;
+        }
+#endif
+        else {
+#if FEATURE_OPT_TF
+            if (pcs_ptr->temporal_layer_index == 0)
+#else
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+#endif
+                context_ptr->tf_level = 4;
+            else
+                context_ptr->tf_level = 0;
+
+        }
+#else
+        else {
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+                context_ptr->tf_level = 2;
+            else
+                context_ptr->tf_level = 0;
+        }
+#endif
+        }
+        else {
+            if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))
+                context_ptr->tf_level = scs_ptr->static_config.tf_level;
+            else
+                context_ptr->tf_level = 0;
+        }
+    }
+    else
+        context_ptr->tf_level = 0;
+#if FEATURE_OPT_TF
+    set_tf_controls(pcs_ptr, context_ptr->tf_level);
+    if (pcs_ptr->tf_ctrls.enabled) {
+#else
+    set_tf_controls(context_ptr, context_ptr->tf_level);
+
+    if (context_ptr->tf_ctrls.enabled) {
+#endif
+        derive_tf_window_params(
+            scs_ptr,
+            scs_ptr->encode_context_ptr,
+            pcs_ptr,
+            context_ptr,
+            out_stride_diff64);
+        pcs_ptr->temp_filt_prep_done = 0;
+
+        // Start Filtering in ME processes
+        {
+            int16_t seg_idx;
+
+            // Initialize Segments
+            pcs_ptr->tf_segments_column_count = scs_ptr->tf_segment_column_count;
+            pcs_ptr->tf_segments_row_count = scs_ptr->tf_segment_row_count;
+            pcs_ptr->tf_segments_total_count = (uint16_t)(pcs_ptr->tf_segments_column_count  * pcs_ptr->tf_segments_row_count);
+            pcs_ptr->temp_filt_seg_acc = 0;
+            if (pcs_ptr->temporal_layer_index == 0)
+                pcs_ptr->altref_strength = scs_ptr->static_config.altref_strength;
+            else
+                pcs_ptr->altref_strength = 2;
+
+            for (seg_idx = 0; seg_idx < pcs_ptr->tf_segments_total_count; ++seg_idx) {
+
+                EbObjectWrapper               *out_results_wrapper_ptr;
+                PictureDecisionResults        *out_results_ptr;
+
+                eb_get_empty_object(
+                    context_ptr->picture_decision_results_output_fifo_ptr,
+                    &out_results_wrapper_ptr);
+                out_results_ptr = (PictureDecisionResults*)out_results_wrapper_ptr->object_ptr;
+                out_results_ptr->pcs_wrapper_ptr = pcs_ptr->p_pcs_wrapper_ptr;
+                out_results_ptr->segment_index = seg_idx;
+                out_results_ptr->task_type = 1;
+                eb_post_full_object(out_results_wrapper_ptr);
+            }
+
+            eb_block_on_semaphore(pcs_ptr->temp_filt_done_semaphore);
+        }
+
+    }
+    else
+        pcs_ptr->temporal_filtering_on = EB_FALSE; // set temporal filtering flag OFF for current picture
+}
+
+
+void store_tpl_pictures(
+    PictureParentControlSet *pcs,
+    PictureDecisionContext  *ctx,
+    uint32_t                 mg_size)
+{
+
+    if(is_delayed_intra(pcs))
+    {
+        pcs->tpl_group[0] = (void*)pcs;
+        memcpy(&pcs->tpl_group[1], ctx->mg_pictures_array, mg_size * sizeof(PictureParentControlSet*));
+        pcs->tpl_group_size = 1 + mg_size;
+
+    }
+    else {
+        memcpy(&pcs->tpl_group[0], ctx->mg_pictures_array, mg_size * sizeof(PictureParentControlSet*));
+        pcs->tpl_group_size = mg_size;
+#if !TUNE_TPL
+        //add 3 future pictures from PD future window
+        for (uint32_t pic_i = 0; pic_i < 3; ++pic_i) {
+            if (pcs->pd_window[2 + pic_i]) {
+                pcs->tpl_group[mg_size + pic_i] = pcs->pd_window[2 + pic_i];
+                pcs->tpl_group_size++;
+            }
+            else
+                break;
+        }
+#endif
+#if ENABLE_TPL_TRAILING
+        //add 6 future pictures from PD future window
+        for (uint32_t pic_i = 0; pic_i < pcs->tpl_trailing_frame_count; ++pic_i) {
+            if (pcs->pd_window[2 + pic_i]) {
+                pcs->tpl_group[mg_size + pic_i] = pcs->pd_window[2 + pic_i];
+                pcs->tpl_group_size++;
+            }
+            else
+                break;
+        }
+#endif
+
+    }
+
+#if FEATURE_INL_ME
+    for (uint32_t pic_i = 0; pic_i < pcs->tpl_group_size; ++pic_i) {
+        PictureParentControlSet* pcs_tpl_ptr = (PictureParentControlSet *)pcs->tpl_group[pic_i];
+
+        if (pcs_tpl_ptr->me_data_wrapper_ptr==NULL) {
+            EbObjectWrapper               *me_wrapper;
+            eb_get_empty_object(ctx->me_fifo_ptr, &me_wrapper);
+            pcs_tpl_ptr->me_data_wrapper_ptr = me_wrapper;
+            pcs_tpl_ptr->pa_me_data = (MotionEstimationData *)me_wrapper->object_ptr;
+            //printf("[%ld]: Got me data [TPL] %p\n", pcs_tpl_ptr->picture_number, pcs_tpl_ptr->pa_me_data);
+        }
+        //printf("====[%ld]: TPL group Base %ld, TPL group size %d\n",pcs->picture_number, pcs_tpl_ptr->picture_number, pcs->tpl_group_size);
+    }
+#endif
+}
+
+void send_picture_out(
+    SequenceControlSet      *scs,
+    PictureParentControlSet *pcs,
+    PictureDecisionContext  *ctx)
+{
+    EbObjectWrapper               *me_wrapper;
+    EbObjectWrapper               *out_results_wrapper;
+
+    if (scs->static_config.look_ahead_distance == 0) {
+
+        EbObjectWrapper* reference_picture_wrapper;
+        // Get Empty Reference Picture Object
+        eb_get_empty_object(
+            scs->encode_context_ptr->reference_picture_pool_fifo_ptr,
+            &reference_picture_wrapper);
+        pcs->reference_picture_wrapper_ptr = reference_picture_wrapper;
+        // Give the new Reference a nominal live_count of 1
+        eb_object_inc_live_count(pcs->reference_picture_wrapper_ptr, 1);
+    }
+    //get a new ME data buffer
+#if FEATURE_INL_ME
+    if (pcs->me_data_wrapper_ptr == NULL) {
+        eb_get_empty_object(ctx->me_fifo_ptr, &me_wrapper);
+        pcs->me_data_wrapper_ptr = me_wrapper;
+        pcs->pa_me_data = (MotionEstimationData *)me_wrapper->object_ptr;
+        //printf("[%ld]: Got me data [NORMAL] %p\n", pcs->picture_number, pcs->pa_me_data);
+    }
+#else
+    eb_get_empty_object(ctx->me_fifo_ptr, &me_wrapper);
+    pcs->me_data_wrapper_ptr = me_wrapper;
+
+    pcs->pa_me_data = (MotionEstimationData *)me_wrapper->object_ptr;
+#endif
+
+    for (uint32_t segment_index = 0; segment_index < pcs->me_segments_total_count; ++segment_index) {
+        // Get Empty Results Object
+        eb_get_empty_object(
+            ctx->picture_decision_results_output_fifo_ptr,
+            &out_results_wrapper);
+
+        PictureDecisionResults* out_results = (PictureDecisionResults*)out_results_wrapper->object_ptr;
+        out_results->pcs_wrapper_ptr = pcs->p_pcs_wrapper_ptr;
+        out_results->segment_index = segment_index;
+        out_results->task_type = 0;
+        //Post the Full Results Object
+        eb_post_full_object(out_results_wrapper);
+    }
+
+}
+
+void print_pre_ass(EncodeContext *ctxt)
+{
+
+    SVT_LOG("\n Pre-Assign(%i):  ", ctxt->pre_assignment_buffer_count);
+    for (uint32_t pic = 0; pic < ctxt->pre_assignment_buffer_count; pic++) {
+
+        PictureParentControlSet *pcs = (PictureParentControlSet*)ctxt->pre_assignment_buffer[pic]->object_ptr;
+        SVT_LOG("%ld ", pcs->picture_number);
+    }
+    SVT_LOG("\n");
+}
+void print_pd_reord_queue(EncodeContext *ctxt)
+{
+    uint32_t idx = ctxt->picture_decision_reorder_queue_head_index;
+    PictureDecisionReorderEntry   *queue_entry = ctxt->picture_decision_reorder_queue[idx];
+
+    while (queue_entry->parent_pcs_wrapper_ptr != NULL) {
+
+        PictureParentControlSet *pcs = (PictureParentControlSet*)queue_entry->parent_pcs_wrapper_ptr->object_ptr;
+        SVT_LOG("%ld  ", pcs->picture_number);
+        queue_entry = ctxt->picture_decision_reorder_queue[++idx];
+    }
+    SVT_LOG("\n");
+}
+
+uint32_t  get_reord_q_size(EncodeContext *ctxt)
+{
+    uint32_t size = 0;
+    uint32_t idx = ctxt->picture_decision_reorder_queue_head_index;
+    PictureDecisionReorderEntry   *queue_entry = ctxt->picture_decision_reorder_queue[idx];
+    while (queue_entry->parent_pcs_wrapper_ptr != NULL) {
+        queue_entry = ctxt->picture_decision_reorder_queue[++idx];
+        size++;
+    }
+    return size;
+}
+#endif
 /***************************************************************************************************
  * Helper function. Compare two frames: center frame and target frame. Return the summation of
  * absolute difference between the two frames from a histogram of luma values
@@ -3867,7 +4231,49 @@ EbErrorType derive_tf_window_params(
         adjust_num = 2;
     }
     }
+#if FEATURE_OPT_TF
+    int altref_nframes = MIN(scs_ptr->static_config.altref_nframes, pcs_ptr->tf_ctrls.window_size + adjust_num);
+#else
     int altref_nframes = MIN(scs_ptr->static_config.altref_nframes, context_ptr->tf_ctrls.window_size + adjust_num);
+    #endif
+#if FEATURE_NEW_DELAY
+    (void)out_stride_diff64;
+    if (is_delayed_intra(pcs_ptr)) {
+        //initilize list
+        for (int pic_itr = 0; pic_itr < ALTREF_MAX_NFRAMES; pic_itr++)
+            pcs_ptr->temp_filt_pcs_list[pic_itr] = NULL;
+
+        pcs_ptr->temp_filt_pcs_list[0] = pcs_ptr;
+        uint32_t num_future_pics = altref_nframes - 1;
+
+        uint32_t pic_i;
+        for (pic_i = 0; pic_i < num_future_pics; pic_i++) {
+            int32_t idx = search_this_pic(context_ptr->mg_pictures_array, context_ptr->mg_size, pcs_ptr->picture_number + pic_i + 1);
+            if (idx >= 0)
+                pcs_ptr->temp_filt_pcs_list[pic_i + 1] = context_ptr->mg_pictures_array[idx];
+            else
+                break;
+        }
+
+        pcs_ptr->past_altref_nframes = 0;
+        pcs_ptr->future_altref_nframes = pic_i;
+        int index_center = 0;
+        uint32_t actual_future_pics = pcs_ptr->future_altref_nframes;
+        int pic_itr;
+
+        int ahd_th = (((pcs_ptr->aligned_width * pcs_ptr->aligned_height) * AHD_TH_WEIGHT) / 100);
+
+        // Accumulative histogram absolute differences between the central and future frame
+        for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
+            int ahd = compute_luma_sad_between_center_and_target_frame(index_center, pic_itr, pcs_ptr, scs_ptr);
+
+            if (ahd < ahd_th)
+               break;
+        }
+        pcs_ptr->future_altref_nframes = pic_itr - index_center;
+    }
+    else
+#endif
     if (pcs_ptr->idr_flag) {
 
         //initilize list
@@ -3917,13 +4323,25 @@ EbErrorType derive_tf_window_params(
         for (int pic_itr = 0; pic_itr < ALTREF_MAX_NFRAMES; pic_itr++)
             pcs_ptr->temp_filt_pcs_list[pic_itr] = NULL;
         // limit the number of pictures to make sure there are enough pictures in the buffer. i.e. Intra CRA case
+#if FEATURE_NEW_DELAY
+        // limit the number of pictures to make sure there are enough pictures in the buffer. i.e. Intra CRA case
+        num_past_pics = MIN(num_past_pics, avail_past_pictures(context_ptr->mg_pictures_array, context_ptr->mg_size, pcs_ptr->picture_number));
+#else
         num_past_pics = MIN(MIN(num_past_pics, (int)encode_context_ptr->pre_assignment_buffer_count - 1), (int)out_stride_diff64);
-
+#endif
         //get previous+current pictures from the the pre-assign buffer
+#if  FEATURE_NEW_DELAY
+        for (int pic_itr = 0; pic_itr <= num_past_pics; pic_itr++) {
+            int32_t idx = search_this_pic(context_ptr->mg_pictures_array, context_ptr->mg_size, pcs_ptr->picture_number - num_past_pics + pic_itr);
+            if (idx >= 0)
+                pcs_ptr->temp_filt_pcs_list[pic_itr] = context_ptr->mg_pictures_array[idx];
+        }
+#else
         for (int pic_itr = 0; pic_itr <= num_past_pics; pic_itr++) {
             PictureParentControlSet* pcs_itr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[out_stride_diff64 - num_past_pics + pic_itr]->object_ptr;
             pcs_ptr->temp_filt_pcs_list[pic_itr] = pcs_itr;
         }
+#endif
         int actual_past_pics = num_past_pics;
         int actual_future_pics = 0;
         int pic_i;
@@ -4130,12 +4548,16 @@ void* picture_decision_kernel(void *input_ptr)
 
     EncodeContext                 *encode_context_ptr;
     SequenceControlSet            *scs_ptr;
+#if !FEATURE_NEW_DELAY
     EbObjectWrapper               *me_wrapper_ptr;
+#endif
     EbObjectWrapper               *in_results_wrapper_ptr;
     PictureAnalysisResults        *in_results_ptr;
 
+#if !FEATURE_NEW_DELAY
     EbObjectWrapper               *out_results_wrapper_ptr;
     PictureDecisionResults        *out_results_ptr;
+#endif
 
     PredictionStructureEntry      *pred_position_ptr;
 
@@ -4165,8 +4587,9 @@ void* picture_decision_kernel(void *input_ptr)
     EbBool                          window_avail, frame_passthrough;
     uint32_t                           window_index;
     uint32_t                           entry_index;
+#if !FEATURE_NEW_DELAY
     PictureParentControlSet        *parent_pcs_window[FUTURE_WINDOW_WIDTH + 2];
-
+#endif
     // Debug
     uint64_t                           loop_count = 0;
 
@@ -4203,6 +4626,7 @@ void* picture_decision_kernel(void *input_ptr)
 
             pcs_ptr->pic_decision_reorder_queue_idx = queue_entry_index;
         }
+
         // Process the head of the Picture Decision Reordering Queue (Entry N)
         // P.S. The Picture Decision Reordering Queue should be parsed in the display order to be able to construct a pred structure
         queue_entry_ptr = encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index];
@@ -4215,16 +4639,33 @@ void* picture_decision_kernel(void *input_ptr)
                 frame_passthrough = EB_FALSE;
             window_avail = EB_TRUE;
             previous_entry_index = QUEUE_GET_PREVIOUS_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index);
+#if FEATURE_NEW_DELAY
+            pcs_ptr = (PictureParentControlSet*)queue_entry_ptr->parent_pcs_wrapper_ptr->object_ptr;
+            memset(pcs_ptr->pd_window, 0, PD_WINDOW_SIZE * sizeof(PictureParentControlSet*));
+#if TUNE_TPL
+            pcs_ptr->pd_window_count = 0;
+#endif
+#else
             parent_pcs_window[ 0] = parent_pcs_window[ 1] = parent_pcs_window[ 2] = parent_pcs_window[ 3] = parent_pcs_window[ 4] = parent_pcs_window[ 5] =
             parent_pcs_window[ 6] = parent_pcs_window[ 7] = parent_pcs_window[ 8] = parent_pcs_window[ 9] = parent_pcs_window[10] = parent_pcs_window[11] =
             parent_pcs_window[12] = parent_pcs_window[13] = NULL;
+#endif
             //for poc 0, ignore previous frame check
             if (queue_entry_ptr->picture_number > 0 && encode_context_ptr->picture_decision_reorder_queue[previous_entry_index]->parent_pcs_wrapper_ptr == NULL)
                 window_avail = EB_FALSE;
             else {
 
+#if FEATURE_NEW_DELAY
+                //TODO: risk of a race condition accessing prev(pcs0 is released, and pcs1 still doing sc).
+                //Actually we dont need to keep prev, just keep previous copy of histograms.
+                pcs_ptr->pd_window[0] =
+                    queue_entry_ptr->picture_number > 0 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[previous_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
+                pcs_ptr->pd_window[1] =
+                    (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index]->parent_pcs_wrapper_ptr->object_ptr;
+#else
                 parent_pcs_window[0] = queue_entry_ptr->picture_number > 0 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[previous_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
                 parent_pcs_window[1] = (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index]->parent_pcs_wrapper_ptr->object_ptr;
+#endif
                 for (window_index = 0; window_index < scs_ptr->scd_delay; window_index++) {
                     entry_index = QUEUE_GET_NEXT_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index, window_index + 1);
                     if (encode_context_ptr->picture_decision_reorder_queue[entry_index]->parent_pcs_wrapper_ptr == NULL) {
@@ -4236,7 +4677,12 @@ void* picture_decision_kernel(void *input_ptr)
                         frame_passthrough = EB_TRUE;
                         break;
                     }else {
+#if FEATURE_NEW_DELAY
+                        pcs_ptr->pd_window[2 + window_index] =
+                            (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[entry_index]->parent_pcs_wrapper_ptr->object_ptr;
+#else
                         parent_pcs_window[2 + window_index] = (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[entry_index]->parent_pcs_wrapper_ptr->object_ptr;
+#endif
                     }
                 }
             }
@@ -4252,7 +4698,11 @@ void* picture_decision_kernel(void *input_ptr)
                     pcs_ptr->scene_change_flag = scene_transition_detector(
                         context_ptr,
                         scs_ptr,
+#if FEATURE_NEW_DELAY
+                        (PictureParentControlSet **)pcs_ptr->pd_window);
+#else
                         parent_pcs_window);
+#endif
                 }
                 else
                     pcs_ptr->scene_change_flag = EB_FALSE;
@@ -4286,6 +4736,13 @@ void* picture_decision_kernel(void *input_ptr)
 
                 pcs_ptr->self_updated_links = 0;
                 pcs_ptr->other_updated_links_cnt = 0;
+#if FEATURE_NEW_DELAY
+
+                pcs_ptr->tpl_group_size = 0;
+                if (pcs_ptr->picture_number == 0)
+                    context_ptr->prev_delayed_intra = NULL;
+
+#endif
                 release_prev_picture_from_reorder_queue(
                     encode_context_ptr);
 
@@ -4309,6 +4766,16 @@ void* picture_decision_kernel(void *input_ptr)
                         pcs_ptr->idr_flag;
                 }
 
+
+#if FIX_LAD_DEADLOCK
+                //TODO: scene change update
+                if (scs_ptr->intra_period_length == 0)
+                    pcs_ptr->is_next_frame_intra = 1;
+                else if (scs_ptr->intra_period_length == -1)
+                    pcs_ptr->is_next_frame_intra = 0;
+                else
+                    pcs_ptr->is_next_frame_intra = (int32_t)(encode_context_ptr->intra_period_position + 1) == scs_ptr->intra_period_length;
+#endif
                 encode_context_ptr->pre_assignment_buffer_eos_flag = (pcs_ptr->end_of_sequence_flag) ? (uint32_t)EB_TRUE : encode_context_ptr->pre_assignment_buffer_eos_flag;
 
                 // Increment the Pre-Assignment Buffer Intra Count
@@ -4861,6 +5328,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 EB_MEMSET(pcs_ptr->ref_pic_poc_array[REF_LIST_1], 0, REF_LIST_MAX_DEPTH * sizeof(uint64_t));
                             }
                             pcs_ptr = cur_picture_control_set_ptr;
+#if ! FEATURE_NEW_DELAY
                             if(context_ptr->tf_ctrls.enabled) {
                                 derive_tf_window_params(
                                     scs_ptr,
@@ -4900,7 +5368,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                             }else
                                 pcs_ptr->temporal_filtering_on = EB_FALSE; // set temporal filtering flag OFF for current picture
-
+#endif
                         }
                         if(scs_ptr->static_config.enable_manual_pred_struct){
                             EbErrorType ret = av1_generate_minigop_rps_info_from_user_config(encode_context_ptr,context_ptr,mini_gop_index);
@@ -5061,6 +5529,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 // Increment the Decode Base Number
                                 encode_context_ptr->decode_base_number += context_ptr->mini_gop_length[mini_gop_index] + has_overlay;
                             }
+#if ! FEATURE_NEW_DELAY
                             if (out_stride_diff64 == encode_context_ptr->pre_assignment_buffer_count - 1 + has_overlay) {
 
                                 // Reset the Pre-Assignment Buffer
@@ -5070,9 +5539,13 @@ void* picture_decision_kernel(void *input_ptr)
                                 encode_context_ptr->pre_assignment_buffer_scene_change_count = 0;
                                 encode_context_ptr->pre_assignment_buffer_eos_flag = EB_FALSE;
                             }
+#endif
                         }
                         uint32_t mg_size = context_ptr->mini_gop_end_index[mini_gop_index] + has_overlay - context_ptr->mini_gop_start_index[mini_gop_index]+1;
-
+#if FEATURE_NEW_DELAY
+                        context_ptr->mg_size = mg_size;
+                        memcpy(context_ptr->mg_pictures_array_disp_order, context_ptr->mg_pictures_array, mg_size * sizeof(PictureParentControlSet*));
+#endif
                         //sort based on decoder order
                         {
                             uint32_t  num_of_cand_to_sort = mg_size;
@@ -5088,10 +5561,52 @@ void* picture_decision_kernel(void *input_ptr)
                             }
                         }
 
+#if FEATURE_NEW_DELAY
+                        //Process previous delayed Intra if we have one
+                        if (context_ptr->prev_delayed_intra) {
+                            pcs_ptr = context_ptr->prev_delayed_intra;
+                            if (scs_ptr->static_config.enable_tpl_la)
+                                store_tpl_pictures(pcs_ptr, context_ptr, mg_size);
+
+                            mctf_frame(scs_ptr, pcs_ptr, context_ptr, out_stride_diff64);
+
+#if FIX_TPL_TRAILING_FRAME_BUG
+                            if (pcs_ptr->enc_mode <= ENC_M4)
+                                pcs_ptr->tpl_data.tpl_opt_flag = 0;
+                            else
+                                pcs_ptr->tpl_data.tpl_opt_flag = 1;
+#endif
+                        }
+
+                        //Do TF loop in display order
+                        for (uint32_t pic_i = 0; pic_i < mg_size; ++pic_i) {
+                            pcs_ptr = context_ptr->mg_pictures_array_disp_order[pic_i];
+
+                            if (is_delayed_intra(pcs_ptr) == EB_FALSE) {
+                                if (scs_ptr->static_config.enable_tpl_la && pcs_ptr->temporal_layer_index == 0 )
+                                    store_tpl_pictures(pcs_ptr, context_ptr, mg_size);
+
+                                mctf_frame(scs_ptr, pcs_ptr, context_ptr, out_stride_diff64);
+                            }
+                        }
+
+                        if (context_ptr->prev_delayed_intra) {
+                            pcs_ptr = context_ptr->prev_delayed_intra;
+                            context_ptr->prev_delayed_intra = NULL;
+                            send_picture_out(scs_ptr, pcs_ptr, context_ptr);
+                        }
+#endif
 
                         for (uint32_t pic_i = 0; pic_i < mg_size; ++pic_i){
 
                             pcs_ptr = context_ptr->mg_pictures_array[pic_i];
+#if FEATURE_NEW_DELAY
+                            if (is_delayed_intra(pcs_ptr)) {
+                                context_ptr->prev_delayed_intra = pcs_ptr;
+                            }else{
+                                send_picture_out(scs_ptr, pcs_ptr, context_ptr);
+                            }
+#else
 
                             if (scs_ptr->static_config.look_ahead_distance == 0) {
 
@@ -5128,10 +5643,19 @@ void* picture_decision_kernel(void *input_ptr)
                                 // Post the Full Results Object
                                 eb_post_full_object(out_results_wrapper_ptr);
                             }
+#endif
 
 
                         }
                     } // End MINI GOPs loop
+#if FEATURE_NEW_DELAY
+                    // Reset the Pre-Assignment Buffer
+                    encode_context_ptr->pre_assignment_buffer_count = 0;
+                    encode_context_ptr->pre_assignment_buffer_idr_count = 0;
+                    encode_context_ptr->pre_assignment_buffer_intra_count = 0;
+                    encode_context_ptr->pre_assignment_buffer_scene_change_count = 0;
+                    encode_context_ptr->pre_assignment_buffer_eos_flag = EB_FALSE;
+#endif
                 }
 
                 // Walk the picture_decision_pa_reference_queue and remove entries that have been completely referenced.
@@ -5170,7 +5694,11 @@ void* picture_decision_kernel(void *input_ptr)
                 // Get the next entry from the Picture Decision Reordering Queue (Entry N+1)
                 queue_entry_ptr = encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index];
             }
+#if FEATURE_NEW_DELAY
+            else
+#else
             if (window_avail == EB_FALSE && frame_passthrough == EB_FALSE)
+#endif
                 break;
         }
 

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -4693,6 +4693,13 @@ void* picture_decision_kernel(void *input_ptr)
 #endif
                     }
                 }
+#if TUNE_TPL
+                for (window_index = 0; window_index < scs_ptr->scd_delay; window_index++)
+                    if (pcs_ptr->pd_window[2 + window_index])
+                        pcs_ptr->pd_window_count++;
+                    else
+                        break;
+#endif
             }
 
             pcs_ptr = (PictureParentControlSet*)queue_entry_ptr->parent_pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1088,7 +1088,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         context_ptr->tf_level = 0;
     set_tf_controls(context_ptr, context_ptr->tf_level);
 #endif
-#if !FIX_TPL_TRAILING_FRAME_BUG
+#if !ENABLE_TPL_TRAILING
     if (pcs_ptr->enc_mode <= ENC_M4)
         pcs_ptr->tpl_opt_flag = 0;
     else
@@ -4782,7 +4782,7 @@ void* picture_decision_kernel(void *input_ptr)
                 }
 
 
-#if FIX_LAD_DEADLOCK
+#if FEATURE_NEW_DELAY
                 //TODO: scene change update
                 if (scs_ptr->intra_period_length == 0)
                     pcs_ptr->is_next_frame_intra = 1;
@@ -5612,7 +5612,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                             mctf_frame(scs_ptr, pcs_ptr, context_ptr, out_stride_diff64);
 
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
                             if (pcs_ptr->enc_mode <= ENC_M4)
                                 pcs_ptr->tpl_data.tpl_opt_flag = 0;
                             else

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
@@ -98,9 +98,7 @@ typedef struct PictureDecisionContext
     uint8_t       last_i_picture_sc_detection;
     uint64_t      key_poc;
     uint8_t tf_level;
-#if !FEATURE_OPT_TF
     TfControls tf_ctrls;
-#endif
     PictureParentControlSet* mg_pictures_array[1<<MAX_TEMPORAL_LAYERS];
     DepCntPicInfo updated_links_arr[UPDATED_LINKS];//if not empty, this picture is a depn-cnt-cleanUp triggering picture (I frame; or MG size change )
                                                       //this array will store all others pictures needing a dep-cnt clean up.

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
@@ -93,11 +93,18 @@ typedef struct PictureDecisionContext
     uint8_t       last_i_picture_sc_detection;
     uint64_t      key_poc;
     uint8_t tf_level;
+#if !FEATURE_OPT_TF
     TfControls tf_ctrls;
+#endif
     PictureParentControlSet* mg_pictures_array[1<<MAX_TEMPORAL_LAYERS];
     DepCntPicInfo updated_links_arr[UPDATED_LINKS];//if not empty, this picture is a depn-cnt-cleanUp triggering picture (I frame; or MG size change )
                                                       //this array will store all others pictures needing a dep-cnt clean up.
     uint32_t other_updated_links_cnt; //how many other pictures in the above array needing a dep-cnt clean-up
+#if FEATURE_NEW_DELAY
+    PictureParentControlSet* prev_delayed_intra; //Key frame or I of LDP short MG
+    uint32_t                 mg_size;//number of active pictures in above array
+    PictureParentControlSet* mg_pictures_array_disp_order[1 << MAX_TEMPORAL_LAYERS];
+#endif
 } PictureDecisionContext;
 
 #endif // EbPictureDecision_h

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
@@ -34,8 +34,13 @@ void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs
                                                         EbPictureBufferDesc *input_picture_ptr);
 void pad_picture_to_multiple_of_min_blk_size_dimensions_16bit(
     SequenceControlSet * scs_ptr, EbPictureBufferDesc *input_picture_ptr);
+#if FEATURE_INL_ME
+void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
+                                       SequenceControlSet *scs_ptr);
+#else
 void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
                                        SequenceControlSet *scs_ptr, uint32_t sb_total_count);
+#endif
 void pad_picture_to_multiple_of_sb_dimensions(EbPictureBufferDesc *input_padded_picture_ptr);
 
 void gathering_picture_statistics(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbPictureDemuxResults.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDemuxResults.c
@@ -29,3 +29,22 @@ EbErrorType picture_results_creator(EbPtr *object_dbl_ptr, EbPtr object_init_dat
 
     return EB_ErrorNone;
 }
+#if FEATURE_INL_ME
+EbErrorType picture_manager_result_ctor(PictureManagerResults *object_ptr,
+    EbPtr                   object_init_data_ptr) {
+    (void)object_ptr;
+    (void)object_init_data_ptr;
+
+    return EB_ErrorNone;
+}
+
+EbErrorType picture_manager_result_creator(EbPtr *object_dbl_ptr, EbPtr object_init_data_ptr) {
+    PictureManagerResults *obj;
+
+    *object_dbl_ptr = NULL;
+    EB_NEW(obj, picture_manager_result_ctor, object_init_data_ptr);
+    *object_dbl_ptr = obj;
+
+    return EB_ErrorNone;
+}
+#endif

--- a/Source/Lib/Encoder/Codec/EbPictureDemuxResults.h
+++ b/Source/Lib/Encoder/Codec/EbPictureDemuxResults.h
@@ -51,4 +51,24 @@ typedef struct PictureResultInitData {
  **************************************/
 extern EbErrorType picture_results_creator(EbPtr *object_dbl_ptr, EbPtr object_init_data_ptr);
 
+
+#if FEATURE_INL_ME
+typedef struct PictureManagerResults {
+    EbDctor          dctor;
+    EbObjectWrapper *pcs_wrapper_ptr;
+    uint32_t         segment_index;
+    uint8_t          task_type;
+    uint8_t          tpl_ref_list0_count;
+    uint8_t          tpl_ref_list1_count;
+    uint8_t          temporal_layer_index;
+    EbBool           is_used_as_reference_flag;
+} PictureManagerResults;
+
+typedef struct PictureManagerResultInitData {
+    int32_t junk;
+} PictureManagerResultInitData;
+
+extern EbErrorType picture_manager_result_creator(EbPtr *object_dbl_ptr,
+    EbPtr  object_init_data_ptr);
+#endif
 #endif //EbPictureResults_h

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -105,8 +105,14 @@ EbErrorType picture_manager_context_ctor(EbThreadContext *  thread_context_ptr,
 
     context_ptr->picture_input_fifo_ptr =
         eb_system_resource_get_consumer_fifo(enc_handle_ptr->picture_demux_results_resource_ptr, 0);
+#if FEATURE_INL_ME
+    UNUSED(rate_control_index);
+    context_ptr->picture_manager_output_fifo_ptr = eb_system_resource_get_producer_fifo(
+        enc_handle_ptr->pic_mgr_res_srm, 0);
+#else
     context_ptr->picture_manager_output_fifo_ptr = eb_system_resource_get_producer_fifo(
         enc_handle_ptr->rate_control_tasks_resource_ptr, rate_control_index);
+#endif
     context_ptr->picture_control_set_fifo_ptr = eb_system_resource_get_producer_fifo(
         enc_handle_ptr->picture_control_set_pool_ptr_array[0], 0); //The Child PCS Pool here
 
@@ -222,6 +228,365 @@ void copy_dep_cnt_cleaning_list(
     }
 
 }
+#if FEATURE_INL_ME
+static uint8_t tpl_setup_me_refs(
+    SequenceControlSet              *scs_ptr,
+    PictureParentControlSet         *pcs_tpl_group_frame_ptr,
+    PictureParentControlSet         *pcs_tpl_base_ptr,
+    uint8_t                         *ref0_count, //out
+    uint8_t                         *ref1_count,
+    EbBool                          *trailing_frames) {
+    *ref0_count = 0;
+    *ref1_count = 0;
+    PredictionStructure* base_pred_struct_ptr = get_prediction_structure(
+            scs_ptr->encode_context_ptr->prediction_structure_group_ptr,
+            pcs_tpl_base_ptr->pred_structure,
+            scs_ptr->reference_count,
+            pcs_tpl_base_ptr->hierarchical_levels);
+    uint32_t init_idx = base_pred_struct_ptr->init_pic_index;
+    uint64_t curr_poc = pcs_tpl_group_frame_ptr->picture_number;
+    uint64_t base_poc = pcs_tpl_base_ptr->picture_number;
+    uint32_t tpl_base_minigop = base_pred_struct_ptr->pred_struct_period;
+    //uint32_t curr_minigop_entry_idx = (curr_poc + tpl_base_minigop - base_poc) % tpl_base_minigop;
+    uint32_t curr_minigop_entry_idx = (curr_poc > base_poc) ?
+                                      (uint32_t)(curr_poc - base_poc) :
+                                      (uint32_t)(curr_poc + tpl_base_minigop - base_poc);
+    uint32_t pred_struct_idx = curr_minigop_entry_idx + init_idx;
+
+#if !TUNE_INL_TPL_ENHANCEMENT
+    // 17/18/19, which is out side of the minigop
+    *trailing_frames = (!pcs_tpl_base_ptr->idr_flag) && (curr_poc > base_poc);
+#endif
+
+    // Get the ref entry point of trailing frames, not good here
+    if (*trailing_frames && pred_struct_idx + tpl_base_minigop < base_pred_struct_ptr->pred_struct_entry_count)
+        pred_struct_idx += tpl_base_minigop;
+
+    PredictionStructureEntry *frame_pred_entry = base_pred_struct_ptr->pred_struct_entry_ptr_array[pred_struct_idx];
+#if !TUNE_INL_TPL_ENHANCEMENT
+    EB_MEMSET(pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[REF_LIST_0],
+            0,
+            REF_LIST_MAX_DEPTH * sizeof(EbDownScaledBufDescPtrArray));
+    EB_MEMSET(pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[REF_LIST_1],
+            0,
+            REF_LIST_MAX_DEPTH * sizeof(EbDownScaledBufDescPtrArray));
+#endif
+
+    uint8_t ref_list_count = 0;
+    for (uint8_t list_index = REF_LIST_0; list_index <= REF_LIST_1; list_index++) {
+        uint8_t *ref_count_ptr = (list_index == REF_LIST_0) ? ref0_count : ref1_count;
+
+        if (*trailing_frames) {
+            ref_list_count = (list_index == REF_LIST_0) ?
+                frame_pred_entry->ref_list0.reference_list_count :
+#if ENABLE_TPL_ZERO_LAD
+                0; //Jing: why remove ref1? for poc17, it should refer to poc18 in L1
+#else
+                frame_pred_entry->ref_list1.reference_list_count;
+#endif
+            //Jing: We can set the it as the same logic of ref_list_count_try in PD kernel
+            //      But need to make sure change them at the same time.
+            //      Now for simplicity, just limit it as 2 for trailing frames
+            //      Corresponding logic in PD:
+            //          if (pcs_ptr->enc_mode <= ENC_M6) {
+            //              pcs_ptr->ref_list0_count_try = MIN(pcs_ptr->ref_list0_count, 4);
+            //              pcs_ptr->ref_list1_count_try = MIN(pcs_ptr->ref_list1_count, 3);
+            //          }
+            //          else {
+            //              pcs_ptr->ref_list0_count_try =
+            //                  pcs_ptr->is_used_as_reference_flag ? MIN(pcs_ptr->ref_list0_count, 2) : MIN(pcs_ptr->ref_list0_count, 1);
+            //              pcs_ptr->ref_list1_count_try =
+            //                  pcs_ptr->is_used_as_reference_flag ? MIN(pcs_ptr->ref_list1_count, 2) : MIN(pcs_ptr->ref_list1_count, 1);
+            //          }
+            ref_list_count = MIN(ref_list_count, 2); //Jing: limit to 2 refs for trailing frames
+        } else {
+            ref_list_count = (list_index == REF_LIST_0) ?
+                pcs_tpl_group_frame_ptr->ref_list0_count_try :
+                pcs_tpl_group_frame_ptr->ref_list1_count_try;
+        }
+
+        for (uint8_t ref_idx = 0; ref_idx < ref_list_count; ref_idx++) {
+            EbBool ref_in_slide_window = EB_FALSE;
+#if FEATURE_IN_LOOP_TPL
+#if TUNE_INL_TPL_ENHANCEMENT
+            pcs_tpl_group_frame_ptr->tpl_data.ref_in_slide_window[list_index][*ref_count_ptr] = EB_FALSE;
+#else
+            pcs_tpl_group_frame_ptr->ref_in_slide_window[list_index][*ref_count_ptr] = EB_FALSE;
+#endif
+#endif
+            uint64_t ref_poc = pcs_tpl_group_frame_ptr->ref_pic_poc_array[list_index][ref_idx];
+            if (*trailing_frames) {
+                int delta_poc = (list_index == REF_LIST_0) ?
+                    frame_pred_entry->ref_list0.reference_list[ref_idx] :
+                    frame_pred_entry->ref_list1.reference_list[ref_idx];
+                ref_poc = pcs_tpl_group_frame_ptr->picture_number - delta_poc;
+            }
+
+            for (uint32_t j = 0; j < pcs_tpl_base_ptr->tpl_group_size; j++) {
+                if (ref_poc == pcs_tpl_base_ptr->tpl_group[j]->picture_number) {
+#if TUNE_INL_TPL_ENHANCEMENT
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][*ref_count_ptr] = pcs_tpl_base_ptr->tpl_group[j]->ds_pics;
+#else
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[list_index][*ref_count_ptr] = pcs_tpl_base_ptr->tpl_group[j]->ds_pics;
+#endif
+                    ref_in_slide_window = EB_TRUE;
+#if FEATURE_IN_LOOP_TPL
+#if TUNE_INL_TPL_ENHANCEMENT
+                    pcs_tpl_group_frame_ptr->tpl_data.ref_in_slide_window[list_index][*ref_count_ptr] = EB_TRUE;
+#else
+                    pcs_tpl_group_frame_ptr->ref_in_slide_window[list_index][*ref_count_ptr] = EB_TRUE;
+#endif
+#endif
+                    *ref_count_ptr += 1;
+#if TUNE_INL_TPL_ME_DBG_MSG
+                    printf("\t L%d: %ld=>%ld, use input, ref_count %d\n", list_index, curr_poc, ref_poc, ref_list_count);
+#endif
+                    break;
+                }
+            }
+#if !TUNE_IME_REUSE_TPL_RESULT
+            if (list_index == REF_LIST_1 && ref_in_slide_window) {
+                // Remove duplicate refs from list1 which is already in list0
+                for (uint8_t i=0; i<*ref0_count; i++) {
+#if TUNE_INL_TPL_ENHANCEMENT
+                    if (pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[0][i].picture_number == ref_poc) {
+#else
+                    if (pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[0][i].picture_number == ref_poc) {
+#endif
+                        *ref_count_ptr -= 1;
+                        break;
+                    }
+                }
+            }
+#endif
+
+            if (!ref_in_slide_window) {
+                ReferenceQueueEntry* ref_entry_ptr = search_ref_in_ref_queue(scs_ptr->encode_context_ptr, ref_poc);
+                if (ref_entry_ptr && ref_entry_ptr->reference_available) {
+#if TUNE_INL_TPL_ENHANCEMENT
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][*ref_count_ptr] =
+#else
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[list_index][*ref_count_ptr] =
+#endif
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->ds_pics;
+#if TUNE_INL_TPL_ME_DBG_MSG
+                    printf("\t L%d: %ld=>%ld, use recon, ref_count %d\n", list_index, curr_poc, ref_poc, ref_list_count);
+#endif
+#if TUNE_INL_TPL_ON_INPUT
+                   // printf("\t Debug purpose, use input pic\n");
+#if TUNE_INL_TPL_ENHANCEMENT
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->input_picture;
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].sixteenth_picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->sixteenth_input_picture;
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].quarter_picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->quarter_input_picture;
+#else
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->input_picture;
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].sixteenth_picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->sixteenth_input_picture;
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[list_index][*ref_count_ptr].quarter_picture_ptr =
+                        ((EbReferenceObject *)ref_entry_ptr->reference_object_ptr->object_ptr)->quarter_input_picture;
+#endif
+#endif
+                    *ref_count_ptr += 1;
+                } else {
+                    //printf("\t L%d: %ld=>%ld, doesn't exist, ref_count %d\n", list_index, curr_poc, ref_poc, ref_list_count);
+                }
+            }
+        }
+    }
+
+#if FEATURE_IN_LOOP_TPL
+#if TUNE_INL_TPL_ENHANCEMENT
+    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref0_count = *ref0_count;
+    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref1_count = *ref1_count;
+
+    // Get the temporal layer index here
+    if (*trailing_frames) {
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_temporal_layer_index =
+            frame_pred_entry->temporal_layer_index;
+        pcs_tpl_group_frame_ptr->tpl_data.is_used_as_reference_flag =
+            frame_pred_entry->is_referenced;
+
+        //decode order not accurate enough when at the end of bitstream where minigop switch happens
+        //and there's no way to detect the accurate dependancy/ref and decode order without caching a lot of frames,
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_decode_order =
+            pcs_tpl_base_ptr->picture_number + frame_pred_entry->decode_order + 1;
+    }
+#else
+    pcs_tpl_group_frame_ptr->tpl_ref0_count = *ref0_count;
+    pcs_tpl_group_frame_ptr->tpl_ref1_count = *ref1_count;
+#endif
+#endif
+#if TUNE_INL_TPL_ME_DBG_MSG
+#if ENABLE_TPL_ZERO_LAD
+    if (*trailing_frames)
+        pcs_tpl_group_frame_ptr->max_number_of_pus_per_sb = pcs_tpl_base_ptr->max_number_of_pus_per_sb;
+#endif
+    for (int i = REF_LIST_0; i <= REF_LIST_1; i++) {
+        int ref_count = (i == 0) ? *ref0_count: *ref1_count;
+        for (int j = 0; j < ref_count; j++) {
+            printf("\t\t Set ref on list: %d, total count %d: %lu => %lu, decode order %lu\n",
+                    i, ref_count,
+                    pcs_tpl_group_frame_ptr->picture_number,
+#if TUNE_INL_TPL_ENHANCEMENT
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[i][j].picture_number,
+                    pcs_tpl_group_frame_ptr->tpl_data.tpl_decode_order);
+#else
+                    pcs_tpl_group_frame_ptr->tpl_ref_ds_ptr_array[i][j].picture_number,
+                    pcs_tpl_group_frame_ptr->decode_order);
+#endif
+        }
+    }
+#endif
+    return 0;
+}
+
+#if TUNE_INL_TPL_ENHANCEMENT
+static EbErrorType tpl_init_pcs_tpl_data(
+    PictureParentControlSet         *pcs_tpl_group_frame_ptr,
+    PictureParentControlSet         *pcs_tpl_base_ptr,
+    EbBool                          *trailing_frames) {
+    uint64_t curr_poc = pcs_tpl_group_frame_ptr->picture_number;
+    uint64_t base_poc = pcs_tpl_base_ptr->picture_number;
+
+    // 17/18/19, which is out side of the minigop
+    *trailing_frames = (!pcs_tpl_base_ptr->idr_flag) && (curr_poc > base_poc);
+
+    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref0_count = 0;
+    pcs_tpl_group_frame_ptr->tpl_data.tpl_ref1_count = 0;
+    EB_MEMSET(pcs_tpl_group_frame_ptr->tpl_data.ref_in_slide_window,
+        0,
+        MAX_NUM_OF_REF_PIC_LIST*REF_LIST_MAX_DEPTH * sizeof(EbBool));
+    EB_MEMSET(pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[REF_LIST_0],
+            0,
+            REF_LIST_MAX_DEPTH * sizeof(EbDownScaledBufDescPtrArray));
+    EB_MEMSET(pcs_tpl_group_frame_ptr->tpl_data.tpl_ref_ds_ptr_array[REF_LIST_1],
+            0,
+            REF_LIST_MAX_DEPTH * sizeof(EbDownScaledBufDescPtrArray));
+    if (*trailing_frames) {
+        // If trailing frames, set as B slice and layer1 first, will update later when getting the refs
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_slice_type = B_SLICE;
+
+        // These will be updated in function tpl_setup_me_refs()
+        //pcs_tpl_group_frame_ptr->tpl_data.is_used_as_reference_flag = EB_FALSE;
+        //pcs_tpl_group_frame_ptr->tpl_data.tpl_temporal_layer_index = 1;
+        //pcs_tpl_group_frame_ptr->tpl_data.tpl_decode_order = 10;
+    } else {
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_slice_type = pcs_tpl_group_frame_ptr->slice_type;
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_temporal_layer_index = pcs_tpl_group_frame_ptr->temporal_layer_index;
+        pcs_tpl_group_frame_ptr->tpl_data.is_used_as_reference_flag = pcs_tpl_group_frame_ptr->is_used_as_reference_flag;
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_decode_order = pcs_tpl_group_frame_ptr->decode_order;
+    }
+
+#if FIX_TPL_TRAILING_FRAME_BUG
+    if (pcs_tpl_group_frame_ptr->enc_mode <= ENC_M4)
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_opt_flag = 0;
+    else
+        pcs_tpl_group_frame_ptr->tpl_data.tpl_opt_flag = 1;
+#endif
+    return 0;
+}
+#endif
+
+
+static EbErrorType tpl_get_open_loop_me(
+    PictureManagerContext           *context_ptr,
+    SequenceControlSet              *scs_ptr,
+    PictureParentControlSet         *pcs_tpl_base_ptr) {
+    //printf("[%ld]: PM got input\n", pcs_tpl_base_ptr->picture_number);
+    if (scs_ptr->in_loop_me &&
+            scs_ptr->static_config.enable_tpl_la &&
+            pcs_tpl_base_ptr->temporal_layer_index == 0) {
+        // Do tpl ME to get ME results
+        for (uint32_t i = 0; i < pcs_tpl_base_ptr->tpl_group_size; i++) {
+            PictureParentControlSet* pcs_tpl_group_frame_ptr = pcs_tpl_base_ptr->tpl_group[i];
+#if !FEATURE_IN_LOOP_TPL
+            if (!pcs_tpl_group_frame_ptr->tpl_me_done) {
+#endif
+            uint8_t ref_list0_count = 0;
+            uint8_t ref_list1_count = 0;
+            EbBool  is_trailing_tpl_frame = EB_FALSE;
+#if TUNE_INL_TPL_ENHANCEMENT
+            tpl_init_pcs_tpl_data(pcs_tpl_group_frame_ptr,
+                pcs_tpl_base_ptr,
+                &is_trailing_tpl_frame);
+
+            if (pcs_tpl_group_frame_ptr->tpl_data.tpl_slice_type != I_SLICE) {
+#else
+#if FEATURE_IN_LOOP_TPL
+            pcs_tpl_group_frame_ptr->tpl_ref0_count = 0;
+            pcs_tpl_group_frame_ptr->tpl_ref1_count = 0;
+            EB_MEMSET(pcs_tpl_group_frame_ptr->ref_in_slide_window,
+                0,
+                MAX_NUM_OF_REF_PIC_LIST*REF_LIST_MAX_DEPTH * sizeof(EbBool));
+
+            if (pcs_tpl_group_frame_ptr->slice_type != I_SLICE) {
+#else
+            if (pcs_tpl_group_frame_ptr->slice_type != I_SLICE /*&&
+                    pcs_tpl_group_frame_ptr != pcs_tpl_base_ptr*/) {
+#endif
+#endif
+#if TUNE_INL_TPL_ME_DBG_MSG
+                printf("[%ld]: Setup TPL ME refs for frame %lu\n",
+                        pcs_tpl_base_ptr->picture_number,
+                        pcs_tpl_group_frame_ptr->picture_number);
+#endif
+
+                tpl_setup_me_refs(scs_ptr,
+                        pcs_tpl_group_frame_ptr, pcs_tpl_base_ptr,
+                        &ref_list0_count, &ref_list1_count,
+                        &is_trailing_tpl_frame);
+#if FEATURE_IN_LOOP_TPL
+                if (!pcs_tpl_group_frame_ptr->tpl_me_done){
+#endif
+                    // Initialize Segments
+                    pcs_tpl_group_frame_ptr->tpl_me_segments_column_count = 1;//scs_ptr->tf_segment_column_count;
+                    pcs_tpl_group_frame_ptr->tpl_me_segments_row_count = 1;//scs_ptr->tf_segment_row_count;
+                    pcs_tpl_group_frame_ptr->tpl_me_segments_total_count =
+                        (uint16_t)(pcs_tpl_group_frame_ptr->tpl_me_segments_column_count *
+                                   pcs_tpl_group_frame_ptr->tpl_me_segments_row_count);
+                    pcs_tpl_group_frame_ptr->tpl_me_seg_acc = 0;
+
+                    for (int16_t seg_idx = 0; seg_idx < pcs_tpl_group_frame_ptr->tpl_me_segments_total_count; ++seg_idx) {
+                        EbObjectWrapper *out_results_wrapper_ptr;
+
+                        eb_get_empty_object(
+                                context_ptr->picture_manager_output_fifo_ptr,
+                                &out_results_wrapper_ptr);
+
+                        PictureManagerResults *out_results_ptr = (PictureManagerResults*)out_results_wrapper_ptr->object_ptr;
+                        out_results_ptr->pcs_wrapper_ptr = pcs_tpl_group_frame_ptr->p_pcs_wrapper_ptr;
+                        out_results_ptr->segment_index = seg_idx;
+                        out_results_ptr->task_type = 2;
+                        out_results_ptr->tpl_ref_list0_count = ref_list0_count;
+                        out_results_ptr->tpl_ref_list1_count = ref_list1_count;
+                        out_results_ptr->temporal_layer_index = is_trailing_tpl_frame ? 1 : pcs_tpl_group_frame_ptr->temporal_layer_index;
+                        out_results_ptr->is_used_as_reference_flag = is_trailing_tpl_frame ? 0 : pcs_tpl_group_frame_ptr->is_used_as_reference_flag;
+                        eb_post_full_object(out_results_wrapper_ptr);
+                    }
+
+                    eb_block_on_semaphore(pcs_tpl_group_frame_ptr->tpl_me_done_semaphore); //chkn we can do all in // ?
+
+                    // When TPL16, flag tpl_me_done of 17/18/19 will be set done during TPL32
+                    if (!is_trailing_tpl_frame) {
+                        pcs_tpl_group_frame_ptr->tpl_me_done = 1;
+#if TUNE_INL_TPL_ME_DBG_MSG
+                        printf("\t Picture %lu TPL ME done\n", pcs_tpl_group_frame_ptr->picture_number);
+#endif
+                    }
+                }
+            }
+        }
+    }
+    // Release pa reference
+    if (scs_ptr->in_loop_me)
+        release_pa_reference_objects(scs_ptr, pcs_tpl_base_ptr);
+    return 0;
+}
+#endif
 /* Picture Manager Kernel */
 
 /***************************************************************************************************
@@ -258,8 +623,10 @@ void *picture_manager_kernel(void *input_ptr) {
     EbObjectWrapper *    input_picture_demux_wrapper_ptr;
     PictureDemuxResults *input_picture_demux_ptr;
 
+#if !FEATURE_INL_ME
     EbObjectWrapper * output_wrapper_ptr;
     RateControlTasks *rate_control_tasks_ptr;
+#endif
 
     EbBool availability_flag;
 
@@ -410,6 +777,10 @@ void *picture_manager_kernel(void *input_ptr) {
             scs_ptr = (SequenceControlSet *)input_picture_demux_ptr->scs_wrapper_ptr->object_ptr;
             encode_context_ptr = scs_ptr->encode_context_ptr;
             clean_pictures_in_ref_queue(scs_ptr->encode_context_ptr);
+#if FEATURE_INL_ME
+            ((EbReferenceObject *)input_picture_demux_ptr->reference_picture_wrapper_ptr->object_ptr)->ds_pics.picture_number =
+                input_picture_demux_ptr->picture_number;
+#endif
             // Check if Reference Queue is full
             CHECK_REPORT_ERROR((encode_context_ptr->reference_picture_queue_head_index !=
                                 encode_context_ptr->reference_picture_queue_tail_index),
@@ -513,7 +884,12 @@ void *picture_manager_kernel(void *input_ptr) {
                         (SequenceControlSet *)entry_pcs_ptr->scs_wrapper_ptr->object_ptr;
 
                     availability_flag = EB_TRUE;
-                    if (entry_pcs_ptr->decode_order != decode_order && use_input_stat(scs_ptr))
+                    if (entry_pcs_ptr->decode_order != decode_order &&
+#if TUNE_INL_ME_DECODE_ORDER
+                        ((scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la) || use_input_stat(scs_ptr)))
+#else
+                        use_input_stat(scs_ptr))
+#endif
                         availability_flag = EB_FALSE;
 
                     // Check RefList0 Availability
@@ -624,6 +1000,10 @@ void *picture_manager_kernel(void *input_ptr) {
                         eb_object_inc_live_count(child_pcs_wrapper_ptr, 1);
 
                         child_pcs_ptr = (PictureControlSet *)child_pcs_wrapper_ptr->object_ptr;
+#if FEATURE_INL_ME
+
+                        child_pcs_ptr->c_pcs_wrapper_ptr = child_pcs_wrapper_ptr;
+#endif
 
                         //1.Link The Child PCS to its Parent
                         child_pcs_ptr->picture_parent_control_set_wrapper_ptr =
@@ -1126,6 +1506,30 @@ void *picture_manager_kernel(void *input_ptr) {
                                                      1);
                         }
 
+#if FEATURE_INL_ME
+
+                        // Get TPL ME
+                        tpl_get_open_loop_me(context_ptr, scs_ptr, child_pcs_ptr->parent_pcs_ptr);
+
+                        //printf("[%ld]: PM post to iME\n", child_pcs_ptr->picture_number);
+                        const uint32_t segment_counts =  child_pcs_ptr->parent_pcs_ptr->inloop_me_segments_total_count;
+                        for (uint32_t segment_index = 0; segment_index < segment_counts; ++segment_index) {
+                            EbObjectWrapper               *out_results_wrapper_ptr;
+                            // Get Empty Results Object
+                            eb_get_empty_object(
+                                context_ptr->picture_manager_output_fifo_ptr,
+                                &out_results_wrapper_ptr);
+
+                            PictureManagerResults   *out_results_ptr = (PictureManagerResults*)out_results_wrapper_ptr->object_ptr;
+                            // PM output ppcs to iME kernel
+                            out_results_ptr->pcs_wrapper_ptr = child_pcs_ptr->parent_pcs_ptr->p_pcs_wrapper_ptr;
+                            out_results_ptr->segment_index = segment_index;
+                            out_results_ptr->task_type = 0;
+                            // Post the Full Results Object
+                            eb_post_full_object(out_results_wrapper_ptr);
+                        }
+
+#else
                         // Get Empty Results Object
                         eb_get_empty_object(context_ptr->picture_manager_output_fifo_ptr,
                                             &output_wrapper_ptr);
@@ -1136,6 +1540,7 @@ void *picture_manager_kernel(void *input_ptr) {
 
                         // Post the Full Results Object
                         eb_post_full_object(output_wrapper_ptr);
+#endif
 
                         // Remove the Input Entry from the Input Queue
                         input_entry_ptr->input_object_ptr = (EbObjectWrapper *)NULL;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -29,6 +29,1107 @@
 #include "EbLambdaRateTables.h"
 #include "pass2_strategy.h"
 
+#if FEATURE_IN_LOOP_TPL
+#include "EbTransforms.h"
+#include "aom_dsp_rtcd.h"
+#include "EbLog.h"
+#include "EbIntraPrediction.h"
+#include "EbMotionEstimation.h"
+#endif
+
+#if FEATURE_IN_LOOP_TPL
+static void generate_lambda_scaling_factor(PictureParentControlSet         *pcs_ptr, int64_t mc_dep_cost_base)
+{
+    Av1Common *cm = pcs_ptr->av1_cm;
+    const int step = 1 << (pcs_ptr->is_720p_or_larger ? 2 : 1);
+    const int mi_cols_sr = ((pcs_ptr->aligned_width + 15) / 16) << 2;
+
+    const int block_size = BLOCK_16X16;
+    const int num_mi_w = mi_size_wide[block_size];
+    const int num_mi_h = mi_size_high[block_size];
+    const int num_cols = (mi_cols_sr + num_mi_w - 1) / num_mi_w;
+    const int num_rows = (cm->mi_rows + num_mi_h - 1) / num_mi_h;
+    const int stride = mi_cols_sr >> (1 + pcs_ptr->is_720p_or_larger);
+    const double c = 1.2;
+
+    for (int row = 0; row < num_rows; row++) {
+        for (int col = 0; col < num_cols; col++) {
+            double intra_cost = 0.0;
+            double mc_dep_cost = 0.0;
+            const int index = row * num_cols + col;
+            for (int mi_row = row * num_mi_h; mi_row < (row + 1) * num_mi_h; mi_row += step) {
+                for (int mi_col = col * num_mi_w; mi_col < (col + 1) * num_mi_w; mi_col += step) {
+                    if (mi_row >= cm->mi_rows || mi_col >= mi_cols_sr) continue;
+
+                    const int index1 = (mi_row >> (1 + pcs_ptr->is_720p_or_larger)) * stride + (mi_col >> (1 + pcs_ptr->is_720p_or_larger));
+                    TplStats *tpl_stats_ptr = pcs_ptr->tpl_stats[index1];
+                    int64_t mc_dep_delta =
+                        RDCOST(pcs_ptr->base_rdmult, tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->mc_dep_dist);
+                    intra_cost += (double)(tpl_stats_ptr->recrf_dist << RDDIV_BITS);
+                    mc_dep_cost += (double)(tpl_stats_ptr->recrf_dist << RDDIV_BITS) + mc_dep_delta;
+                }
+            }
+            double rk = 0;
+            if (mc_dep_cost > 0 && intra_cost > 0) {
+                rk = intra_cost / mc_dep_cost;
+            }
+
+            pcs_ptr->tpl_rdmult_scaling_factors[index] = (mc_dep_cost_base) ? rk / pcs_ptr->r0 + c : c;
+        }
+    }
+
+    return;
+}
+
+static AOM_INLINE void get_quantize_error(MacroblockPlane *p,
+    const TranLow *coeff, TranLow *qcoeff,
+    TranLow *dqcoeff, TxSize tx_size,
+    uint16_t *eob, int64_t *recon_error,
+    int64_t *sse) {
+    const ScanOrder *const scan_order = &av1_scan_orders[tx_size][DCT_DCT]; //&av1_default_scan_orders[tx_size]
+    int pix_num = 1 << num_pels_log2_lookup[txsize_to_bsize[tx_size]];
+    const int shift = tx_size == TX_32X32 ? 0 : 2;
+
+    eb_av1_quantize_fp(coeff, pix_num, p->zbin_qtx, p->round_fp_qtx, p->quant_fp_qtx,
+        p->quant_shift_qtx, qcoeff, dqcoeff, p->dequant_qtx, eob,
+        scan_order->scan, scan_order->iscan);
+
+    *recon_error = svt_av1_block_error(coeff, dqcoeff, pix_num, sse) >> shift;
+    *recon_error = AOMMAX(*recon_error, 1);
+
+    *sse = (*sse) >> shift;
+    *sse = AOMMAX(*sse, 1);
+}
+
+static int rate_estimator(TranLow *qcoeff, int eob, TxSize tx_size) {
+    const ScanOrder *const scan_order = &av1_scan_orders[tx_size][DCT_DCT]; //&av1_default_scan_orders[tx_size]
+
+    assert((1 << num_pels_log2_lookup[txsize_to_bsize[tx_size]]) >= eob);
+
+    int rate_cost = 1;
+
+    for (int idx = 0; idx < eob; ++idx) {
+        int abs_level = abs(qcoeff[scan_order->scan[idx]]);
+        rate_cost += (int)(log1p(abs_level) / log(2.0)) + 1;
+    }
+
+    return (rate_cost << AV1_PROB_COST_SHIFT);
+}
+
+static void result_model_store(PictureParentControlSet *pcs_ptr, TplStats  *tpl_stats_ptr,
+    uint32_t mb_origin_x, uint32_t mb_origin_y) {
+    const int mi_height = mi_size_high[BLOCK_16X16];
+    const int mi_width = mi_size_wide[BLOCK_16X16];
+    const int step = 1 << (pcs_ptr->is_720p_or_larger ? 2 : 1);
+    const int shift = 3 + pcs_ptr->is_720p_or_larger;
+    const int aligned16_width = ((pcs_ptr->aligned_width + 15) / 16) << 4;
+
+    int64_t srcrf_dist = tpl_stats_ptr->srcrf_dist / (mi_height * mi_width);
+    int64_t recrf_dist = tpl_stats_ptr->recrf_dist / (mi_height * mi_width);
+    int64_t srcrf_rate = tpl_stats_ptr->srcrf_rate / (mi_height * mi_width);
+    int64_t recrf_rate = tpl_stats_ptr->recrf_rate / (mi_height * mi_width);
+
+    srcrf_dist = AOMMAX(1, srcrf_dist);
+    recrf_dist = AOMMAX(1, recrf_dist);
+    srcrf_rate = AOMMAX(1, srcrf_rate);
+    recrf_rate = AOMMAX(1, recrf_rate);
+
+    for (int idy = 0; idy < mi_height; idy += step) {
+        TplStats *dst_ptr = pcs_ptr->tpl_stats[((mb_origin_y >> shift) + (idy >> 1)) * (aligned16_width >> shift) + (mb_origin_x >> shift)];
+        for (int idx = 0; idx < mi_width; idx += step) {
+            dst_ptr->srcrf_dist = srcrf_dist;
+            dst_ptr->recrf_dist = recrf_dist;
+            dst_ptr->srcrf_rate = srcrf_rate;
+            dst_ptr->recrf_rate = recrf_rate;
+            dst_ptr->mv = tpl_stats_ptr->mv;
+            dst_ptr->ref_frame_poc = tpl_stats_ptr->ref_frame_poc;
+            ++dst_ptr;
+        }
+    }
+}
+
+static const int16_t dc_qlookup_QTX[QINDEX_RANGE] = {
+  4,    8,    8,    9,    10,  11,  12,  12,  13,  14,  15,   16,   17,   18,
+  19,   19,   20,   21,   22,  23,  24,  25,  26,  26,  27,   28,   29,   30,
+  31,   32,   32,   33,   34,  35,  36,  37,  38,  38,  39,   40,   41,   42,
+  43,   43,   44,   45,   46,  47,  48,  48,  49,  50,  51,   52,   53,   53,
+  54,   55,   56,   57,   57,  58,  59,  60,  61,  62,  62,   63,   64,   65,
+  66,   66,   67,   68,   69,  70,  70,  71,  72,  73,  74,   74,   75,   76,
+  77,   78,   78,   79,   80,  81,  81,  82,  83,  84,  85,   85,   87,   88,
+  90,   92,   93,   95,   96,  98,  99,  101, 102, 104, 105,  107,  108,  110,
+  111,  113,  114,  116,  117, 118, 120, 121, 123, 125, 127,  129,  131,  134,
+  136,  138,  140,  142,  144, 146, 148, 150, 152, 154, 156,  158,  161,  164,
+  166,  169,  172,  174,  177, 180, 182, 185, 187, 190, 192,  195,  199,  202,
+  205,  208,  211,  214,  217, 220, 223, 226, 230, 233, 237,  240,  243,  247,
+  250,  253,  257,  261,  265, 269, 272, 276, 280, 284, 288,  292,  296,  300,
+  304,  309,  313,  317,  322, 326, 330, 335, 340, 344, 349,  354,  359,  364,
+  369,  374,  379,  384,  389, 395, 400, 406, 411, 417, 423,  429,  435,  441,
+  447,  454,  461,  467,  475, 482, 489, 497, 505, 513, 522,  530,  539,  549,
+  559,  569,  579,  590,  602, 614, 626, 640, 654, 668, 684,  700,  717,  736,
+  755,  775,  796,  819,  843, 869, 896, 925, 955, 988, 1022, 1058, 1098, 1139,
+  1184, 1232, 1282, 1336,
+};
+
+static const int16_t dc_qlookup_10_QTX[QINDEX_RANGE] = {
+  4,    9,    10,   13,   15,   17,   20,   22,   25,   28,   31,   34,   37,
+  40,   43,   47,   50,   53,   57,   60,   64,   68,   71,   75,   78,   82,
+  86,   90,   93,   97,   101,  105,  109,  113,  116,  120,  124,  128,  132,
+  136,  140,  143,  147,  151,  155,  159,  163,  166,  170,  174,  178,  182,
+  185,  189,  193,  197,  200,  204,  208,  212,  215,  219,  223,  226,  230,
+  233,  237,  241,  244,  248,  251,  255,  259,  262,  266,  269,  273,  276,
+  280,  283,  287,  290,  293,  297,  300,  304,  307,  310,  314,  317,  321,
+  324,  327,  331,  334,  337,  343,  350,  356,  362,  369,  375,  381,  387,
+  394,  400,  406,  412,  418,  424,  430,  436,  442,  448,  454,  460,  466,
+  472,  478,  484,  490,  499,  507,  516,  525,  533,  542,  550,  559,  567,
+  576,  584,  592,  601,  609,  617,  625,  634,  644,  655,  666,  676,  687,
+  698,  708,  718,  729,  739,  749,  759,  770,  782,  795,  807,  819,  831,
+  844,  856,  868,  880,  891,  906,  920,  933,  947,  961,  975,  988,  1001,
+  1015, 1030, 1045, 1061, 1076, 1090, 1105, 1120, 1137, 1153, 1170, 1186, 1202,
+  1218, 1236, 1253, 1271, 1288, 1306, 1323, 1342, 1361, 1379, 1398, 1416, 1436,
+  1456, 1476, 1496, 1516, 1537, 1559, 1580, 1601, 1624, 1647, 1670, 1692, 1717,
+  1741, 1766, 1791, 1817, 1844, 1871, 1900, 1929, 1958, 1990, 2021, 2054, 2088,
+  2123, 2159, 2197, 2236, 2276, 2319, 2363, 2410, 2458, 2508, 2561, 2616, 2675,
+  2737, 2802, 2871, 2944, 3020, 3102, 3188, 3280, 3375, 3478, 3586, 3702, 3823,
+  3953, 4089, 4236, 4394, 4559, 4737, 4929, 5130, 5347,
+};
+
+static const int16_t dc_qlookup_12_QTX[QINDEX_RANGE] = {
+  4,     12,    18,    25,    33,    41,    50,    60,    70,    80,    91,
+  103,   115,   127,   140,   153,   166,   180,   194,   208,   222,   237,
+  251,   266,   281,   296,   312,   327,   343,   358,   374,   390,   405,
+  421,   437,   453,   469,   484,   500,   516,   532,   548,   564,   580,
+  596,   611,   627,   643,   659,   674,   690,   706,   721,   737,   752,
+  768,   783,   798,   814,   829,   844,   859,   874,   889,   904,   919,
+  934,   949,   964,   978,   993,   1008,  1022,  1037,  1051,  1065,  1080,
+  1094,  1108,  1122,  1136,  1151,  1165,  1179,  1192,  1206,  1220,  1234,
+  1248,  1261,  1275,  1288,  1302,  1315,  1329,  1342,  1368,  1393,  1419,
+  1444,  1469,  1494,  1519,  1544,  1569,  1594,  1618,  1643,  1668,  1692,
+  1717,  1741,  1765,  1789,  1814,  1838,  1862,  1885,  1909,  1933,  1957,
+  1992,  2027,  2061,  2096,  2130,  2165,  2199,  2233,  2267,  2300,  2334,
+  2367,  2400,  2434,  2467,  2499,  2532,  2575,  2618,  2661,  2704,  2746,
+  2788,  2830,  2872,  2913,  2954,  2995,  3036,  3076,  3127,  3177,  3226,
+  3275,  3324,  3373,  3421,  3469,  3517,  3565,  3621,  3677,  3733,  3788,
+  3843,  3897,  3951,  4005,  4058,  4119,  4181,  4241,  4301,  4361,  4420,
+  4479,  4546,  4612,  4677,  4742,  4807,  4871,  4942,  5013,  5083,  5153,
+  5222,  5291,  5367,  5442,  5517,  5591,  5665,  5745,  5825,  5905,  5984,
+  6063,  6149,  6234,  6319,  6404,  6495,  6587,  6678,  6769,  6867,  6966,
+  7064,  7163,  7269,  7376,  7483,  7599,  7715,  7832,  7958,  8085,  8214,
+  8352,  8492,  8635,  8788,  8945,  9104,  9275,  9450,  9639,  9832,  10031,
+  10245, 10465, 10702, 10946, 11210, 11482, 11776, 12081, 12409, 12750, 13118,
+  13501, 13913, 14343, 14807, 15290, 15812, 16356, 16943, 17575, 18237, 18949,
+  19718, 20521, 21387,
+};
+
+int16_t av1_dc_quant_qtx(int qindex, int delta, AomBitDepth bit_depth) {
+    const int q_clamped = clamp(qindex + delta, 0, MAXQ);
+    switch (bit_depth) {
+    case AOM_BITS_8: return dc_qlookup_QTX[q_clamped];
+    case AOM_BITS_10: return dc_qlookup_10_QTX[q_clamped];
+    case AOM_BITS_12: return dc_qlookup_12_QTX[q_clamped];
+    default:
+        assert(0 && "bit_depth should be AOM_BITS_8, AOM_BITS_10 or AOM_BITS_12");
+        return -1;
+    }
+}
+
+int svt_av1_compute_rd_mult_based_on_qindex(AomBitDepth bit_depth, int qindex) {
+    const int q = av1_dc_quant_qtx(qindex, 0, bit_depth);
+    //const int q = eb_av1_dc_quant_Q3(qindex, 0, bit_depth);
+    int rdmult = q * q;
+    rdmult = rdmult * 3 + (rdmult * 2 / 3);
+    switch (bit_depth) {
+    case AOM_BITS_8: break;
+    case AOM_BITS_10: rdmult = ROUND_POWER_OF_TWO(rdmult, 4); break;
+    case AOM_BITS_12: rdmult = ROUND_POWER_OF_TWO(rdmult, 8); break;
+    default:
+        assert(0 && "bit_depth should be AOM_BITS_8, AOM_BITS_10 or AOM_BITS_12");
+        return -1;
+    }
+    return rdmult > 0 ? rdmult : 1;
+}
+
+void eb_av1_set_quantizer(PictureParentControlSet *pcs_ptr, int32_t q);
+void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q, int32_t u_dc_delta_q,
+    int32_t u_ac_delta_q, int32_t v_dc_delta_q, int32_t v_ac_delta_q,
+    Quants *const quants, Dequants *const deq);
+
+#define TPL_DEP_COST_SCALE_LOG2 4
+double eb_av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
+int32_t eb_av1_compute_qdelta(double qstart, double qtarget, AomBitDepth bit_depth);
+extern void filter_intra_edge(OisMbResults *ois_mb_results_ptr, uint8_t mode, uint16_t max_frame_width, uint16_t max_frame_height,
+    int32_t p_angle, int32_t cu_origin_x, int32_t cu_origin_y, uint8_t *above_row, uint8_t *left_col);
+
+//Given one reference frame identified by the pair (list_index,ref_index)
+//indicate if ME data is valid
+static uint8_t is_me_data_valid(
+    const MeSbResults           *me_results,
+    uint32_t                     me_mb_offset,
+    uint8_t                      list_idx,
+    uint8_t                      ref_idx) {
+
+    uint8_t total_me_cnt = me_results->total_me_candidate_index[me_mb_offset];
+    const MeCandidate *me_block_results = &me_results->me_candidate_array[me_mb_offset*MAX_PA_ME_CAND];
+
+    for (uint32_t me_cand_i = 0; me_cand_i < total_me_cnt; ++me_cand_i) {
+        const MeCandidate *me_cand = &me_block_results[me_cand_i];
+        assert(/*me_cand->direction >= 0 && */me_cand->direction <= 2);
+        if (me_cand->direction == 0 || me_cand->direction == 2) {
+            if (list_idx == me_cand->ref0_list && ref_idx == me_cand->ref_idx_l0)
+                return 1;
+        }
+        if (me_cand->direction == 1 || me_cand->direction == 2) {
+            if (list_idx == me_cand->ref1_list && ref_idx == me_cand->ref_idx_l1)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+/************************************************
+* Genrate TPL MC Flow Dispenser  Based on Lookahead
+** LAD Window: sliding window size
+************************************************/
+void tpl_mc_flow_dispenser(
+    EncodeContext                   *encode_context_ptr,
+    SequenceControlSet              *scs_ptr,
+    PictureParentControlSet         *pcs_ptr,
+    int32_t                          frame_idx)
+{
+    uint32_t    picture_width_in_sb = (pcs_ptr->enhanced_picture_ptr->width + BLOCK_SIZE_64 - 1) / BLOCK_SIZE_64;
+    uint32_t    picture_width_in_mb = (pcs_ptr->enhanced_picture_ptr->width + 16 - 1) / 16;
+    uint32_t    picture_height_in_sb = (pcs_ptr->enhanced_picture_ptr->height + BLOCK_SIZE_64 - 1) / BLOCK_SIZE_64;
+    int16_t     x_curr_mv = 0;
+    int16_t     y_curr_mv = 0;
+    uint32_t    me_mb_offset = 0;
+    TxSize      tx_size = TX_16X16;
+    EbPictureBufferDesc  *ref_pic_ptr;
+    struct      ScaleFactors sf;
+    BlockGeom   blk_geom;
+    uint32_t    kernel = (EIGHTTAP_REGULAR << 16) | EIGHTTAP_REGULAR;
+    EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+    EbPictureBufferDesc *recon_picture_ptr = encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx];
+    TplStats  tpl_stats;
+
+    DECLARE_ALIGNED(32, uint8_t, predictor8[256 * 2]);
+    DECLARE_ALIGNED(32, int16_t, src_diff[256]);
+    DECLARE_ALIGNED(32, TranLow, coeff[256]);
+    DECLARE_ALIGNED(32, TranLow, qcoeff[256]);
+    DECLARE_ALIGNED(32, TranLow, dqcoeff[256]);
+    DECLARE_ALIGNED(32, TranLow, best_coeff[256]);
+    uint8_t *predictor = predictor8;
+
+    blk_geom.bwidth = 16;
+    blk_geom.bheight = 16;
+
+    eb_av1_setup_scale_factors_for_frame(
+        &sf, picture_width_in_sb * BLOCK_SIZE_64,
+        picture_height_in_sb * BLOCK_SIZE_64,
+        picture_width_in_sb * BLOCK_SIZE_64,
+        picture_height_in_sb * BLOCK_SIZE_64);
+
+    MacroblockPlane mb_plane;
+    int32_t qIndex = quantizer_to_qindex[(uint8_t)scs_ptr->static_config.qp];
+
+    const  double delta_rate_new[7][6] =
+    {
+        { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 }, // 1L
+        { 0.6, 1.0, 1.0, 1.0, 1.0, 1.0 }, // 2L
+        { 0.6, 0.8, 1.0, 1.0, 1.0, 1.0 }, // 3L
+        { 0.6 , 0.8, 0.9, 1.0, 1.0, 1.0 }, // 4L
+        { 0.35, 0.6, 0.8,  0.9, 1.0, 1.0},  //5L
+        { 0.35, 0.6, 0.8,  0.9, 0.95, 1.0}  //6L
+    };
+    double q_val;  q_val = eb_av1_convert_qindex_to_q(qIndex, 8);
+    int32_t delta_qindex;
+#if ENABLE_TPL_TRAILING
+    if (pcs_ptr->tpl_data.tpl_slice_type == I_SLICE)
+#else
+    if (pcs_ptr->slice_type == I_SLICE)
+#endif
+        delta_qindex = eb_av1_compute_qdelta(
+            q_val,
+            q_val * 0.25,
+            8);
+    else
+        delta_qindex = eb_av1_compute_qdelta(
+            q_val,
+#if ENABLE_TPL_TRAILING
+            q_val * delta_rate_new[pcs_ptr->hierarchical_levels]
+            [pcs_ptr->tpl_data.tpl_temporal_layer_index],
+#else
+            q_val * delta_rate_new[pcs_ptr->hierarchical_levels]
+            [pcs_ptr->temporal_layer_index],
+#endif
+            8);
+    qIndex =
+        (qIndex + delta_qindex);
+#if FIX_OPTIMIZE_BUILD_QUANTIZER
+    mb_plane.quant_qtx = scs_ptr->quants_8bit.y_quant[qIndex];
+    mb_plane.quant_fp_qtx = scs_ptr->quants_8bit.y_quant_fp[qIndex];
+    mb_plane.round_fp_qtx = scs_ptr->quants_8bit.y_round_fp[qIndex];
+    mb_plane.quant_shift_qtx = scs_ptr->quants_8bit.y_quant_shift[qIndex];
+    mb_plane.zbin_qtx = scs_ptr->quants_8bit.y_zbin[qIndex];
+    mb_plane.round_qtx = scs_ptr->quants_8bit.y_round[qIndex];
+    mb_plane.dequant_qtx = scs_ptr->deq_8bit.y_dequant_qtx[qIndex];
+#else
+    Quants *const quants_bd = &pcs_ptr->quants_bd;
+    Dequants *const deq_bd = &pcs_ptr->deq_bd;
+    eb_av1_set_quantizer(
+        pcs_ptr,
+        pcs_ptr->frm_hdr.quantization_params.base_q_idx);
+    eb_av1_build_quantizer(
+        /*pcs_ptr->hbd_mode_decision ? AOM_BITS_10 :*/ AOM_BITS_8,
+        pcs_ptr->frm_hdr.quantization_params.delta_q_dc[AOM_PLANE_Y],
+        pcs_ptr->frm_hdr.quantization_params.delta_q_dc[AOM_PLANE_U],
+        pcs_ptr->frm_hdr.quantization_params.delta_q_ac[AOM_PLANE_U],
+        pcs_ptr->frm_hdr.quantization_params.delta_q_dc[AOM_PLANE_V],
+        pcs_ptr->frm_hdr.quantization_params.delta_q_ac[AOM_PLANE_V],
+        quants_bd,
+        deq_bd);
+    mb_plane.quant_qtx = pcs_ptr->quants_bd.y_quant[qIndex];
+    mb_plane.quant_fp_qtx = pcs_ptr->quants_bd.y_quant_fp[qIndex];
+    mb_plane.round_fp_qtx = pcs_ptr->quants_bd.y_round_fp[qIndex];
+    mb_plane.quant_shift_qtx = pcs_ptr->quants_bd.y_quant_shift[qIndex];
+    mb_plane.zbin_qtx = pcs_ptr->quants_bd.y_zbin[qIndex];
+    mb_plane.round_qtx = pcs_ptr->quants_bd.y_round[qIndex];
+    mb_plane.dequant_qtx = pcs_ptr->deq_bd.y_dequant_qtx[qIndex];
+#endif
+    pcs_ptr->base_rdmult = svt_av1_compute_rd_mult_based_on_qindex((AomBitDepth)8/*scs_ptr->static_config.encoder_bit_depth*/, qIndex) / 6;
+#if TUNE_TPL_OIS
+    DECLARE_ALIGNED(16, uint8_t, left0_data[MAX_TX_SIZE * 2 + 32]);
+    DECLARE_ALIGNED(16, uint8_t, above0_data[MAX_TX_SIZE * 2 + 32]);
+    DECLARE_ALIGNED(16, uint8_t, left_data[MAX_TX_SIZE * 2 + 32]);
+    DECLARE_ALIGNED(16, uint8_t, above_data[MAX_TX_SIZE * 2 + 32]);
+
+    EbPictureBufferDesc *input_ptr =  pcs_ptr->enhanced_picture_ptr;
+    uint8_t *above_row;
+    uint8_t *left_col;
+    uint8_t *above0_row;
+    uint8_t *left0_col;
+#endif
+    // Walk the first N entries in the sliding window
+    for (uint32_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
+        {
+            SbParams *sb_params = &scs_ptr->sb_params_array[sb_index];
+            uint32_t pa_blk_index = 0;
+            while (pa_blk_index < CU_MAX_COUNT) {
+                const CodedBlockStats *blk_stats_ptr;
+                blk_stats_ptr = get_coded_blk_stats(pa_blk_index);
+                uint8_t bsize = blk_stats_ptr->size;
+                EbBool small_boundary_blk = EB_FALSE;
+
+                //if(sb_params->raster_scan_blk_validity[md_scan_to_raster_scan[pa_blk_index]])
+                {
+                    uint32_t cu_origin_x = sb_params->origin_x + blk_stats_ptr->origin_x;
+                    uint32_t cu_origin_y = sb_params->origin_y + blk_stats_ptr->origin_y;
+                    if ((blk_stats_ptr->origin_x % 16) == 0 && (blk_stats_ptr->origin_y % 16) == 0 &&
+                        ((pcs_ptr->enhanced_picture_ptr->width - cu_origin_x) < 16 || (pcs_ptr->enhanced_picture_ptr->height - cu_origin_y) < 16))
+                        small_boundary_blk = EB_TRUE;
+                }
+                if (bsize != 16 && !small_boundary_blk) {
+                    pa_blk_index++;
+                    continue;
+                }
+                if (sb_params->raster_scan_blk_validity[md_scan_to_raster_scan[pa_blk_index]]) {
+                    uint32_t mb_origin_x = sb_params->origin_x + blk_stats_ptr->origin_x;
+                    uint32_t mb_origin_y = sb_params->origin_y + blk_stats_ptr->origin_y;
+                    const int dst_buffer_stride = recon_picture_ptr->stride_y;
+                    const int dst_mb_offset = mb_origin_y * dst_buffer_stride + mb_origin_x;
+                    const int dst_basic_offset = recon_picture_ptr->origin_y * recon_picture_ptr->stride_y + recon_picture_ptr->origin_x;
+                    uint8_t *dst_buffer = recon_picture_ptr->buffer_y + dst_basic_offset + dst_mb_offset;
+
+                    int64_t inter_cost;
+                    int64_t recon_error = 1, sse = 1;
+                    uint64_t best_ref_poc = 0;
+                    int32_t best_rf_idx = -1;
+                    int64_t best_inter_cost = INT64_MAX;
+                    MV final_best_mv = { 0, 0 };
+                    uint32_t max_inter_ref = MAX_PA_ME_MV;
+#if !TUNE_TPL_OIS
+                    OisMbResults *ois_mb_results_ptr = pcs_ptr->ois_mb_results[(mb_origin_y >> 4) * picture_width_in_mb + (mb_origin_x >> 4)];
+                    int64_t best_intra_cost = ois_mb_results_ptr->intra_cost;
+#else
+
+                    PredictionMode best_intra_mode = DC_PRED;
+                    int64_t        best_intra_cost = INT64_MAX;
+                    if (scs_ptr->in_loop_ois == 0) {
+                        OisMbResults *ois_mb_results_ptr = pcs_ptr->ois_mb_results[(mb_origin_y >> 4) * picture_width_in_mb + (mb_origin_x >> 4)];
+                        best_intra_mode       = ois_mb_results_ptr->intra_mode;
+                        best_intra_cost       = ois_mb_results_ptr->intra_cost;
+
+                    }
+                    else { // ois
+                        // always process as block16x16 even bsize or tx_size is 8x8
+                        TxSize tx_size = TX_16X16;
+                        bsize = 16;
+
+                        above0_row = above0_data + 16;
+                        left0_col = left0_data + 16;
+                        above_row = above_data + 16;
+                        left_col = left_data + 16;
+
+
+                        uint8_t *src = input_ptr->buffer_y + pcs_ptr->enhanced_picture_ptr->origin_x + mb_origin_x +
+                                       (pcs_ptr->enhanced_picture_ptr->origin_y + mb_origin_y) * input_ptr->stride_y;
+
+                        // Fill Neighbor Arrays
+                        update_neighbor_samples_array_open_loop_mb(above0_row - 1, left0_col - 1,
+                                                                   input_ptr, input_ptr->stride_y, mb_origin_x, mb_origin_y, bsize, bsize);
+                        uint8_t ois_intra_mode;
+                        uint8_t intra_mode_start = DC_PRED;
+                        EbBool   enable_paeth                = pcs_ptr->scs_ptr->static_config.enable_paeth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_paeth;
+                        EbBool   enable_smooth               = pcs_ptr->scs_ptr->static_config.enable_smooth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_smooth;
+                        uint8_t intra_mode_end =
+#if FIX_TPL_TRAILING_FRAME_BUG
+                            pcs_ptr->tpl_data.tpl_opt_flag
+#else
+                            pcs_ptr->tpl_opt_flag
+#endif
+                                ? DC_PRED
+                                : enable_paeth ? PAETH_PRED : enable_smooth ? SMOOTH_H_PRED : D67_PRED;
+
+                        for (ois_intra_mode = intra_mode_start; ois_intra_mode <= intra_mode_end; ++ois_intra_mode) {
+                            int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
+                            // Edge filter
+                            if(av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
+                                EB_MEMCPY(left_data,  left0_data,  sizeof(uint8_t)*(MAX_TX_SIZE * 2 + 32));
+                                EB_MEMCPY(above_data, above0_data, sizeof(uint8_t)*(MAX_TX_SIZE * 2 + 32));
+                                above_row = above_data + 16;
+                                left_col  = left_data + 16;
+                                filter_intra_edge(NULL, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, (int32_t)mb_origin_x, (int32_t)mb_origin_y, above_row, left_col);
+                            } else {
+                                above_row = above0_row;
+                                left_col  = left0_col;
+                            }
+                            // PRED
+                            intra_prediction_open_loop_mb(p_angle, ois_intra_mode,mb_origin_x, mb_origin_y, tx_size, above_row, left_col, predictor, 16);
+
+                            // Distortion
+                            eb_aom_subtract_block(16, 16, src_diff, 16, src, input_ptr->stride_y, predictor, 16);
+                            svt_av1_wht_fwd_txfm(src_diff, 16, coeff, 2/*TX_16X16*/, 8, 0);
+                            int64_t intra_cost = svt_aom_satd(coeff, 16 * 16);
+
+                            if (intra_cost < best_intra_cost) {
+                                best_intra_cost = intra_cost;
+                                best_intra_mode = ois_intra_mode;
+                            }
+                        }
+                }
+#endif
+
+                    uint8_t best_mode = DC_PRED;
+                    uint8_t *src_mb = input_picture_ptr->buffer_y + input_picture_ptr->origin_x + mb_origin_x +
+                        (input_picture_ptr->origin_y + mb_origin_y) * input_picture_ptr->stride_y;
+                    memset(&tpl_stats, 0, sizeof(tpl_stats));
+                    blk_geom.origin_x = blk_stats_ptr->origin_x;
+                    blk_geom.origin_y = blk_stats_ptr->origin_y;
+                    me_mb_offset = get_me_info_index(pcs_ptr->max_number_of_pus_per_sb, &blk_geom, 0, 0);
+                    for (uint32_t rf_idx = 0; rf_idx < max_inter_ref; rf_idx++) {
+                        uint32_t list_index = rf_idx < 4 ? 0 : 1;
+                        uint32_t ref_pic_index = rf_idx >= 4 ? (rf_idx - 4) : rf_idx;
+#if TUNE_INL_TPL_ENHANCEMENT
+                        if ((list_index == 0 && (ref_pic_index + 1) > pcs_ptr->tpl_data.tpl_ref0_count) ||
+                            (list_index == 1 && (ref_pic_index + 1) > pcs_ptr->tpl_data.tpl_ref1_count))
+                            continue;
+#else
+                        if ((list_index == 0 && (ref_pic_index + 1) > pcs_ptr->tpl_ref0_count) ||
+                            (list_index == 1 && (ref_pic_index + 1) > pcs_ptr->tpl_ref1_count))
+                            continue;
+#endif
+                        if (!is_me_data_valid(pcs_ptr->pa_me_data->me_results[sb_index], me_mb_offset, list_index, ref_pic_index))
+                            continue;
+#if TUNE_INL_TPL_ENHANCEMENT
+                        ref_pic_ptr = (EbPictureBufferDesc*)pcs_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_ptr;
+#else
+                        ref_pic_ptr = (EbPictureBufferDesc*)pcs_ptr->tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_ptr;
+#endif
+
+                        const int ref_basic_offset = ref_pic_ptr->origin_y * ref_pic_ptr->stride_y + ref_pic_ptr->origin_x;
+                        const int ref_mb_offset = mb_origin_y * ref_pic_ptr->stride_y + mb_origin_x;
+                        uint8_t *ref_mb = ref_pic_ptr->buffer_y + ref_basic_offset + ref_mb_offset;
+
+                        struct Buf2D ref_buf = { NULL, ref_pic_ptr->buffer_y + ref_basic_offset,
+                                                  ref_pic_ptr->width, ref_pic_ptr->height,
+                                                  ref_pic_ptr->stride_y };
+                        const MeSbResults *me_results = pcs_ptr->pa_me_data->me_results[sb_index];
+                        x_curr_mv = me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].x_mv << 1;
+                        y_curr_mv = me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].y_mv << 1;
+                        InterPredParams inter_pred_params;
+                        svt_av1_init_inter_params(&inter_pred_params, 16, 16, mb_origin_y,
+                            mb_origin_x, 0, 0, 8, 0, 0,
+                            &sf, &ref_buf, kernel);
+
+                        inter_pred_params.conv_params = get_conv_params(0, 0, 0, 8);
+
+                        MV best_mv = { y_curr_mv, x_curr_mv };
+                        av1_build_inter_predictor(pcs_ptr->av1_cm,
+                            ref_mb,
+                            ref_pic_ptr->stride_y,
+                            predictor,
+                            16,
+                            &best_mv,
+                            mb_origin_x,
+                            mb_origin_y,
+                            &inter_pred_params);
+                        eb_aom_subtract_block(16, 16, src_diff, 16, src_mb, input_picture_ptr->stride_y, predictor, 16);
+
+                        svt_av1_wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
+
+                        inter_cost = svt_aom_satd(coeff, 256);
+                        if (inter_cost < best_inter_cost) {
+                            memcpy(best_coeff, coeff, sizeof(best_coeff));
+#if TUNE_INL_TPL_ENHANCEMENT
+                            best_ref_poc = pcs_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_number;
+#else
+                            best_ref_poc = pcs_ptr->tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_number;
+#endif
+
+                            best_rf_idx = rf_idx;
+                            best_inter_cost = inter_cost;
+                            final_best_mv = best_mv;
+
+                            if (best_inter_cost < best_intra_cost) best_mode = NEWMV;
+                        }
+                    } // rf_idx
+                    if (best_inter_cost < INT64_MAX) {
+                        uint16_t eob = 0;
+                        get_quantize_error(&mb_plane, best_coeff, qcoeff, dqcoeff, tx_size, &eob, &recon_error, &sse);
+#if FIX_TPL_TRAILING_FRAME_BUG
+                        int rate_cost = pcs_ptr->tpl_data.tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
+#else
+                        int rate_cost = pcs_ptr->tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
+#endif
+                        tpl_stats.srcrf_rate = rate_cost << TPL_DEP_COST_SCALE_LOG2;
+                    }
+                    best_intra_cost = AOMMAX(best_intra_cost, 1);
+#if ENABLE_TPL_TRAILING
+                    if (pcs_ptr->tpl_data.tpl_slice_type == I_SLICE)
+#else
+                    if (frame_is_intra_only(pcs_ptr))
+#endif
+                        best_inter_cost = 0;
+                    else
+                        best_inter_cost = AOMMIN(best_intra_cost, best_inter_cost);
+
+                    tpl_stats.srcrf_dist = recon_error << (TPL_DEP_COST_SCALE_LOG2);
+
+                    if (best_mode == NEWMV) {
+                        // inter recon with rec_picture as reference pic
+                        uint64_t ref_poc = best_ref_poc;
+                        uint32_t ref_frame_idx = 0;
+                        uint32_t list_index = best_rf_idx < 4 ? 0 : 1;
+                        uint32_t ref_pic_index = best_rf_idx >= 4 ? (best_rf_idx - 4) : best_rf_idx;
+#if TUNE_INL_TPL_ENHANCEMENT
+                        if (pcs_ptr->tpl_data.ref_in_slide_window[list_index][ref_pic_index]) {
+#else
+                        if (pcs_ptr->ref_in_slide_window[list_index][ref_pic_index]) {
+#endif
+                            while (ref_frame_idx < MAX_TPL_LA_SW && encode_context_ptr->poc_map_idx[ref_frame_idx] != ref_poc)
+                                ref_frame_idx++;
+                            assert(ref_frame_idx != MAX_TPL_LA_SW);
+                            ref_pic_ptr = encode_context_ptr->mc_flow_rec_picture_buffer[ref_frame_idx];
+                        }
+                        else
+#if TUNE_INL_TPL_ENHANCEMENT
+                            ref_pic_ptr = (EbPictureBufferDesc*)pcs_ptr->tpl_data.tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_ptr;
+#else
+                            ref_pic_ptr = (EbPictureBufferDesc*)pcs_ptr->tpl_ref_ds_ptr_array[list_index][ref_pic_index].picture_ptr;
+#endif
+
+                        const int ref_basic_offset = ref_pic_ptr->origin_y * ref_pic_ptr->stride_y + ref_pic_ptr->origin_x;
+                        const int ref_mb_offset = mb_origin_y * ref_pic_ptr->stride_y + mb_origin_x;
+                        uint8_t *ref_mb = ref_pic_ptr->buffer_y + ref_basic_offset + ref_mb_offset;
+
+                        struct Buf2D ref_buf = { NULL, ref_pic_ptr->buffer_y + ref_basic_offset,
+                                                  ref_pic_ptr->width, ref_pic_ptr->height,
+                                                  ref_pic_ptr->stride_y };
+
+                        InterPredParams inter_pred_params;
+                        svt_av1_init_inter_params(&inter_pred_params, 16, 16, mb_origin_y,
+                            mb_origin_x, 0, 0, 8, 0, 0,
+                            &sf, &ref_buf, kernel);
+
+                        inter_pred_params.conv_params = get_conv_params(0, 0, 0, 8);
+                        av1_build_inter_predictor(pcs_ptr->av1_cm,
+                            ref_mb,
+                            ref_pic_ptr->stride_y,
+                            dst_buffer,
+                            dst_buffer_stride,
+                            &final_best_mv,
+                            mb_origin_x,
+                            mb_origin_y,
+                            &inter_pred_params);
+                    }
+                    else {
+                        // intra recon
+                        uint8_t *above_row;
+                        uint8_t *left_col;
+                        DECLARE_ALIGNED(16, uint8_t, left_data[MAX_TX_SIZE * 2 + 32]);
+                        DECLARE_ALIGNED(16, uint8_t, above_data[MAX_TX_SIZE * 2 + 32]);
+
+                        above_row = above_data + 16;
+                        left_col = left_data + 16;
+                        TxSize tx_size = TX_16X16;
+                        uint8_t *recon_buffer =
+                            recon_picture_ptr->buffer_y + dst_basic_offset;
+
+                        update_neighbor_samples_array_open_loop_mb_recon(above_row - 1,
+                            left_col - 1,
+                            recon_buffer,
+                            dst_buffer_stride,
+                            mb_origin_x,
+                            mb_origin_y,
+                            16,
+                            16,
+                            input_picture_ptr->width,
+                            input_picture_ptr->height);
+#if TUNE_TPL_OIS
+                        uint8_t ois_intra_mode = best_intra_mode;// ois_mb_results_ptr->intra_mode;
+                        int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
+                        // Edge filter
+                        if (av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
+                            filter_intra_edge(NULL, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, mb_origin_x, mb_origin_y, above_row, left_col);
+                        }
+#else
+                        uint8_t ois_intra_mode = ois_mb_results_ptr->intra_mode;
+                        int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
+                        // Edge filter
+                        if (av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
+                            filter_intra_edge(ois_mb_results_ptr, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, mb_origin_x, mb_origin_y, above_row, left_col);
+                        }
+#endif
+                        // PRED
+                        intra_prediction_open_loop_mb(p_angle, ois_intra_mode, mb_origin_x, mb_origin_y, tx_size, above_row, left_col, dst_buffer, dst_buffer_stride);
+                    }
+
+                    eb_aom_subtract_block(16, 16, src_diff, 16, src_mb, input_picture_ptr->stride_y, dst_buffer, dst_buffer_stride);
+                    svt_av1_wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
+
+                    uint16_t eob = 0;
+
+                    get_quantize_error(&mb_plane, coeff, qcoeff, dqcoeff, tx_size, &eob, &recon_error, &sse);
+
+#if FIX_TPL_TRAILING_FRAME_BUG
+                    int rate_cost = pcs_ptr->tpl_data.tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
+#else
+                    int rate_cost = pcs_ptr->tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
+#endif
+
+                    if (eob) {
+                        av1_inv_transform_recon8bit((int32_t*)dqcoeff, dst_buffer, dst_buffer_stride, dst_buffer, dst_buffer_stride, TX_16X16, DCT_DCT, PLANE_TYPE_Y, eob, 0);
+                    }
+
+                    tpl_stats.recrf_dist = recon_error << (TPL_DEP_COST_SCALE_LOG2);
+                    tpl_stats.recrf_rate = rate_cost << TPL_DEP_COST_SCALE_LOG2;
+                    if (best_mode != NEWMV) {
+                        tpl_stats.srcrf_dist = recon_error << (TPL_DEP_COST_SCALE_LOG2);
+                        tpl_stats.srcrf_rate = rate_cost << TPL_DEP_COST_SCALE_LOG2;
+                    }
+                    tpl_stats.recrf_dist = AOMMAX(tpl_stats.srcrf_dist, tpl_stats.recrf_dist);
+                    tpl_stats.recrf_rate = AOMMAX(tpl_stats.srcrf_rate, tpl_stats.recrf_rate);
+#if ENABLE_TPL_TRAILING
+                    if (pcs_ptr->tpl_data.tpl_slice_type != I_SLICE && best_rf_idx != -1) {
+#else
+                    if (!frame_is_intra_only(pcs_ptr) && best_rf_idx != -1) {
+#endif
+                        tpl_stats.mv = final_best_mv;
+                        tpl_stats.ref_frame_poc = best_ref_poc;
+                    }
+                    // Motion flow dependency dispenser.
+                    result_model_store(pcs_ptr, &tpl_stats, mb_origin_x, mb_origin_y);
+                }
+                pa_blk_index++;
+            }
+        }
+    }
+
+    // padding current recon picture
+    generate_padding(
+        recon_picture_ptr->buffer_y,
+        recon_picture_ptr->stride_y,
+        recon_picture_ptr->width,
+        recon_picture_ptr->height,
+        recon_picture_ptr->origin_x,
+        recon_picture_ptr->origin_y);
+
+    return;
+}
+
+
+static int get_overlap_area(int grid_pos_row, int grid_pos_col, int ref_pos_row,
+    int ref_pos_col, int block, int/*BLOCK_SIZE*/ bsize) {
+    int width = 0, height = 0;
+    int bw = 4 << mi_size_wide_log2[bsize];
+    int bh = 4 << mi_size_high_log2[bsize];
+
+    switch (block) {
+    case 0:
+        width = grid_pos_col + bw - ref_pos_col;
+        height = grid_pos_row + bh - ref_pos_row;
+        break;
+    case 1:
+        width = ref_pos_col + bw - grid_pos_col;
+        height = grid_pos_row + bh - ref_pos_row;
+        break;
+    case 2:
+        width = grid_pos_col + bw - ref_pos_col;
+        height = ref_pos_row + bh - grid_pos_row;
+        break;
+    case 3:
+        width = ref_pos_col + bw - grid_pos_col;
+        height = ref_pos_row + bh - grid_pos_row;
+        break;
+    default: assert(0);
+    }
+
+    return width * height;
+}
+
+static int round_floor(int ref_pos, int bsize_pix) {
+    int round;
+    if (ref_pos < 0)
+        round = -(1 + (-ref_pos - 1) / bsize_pix);
+    else
+        round = ref_pos / bsize_pix;
+
+    return round;
+}
+
+static int64_t delta_rate_cost(int64_t delta_rate, int64_t recrf_dist,
+    int64_t srcrf_dist, int pix_num) {
+    double beta = (double)srcrf_dist / recrf_dist;
+    int64_t rate_cost = delta_rate;
+
+    if (srcrf_dist <= 128) return rate_cost;
+
+    double dr =
+        (double)(delta_rate >> (TPL_DEP_COST_SCALE_LOG2 + AV1_PROB_COST_SHIFT)) /
+        pix_num;
+
+    double log_den = log(beta) / log(2.0) + 2.0 * dr;
+
+    if (log_den > log(10.0) / log(2.0)) {
+        rate_cost = (int64_t)((log(1.0 / beta) * pix_num) / log(2.0) / 2.0);
+        rate_cost <<= (TPL_DEP_COST_SCALE_LOG2 + AV1_PROB_COST_SHIFT);
+        return rate_cost;
+    }
+
+    double num = pow(2.0, log_den);
+    double den = num * beta + (1 - beta) * beta;
+
+    rate_cost = (int64_t)((pix_num * log(num / den)) / log(2.0) / 2.0);
+
+    rate_cost <<= (TPL_DEP_COST_SCALE_LOG2 + AV1_PROB_COST_SHIFT);
+
+    return rate_cost;
+}
+
+static AOM_INLINE void tpl_model_update_b(PictureParentControlSet *ref_pcs_ptr, PictureParentControlSet *pcs_ptr,
+    TplStats *tpl_stats_ptr,
+    int mi_row, int mi_col,
+    const int/*BLOCK_SIZE*/ bsize) {
+    Av1Common *ref_cm = ref_pcs_ptr->av1_cm;
+    TplStats *ref_tpl_stats_ptr;
+
+    const FULLPEL_MV full_mv = get_fullmv_from_mv(&tpl_stats_ptr->mv);
+    const int ref_pos_row = mi_row * MI_SIZE + full_mv.row;
+    const int ref_pos_col = mi_col * MI_SIZE + full_mv.col;
+
+    const int bw = 4 << mi_size_wide_log2[bsize];
+    const int bh = 4 << mi_size_high_log2[bsize];
+    const int mi_height = mi_size_high[bsize];
+    const int mi_width = mi_size_wide[bsize];
+    const int pix_num = bw * bh;
+    const int shift = pcs_ptr->is_720p_or_larger ? 2 : 1;
+    const int mi_cols_sr = ((ref_pcs_ptr->aligned_width + 15) / 16) << 2;
+
+    // top-left on grid block location in pixel
+    int grid_pos_row_base = round_floor(ref_pos_row, bh) * bh;
+    int grid_pos_col_base = round_floor(ref_pos_col, bw) * bw;
+    int block;
+
+    int64_t cur_dep_dist = tpl_stats_ptr->recrf_dist - tpl_stats_ptr->srcrf_dist;
+    int64_t mc_dep_dist = (int64_t)(
+        tpl_stats_ptr->mc_dep_dist *
+        ((double)(tpl_stats_ptr->recrf_dist - tpl_stats_ptr->srcrf_dist) /
+            tpl_stats_ptr->recrf_dist));
+    int64_t delta_rate = tpl_stats_ptr->recrf_rate - tpl_stats_ptr->srcrf_rate;
+#if TUNE_TPL_RATE
+    int64_t mc_dep_rate = pcs_ptr->tpl_data.tpl_opt_flag ? 0 :
+        delta_rate_cost(tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->recrf_dist,
+            tpl_stats_ptr->srcrf_dist, pix_num);
+#else
+    int64_t mc_dep_rate =
+        delta_rate_cost(tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->recrf_dist,
+            tpl_stats_ptr->srcrf_dist, pix_num);
+#endif
+
+    for (block = 0; block < 4; ++block) {
+        int grid_pos_row = grid_pos_row_base + bh * (block >> 1);
+        int grid_pos_col = grid_pos_col_base + bw * (block & 0x01);
+
+        if (grid_pos_row >= 0 && grid_pos_row < ref_cm->mi_rows * MI_SIZE &&
+            grid_pos_col >= 0 && grid_pos_col < ref_cm->mi_cols * MI_SIZE) {
+            int overlap_area = get_overlap_area(
+                grid_pos_row, grid_pos_col, ref_pos_row, ref_pos_col, block, bsize);
+            int ref_mi_row = round_floor(grid_pos_row, bh) * mi_height;
+            int ref_mi_col = round_floor(grid_pos_col, bw) * mi_width;
+            const int step = 1 << (pcs_ptr->is_720p_or_larger ? 2 : 1);
+
+            for (int idy = 0; idy < mi_height; idy += step) {
+                for (int idx = 0; idx < mi_width; idx += step) {
+                    ref_tpl_stats_ptr = ref_pcs_ptr->tpl_stats[((ref_mi_row + idy) >> shift) * (mi_cols_sr >> shift) + ((ref_mi_col + idx) >> shift)];
+                    ref_tpl_stats_ptr->mc_dep_dist +=
+                        ((cur_dep_dist + mc_dep_dist) * overlap_area) / pix_num;
+                    ref_tpl_stats_ptr->mc_dep_rate +=
+                        ((delta_rate + mc_dep_rate) * overlap_area) / pix_num;
+                    assert(overlap_area >= 0);
+                }
+            }
+        }
+    }
+}
+
+static AOM_INLINE void tpl_model_update(PictureParentControlSet *pcs_array[MAX_TPL_LA_SW], int32_t frame_idx, int mi_row, int mi_col, const int/*BLOCK_SIZE*/ bsize, uint8_t frames_in_sw) {
+    const int mi_height = mi_size_high[bsize];
+    const int mi_width = mi_size_wide[bsize];
+    PictureParentControlSet *pcs_ptr = pcs_array[frame_idx];
+    const int/*BLOCK_SIZE*/ block_size = pcs_ptr->is_720p_or_larger ? BLOCK_16X16 : BLOCK_8X8;
+    const int step = 1 << (pcs_ptr->is_720p_or_larger ? 2 : 1);
+    const int shift = pcs_ptr->is_720p_or_larger ? 2 : 1;
+    const int mi_cols_sr = ((pcs_ptr->aligned_width + 15) / 16) << 2;
+    int i = 0;
+
+    for (int idy = 0; idy < mi_height; idy += step) {
+        for (int idx = 0; idx < mi_width; idx += step) {
+            TplStats *tpl_stats_ptr = pcs_ptr->tpl_stats[(((mi_row + idy) >> shift) * (mi_cols_sr >> shift)) + ((mi_col + idx) >> shift)];
+
+            while (i < frames_in_sw && pcs_array[i]->picture_number != tpl_stats_ptr->ref_frame_poc)
+                i++;
+            if (i < frames_in_sw)
+                tpl_model_update_b(pcs_array[i], pcs_ptr, tpl_stats_ptr, mi_row + idy, mi_col + idx, block_size);
+        }
+    }
+}
+
+/************************************************
+* Genrate TPL MC Flow Synthesizer Based on Lookahead
+** LAD Window: sliding window size
+************************************************/
+void tpl_mc_flow_synthesizer(
+    PictureParentControlSet         *pcs_array[MAX_TPL_LA_SW],
+    int32_t                          frame_idx,
+    uint8_t                          frames_in_sw)
+{
+    Av1Common *cm = pcs_array[frame_idx]->av1_cm;
+    const int/*BLOCK_SIZE*/ bsize = BLOCK_16X16;
+    const int mi_height = mi_size_high[bsize];
+    const int mi_width = mi_size_wide[bsize];
+
+    for (int mi_row = 0; mi_row < cm->mi_rows; mi_row += mi_height) {
+        for (int mi_col = 0; mi_col < cm->mi_cols; mi_col += mi_width) {
+            tpl_model_update(pcs_array, frame_idx, mi_row, mi_col, bsize, frames_in_sw);
+        }
+    }
+    return;
+}
+
+static void generate_r0beta(PictureParentControlSet *pcs_ptr)
+{
+    Av1Common *cm = pcs_ptr->av1_cm;
+    SequenceControlSet *scs_ptr = pcs_ptr->scs_ptr;
+    int64_t intra_cost_base = 0;
+    int64_t mc_dep_cost_base = 0;
+    const int step = 1 << (pcs_ptr->is_720p_or_larger ? 2 : 1);
+    const int mi_cols_sr = ((pcs_ptr->aligned_width + 15) / 16) << 2;
+    const int shift = pcs_ptr->is_720p_or_larger ? 2 : 1;
+
+    for (int row = 0; row < cm->mi_rows; row += step) {
+        for (int col = 0; col < mi_cols_sr; col += step) {
+            TplStats *tpl_stats_ptr = pcs_ptr->tpl_stats[(row >> shift) * (mi_cols_sr >> shift) + (col >> shift)];
+            int64_t mc_dep_delta =
+                RDCOST(pcs_ptr->base_rdmult, tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->mc_dep_dist);
+            intra_cost_base += (tpl_stats_ptr->recrf_dist << RDDIV_BITS);
+            mc_dep_cost_base += (tpl_stats_ptr->recrf_dist << RDDIV_BITS) + mc_dep_delta;
+        }
+    }
+
+    if (mc_dep_cost_base != 0) {
+        pcs_ptr->r0 = (double)intra_cost_base / mc_dep_cost_base;
+    }
+
+   // SVT_LOG("generate_r0beta ------> poc %ld\t%.0f\t%.0f \t%.5f base_rdmult=%d\n", pcs_ptr->picture_number, (double)intra_cost_base, (double)mc_dep_cost_base, pcs_ptr->r0, pcs_ptr->base_rdmult);
+    generate_lambda_scaling_factor(pcs_ptr, mc_dep_cost_base);
+
+    const uint32_t sb_sz = scs_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64;
+    const uint32_t picture_sb_width = (uint32_t)((scs_ptr->seq_header.max_frame_width + sb_sz - 1) / sb_sz);
+    const uint32_t picture_sb_height = (uint32_t)((scs_ptr->seq_header.max_frame_height + sb_sz - 1) / sb_sz);
+    const uint32_t picture_width_in_mb = (scs_ptr->seq_header.max_frame_width + 16 - 1) / 16;
+    const uint32_t picture_height_in_mb = (scs_ptr->seq_header.max_frame_height + 16 - 1) / 16;
+    const uint32_t blks = scs_ptr->seq_header.sb_size == BLOCK_128X128 ? (128 >> (3 + pcs_ptr->is_720p_or_larger))
+        : (64 >> (3 + pcs_ptr->is_720p_or_larger));
+    for (uint32_t sb_y = 0; sb_y < picture_sb_height; ++sb_y) {
+        for (uint32_t sb_x = 0; sb_x < picture_sb_width; ++sb_x) {
+            int64_t intra_cost = 0;
+            int64_t mc_dep_cost = 0;
+            for (uint32_t blky_offset = 0; blky_offset < blks; blky_offset++) {
+                for (uint32_t blkx_offset = 0; blkx_offset < blks; blkx_offset++) {
+                    uint32_t blkx = ((sb_x * sb_sz) >> (3 + pcs_ptr->is_720p_or_larger)) + blkx_offset;
+                    uint32_t blky = ((sb_y * sb_sz) >> (3 + pcs_ptr->is_720p_or_larger)) + blky_offset;
+                    if ((blkx >> (1 - pcs_ptr->is_720p_or_larger)) >= picture_width_in_mb ||
+                        (blky >> (1 - pcs_ptr->is_720p_or_larger)) >= picture_height_in_mb)
+                        continue;
+                    TplStats *tpl_stats_ptr = pcs_ptr->tpl_stats[blky * (mi_cols_sr >> shift) + blkx];
+                    int64_t mc_dep_delta =
+                        RDCOST(pcs_ptr->base_rdmult, tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->mc_dep_dist);
+                    intra_cost += (tpl_stats_ptr->recrf_dist << RDDIV_BITS);
+                    mc_dep_cost += (tpl_stats_ptr->recrf_dist << RDDIV_BITS) + mc_dep_delta;
+                }
+            }
+            double beta = 1.0;
+            if (mc_dep_cost > 0 && intra_cost > 0) {
+                double rk = (double)intra_cost / mc_dep_cost;
+                beta = (pcs_ptr->r0 / rk);
+                assert(beta > 0.0);
+            }
+            pcs_ptr->tpl_beta[sb_y * picture_sb_width + sb_x] = beta;
+        }
+    }
+    return;
+}
+/************************************************
+* Allocate and initialize buffers needed for tpl
+************************************************/
+EbErrorType init_tpl_buffers(
+    EncodeContext                   *encode_context_ptr,
+    PictureParentControlSet         *pcs_ptr,
+    PictureParentControlSet        **pcs_array) {
+
+    int32_t                         frames_in_sw = MIN(MAX_TPL_LA_SW, pcs_ptr->tpl_group_size);
+    int32_t                         frame_idx;
+
+    for (frame_idx = 0; frame_idx < MAX_TPL_LA_SW; frame_idx++) {
+        encode_context_ptr->poc_map_idx[frame_idx] = -1;
+        encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx] = NULL;
+    }
+    EbPictureBufferDescInitData picture_buffer_desc_init_data;
+    picture_buffer_desc_init_data.max_width = pcs_ptr->enhanced_picture_ptr->max_width;
+    picture_buffer_desc_init_data.max_height = pcs_ptr->enhanced_picture_ptr->max_height;
+    picture_buffer_desc_init_data.bit_depth = pcs_ptr->enhanced_picture_ptr->bit_depth;
+    picture_buffer_desc_init_data.color_format = pcs_ptr->enhanced_picture_ptr->color_format;
+    picture_buffer_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_Y_FLAG;
+    picture_buffer_desc_init_data.left_padding = pcs_ptr->enhanced_picture_ptr->origin_x;
+    picture_buffer_desc_init_data.right_padding = pcs_ptr->enhanced_picture_ptr->origin_x;
+    picture_buffer_desc_init_data.top_padding = pcs_ptr->enhanced_picture_ptr->origin_y;
+    picture_buffer_desc_init_data.bot_padding = pcs_ptr->enhanced_picture_ptr->origin_bot_y;
+    picture_buffer_desc_init_data.split_mode = EB_FALSE;
+
+    EB_NEW(encode_context_ptr->mc_flow_rec_picture_buffer_noref,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&picture_buffer_desc_init_data);
+
+    for (frame_idx = 0; frame_idx < frames_in_sw; frame_idx++) {
+#if TUNE_INL_TPL_ENHANCEMENT
+        if (pcs_array[frame_idx]->tpl_data.is_used_as_reference_flag) {
+#else
+        if (pcs_array[frame_idx]->is_used_as_reference_flag) {
+#endif
+            EB_NEW(encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx],
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&picture_buffer_desc_init_data);
+        }
+        else {
+            encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx] = encode_context_ptr->mc_flow_rec_picture_buffer_noref;
+        }
+    }
+    return EB_ErrorNone;
+}
+/************************************************
+* Genrate TPL MC Flow Based on frames in the tpl group
+************************************************/
+EbErrorType tpl_mc_flow(
+    EncodeContext                   *encode_context_ptr,
+    SequenceControlSet              *scs_ptr,
+    PictureParentControlSet         *pcs_ptr)
+{
+
+    PictureParentControlSet          *pcs_array[MAX_TPL_LA_SW] = { NULL, };
+    int32_t                          frames_in_sw = MIN(MAX_TPL_LA_SW, pcs_ptr->tpl_group_size);
+    int32_t                         frame_idx;
+    uint32_t                         shift = pcs_ptr->is_720p_or_larger ? 0 : 1;
+    uint32_t picture_width_in_mb = (pcs_ptr->enhanced_picture_ptr->width + 16 - 1) / 16;
+    uint32_t picture_height_in_mb = (pcs_ptr->enhanced_picture_ptr->height + 16 - 1) / 16;
+
+    pcs_array[0] = pcs_ptr;
+
+    for (frame_idx = 0; frame_idx < (int32_t)pcs_ptr->tpl_group_size; frame_idx++)
+        pcs_array[frame_idx] = pcs_ptr->tpl_group[frame_idx];
+
+    init_tpl_buffers(
+        encode_context_ptr,
+        pcs_ptr,
+        pcs_array);
+
+#if TUNE_INL_TPL_ENHANCEMENT
+    if (pcs_array[0]->tpl_data.tpl_temporal_layer_index == 0) {
+#else
+    if (pcs_array[0]->temporal_layer_index == 0) {
+#endif
+        encode_context_ptr->poc_map_idx[0] = pcs_array[0]->picture_number;
+        for (frame_idx = 0; frame_idx < frames_in_sw; frame_idx++) {
+            encode_context_ptr->poc_map_idx[frame_idx] = pcs_array[frame_idx]->picture_number;
+            for (uint32_t blky = 0; blky < (picture_height_in_mb << shift); blky++) {
+                memset(pcs_array[frame_idx]->tpl_stats[blky * (picture_width_in_mb << shift)], 0, (picture_width_in_mb << shift) * sizeof(TplStats));
+            }
+            tpl_mc_flow_dispenser(encode_context_ptr, scs_ptr, pcs_array[frame_idx], frame_idx);
+        }
+
+        // synthesizer
+        for (frame_idx = frames_in_sw - 1; frame_idx >= 0; frame_idx--)
+            tpl_mc_flow_synthesizer(pcs_array, frame_idx, frames_in_sw);
+        generate_r0beta(pcs_array[0]);
+
+#if 0 //AMIR_PRINTS
+        SVT_LOG("LOG displayorder:%ld\n",
+            pcs_array[0]->picture_number);
+        for (frame_idx = 0; frame_idx < frames_in_sw; frame_idx++)
+        {
+            PictureParentControlSet         *pcs_ptr_tmp = pcs_array[frame_idx];
+            Av1Common *cm = pcs_ptr->av1_cm;
+            SequenceControlSet *scs_ptr = pcs_ptr_tmp->scs_ptr;
+            int64_t intra_cost_base = 0;
+            int64_t mc_dep_cost_base = 0;
+            const int step = 1 << (pcs_ptr_tmp->is_720p_or_larger ? 2 : 1);
+            const int mi_cols_sr = ((pcs_ptr_tmp->aligned_width + 15) / 16) << 2;
+            const int shift = pcs_ptr_tmp->is_720p_or_larger ? 2 : 1;
+
+            for (int row = 0; row < cm->mi_rows; row += step) {
+                for (int col = 0; col < mi_cols_sr; col += step) {
+                    TplStats *tpl_stats_ptr = pcs_ptr_tmp->tpl_stats[(row >> shift) * (mi_cols_sr >> shift) + (col >> shift)];
+                    int64_t mc_dep_delta =
+                        RDCOST(pcs_ptr_tmp->base_rdmult, tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->mc_dep_dist);
+                    intra_cost_base += (tpl_stats_ptr->recrf_dist << RDDIV_BITS);
+                    mc_dep_cost_base += (tpl_stats_ptr->recrf_dist << RDDIV_BITS) + mc_dep_delta;
+                }
+            }
+
+            SVT_LOG("After mc_flow_synthesizer:\tframe_indx:%d\tdisplayorder:%ld\tIntra:%lld\tmc_dep:%lld\n",
+                frame_idx, pcs_ptr_tmp->picture_number, intra_cost_base, mc_dep_cost_base);
+        }
+#endif
+
+    }
+
+    for (frame_idx = 0; frame_idx < frames_in_sw; frame_idx++) {
+        if (encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx] &&
+            encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx] != encode_context_ptr->mc_flow_rec_picture_buffer_noref)
+            EB_DELETE(encode_context_ptr->mc_flow_rec_picture_buffer[frame_idx]);
+    }
+    EB_DELETE(encode_context_ptr->mc_flow_rec_picture_buffer_noref);
+
+    return EB_ErrorNone;
+}
+#endif
 static const uint32_t rate_percentage_layer_array[EB_MAX_TEMPORAL_LAYERS][EB_MAX_TEMPORAL_LAYERS] =
     {{100, 0, 0, 0, 0, 0},
      {70, 30, 0, 0, 0, 0},
@@ -5979,12 +7080,43 @@ void *rate_control_kernel(void *input_ptr) {
 
         // Modify these for different temporal layers later
         switch (task_type) {
+#if !FEATURE_INL_ME
         case RC_PICTURE_MANAGER_RESULT:
+#else
+        case RC_INPUT:
+            pcs_ptr = (PictureControlSet *)rate_control_tasks_ptr->pcs_wrapper_ptr->object_ptr;
+
+            // Set the segment mask
+            SEGMENT_COMPLETION_MASK_SET(pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_mask,
+                    rate_control_tasks_ptr->segment_index);
+
+            // If the picture is complete, proceed
+            if (!(SEGMENT_COMPLETION_MASK_TEST(pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_mask,
+                        pcs_ptr->parent_pcs_ptr->inloop_me_segments_total_count))) {
+                eb_release_object(rate_control_tasks_wrapper_ptr);
+                continue;
+            }
+#endif
 
             pcs_ptr = (PictureControlSet *)rate_control_tasks_ptr->pcs_wrapper_ptr->object_ptr;
             scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
             FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
             pcs_ptr->parent_pcs_ptr->blk_lambda_tuning = EB_FALSE;
+
+#if FEATURE_IN_LOOP_TPL
+            if (scs_ptr->in_loop_me && scs_ptr->static_config.enable_tpl_la &&
+                pcs_ptr->temporal_layer_index == 0) {
+                tpl_mc_flow(scs_ptr->encode_context_ptr, scs_ptr, pcs_ptr->parent_pcs_ptr);
+            }
+#endif
+
+#if FEATURE_INL_ME
+            // Release the down scaled input
+            if (scs_ptr->in_loop_me) {
+                eb_release_object(pcs_ptr->parent_pcs_ptr->down_scaled_picture_wrapper_ptr);
+                pcs_ptr->parent_pcs_ptr->down_scaled_picture_wrapper_ptr = NULL;
+            }
+#endif
 
             if (pcs_ptr->picture_number == 0) {
                 //init rate control parameters

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -254,7 +254,7 @@ void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q, int32_t
     int32_t u_ac_delta_q, int32_t v_dc_delta_q, int32_t v_ac_delta_q,
     Quants *const quants, Dequants *const deq);
 
-#define TPL_DEP_COST_SCALE_LOG2 4
+
 double eb_av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
 
 int32_t eb_av1_compute_qdelta(double qstart, double qtarget, AomBitDepth bit_depth);

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -483,7 +483,7 @@ void tpl_mc_flow_dispenser(
                         EbBool   enable_paeth                = pcs_ptr->scs_ptr->static_config.enable_paeth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_paeth;
                         EbBool   enable_smooth               = pcs_ptr->scs_ptr->static_config.enable_smooth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_smooth;
                         uint8_t intra_mode_end =
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
                             pcs_ptr->tpl_data.tpl_opt_flag
 #else
                             pcs_ptr->tpl_opt_flag
@@ -597,7 +597,7 @@ void tpl_mc_flow_dispenser(
                     if (best_inter_cost < INT64_MAX) {
                         uint16_t eob = 0;
                         get_quantize_error(&mb_plane, best_coeff, qcoeff, dqcoeff, tx_size, &eob, &recon_error, &sse);
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
                         int rate_cost = pcs_ptr->tpl_data.tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
 #else
                         int rate_cost = pcs_ptr->tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
@@ -711,7 +711,7 @@ void tpl_mc_flow_dispenser(
 
                     get_quantize_error(&mb_plane, coeff, qcoeff, dqcoeff, tx_size, &eob, &recon_error, &sse);
 
-#if FIX_TPL_TRAILING_FRAME_BUG
+#if ENABLE_TPL_TRAILING
                     int rate_cost = pcs_ptr->tpl_data.tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);
 #else
                     int rate_cost = pcs_ptr->tpl_opt_flag ? 0 : rate_estimator(qcoeff, eob, tx_size);

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -249,13 +249,16 @@ int svt_av1_compute_rd_mult_based_on_qindex(AomBitDepth bit_depth, int qindex) {
 }
 
 void eb_av1_set_quantizer(PictureParentControlSet *pcs_ptr, int32_t q);
+
 void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q, int32_t u_dc_delta_q,
     int32_t u_ac_delta_q, int32_t v_dc_delta_q, int32_t v_ac_delta_q,
     Quants *const quants, Dequants *const deq);
 
 #define TPL_DEP_COST_SCALE_LOG2 4
 double eb_av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
+
 int32_t eb_av1_compute_qdelta(double qstart, double qtarget, AomBitDepth bit_depth);
+
 extern void filter_intra_edge(OisMbResults *ois_mb_results_ptr, uint8_t mode, uint16_t max_frame_width, uint16_t max_frame_height,
     int32_t p_angle, int32_t cu_origin_x, int32_t cu_origin_y, uint8_t *above_row, uint8_t *left_col);
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -616,7 +616,6 @@ void tpl_mc_flow_dispenser(
                     if (best_mode == NEWMV) {
                         // inter recon with rec_picture as reference pic
                         uint64_t ref_poc = best_ref_poc;
-                        uint32_t ref_frame_idx = 0;
                         uint32_t list_index = best_rf_idx < 4 ? 0 : 1;
                         uint32_t ref_pic_index = best_rf_idx >= 4 ? (best_rf_idx - 4) : best_rf_idx;
 #if TUNE_INL_TPL_ENHANCEMENT
@@ -624,6 +623,7 @@ void tpl_mc_flow_dispenser(
 #else
                         if (pcs_ptr->ref_in_slide_window[list_index][ref_pic_index]) {
 #endif
+                        uint32_t ref_frame_idx = 0;
                             while (ref_frame_idx < MAX_TPL_LA_SW && encode_context_ptr->poc_map_idx[ref_frame_idx] != ref_poc)
                                 ref_frame_idx++;
                             assert(ref_frame_idx != MAX_TPL_LA_SW);
@@ -669,7 +669,6 @@ void tpl_mc_flow_dispenser(
 
                         above_row = above_data + 16;
                         left_col = left_data + 16;
-                        TxSize tx_size = TX_16X16;
                         uint8_t *recon_buffer =
                             recon_picture_ptr->buffer_y + dst_basic_offset;
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -366,15 +366,6 @@ void tpl_mc_flow_dispenser(
             8);
     qIndex =
         (qIndex + delta_qindex);
-#if FIX_OPTIMIZE_BUILD_QUANTIZER
-    mb_plane.quant_qtx = scs_ptr->quants_8bit.y_quant[qIndex];
-    mb_plane.quant_fp_qtx = scs_ptr->quants_8bit.y_quant_fp[qIndex];
-    mb_plane.round_fp_qtx = scs_ptr->quants_8bit.y_round_fp[qIndex];
-    mb_plane.quant_shift_qtx = scs_ptr->quants_8bit.y_quant_shift[qIndex];
-    mb_plane.zbin_qtx = scs_ptr->quants_8bit.y_zbin[qIndex];
-    mb_plane.round_qtx = scs_ptr->quants_8bit.y_round[qIndex];
-    mb_plane.dequant_qtx = scs_ptr->deq_8bit.y_dequant_qtx[qIndex];
-#else
     Quants *const quants_bd = &pcs_ptr->quants_bd;
     Dequants *const deq_bd = &pcs_ptr->deq_bd;
     eb_av1_set_quantizer(
@@ -396,20 +387,7 @@ void tpl_mc_flow_dispenser(
     mb_plane.zbin_qtx = pcs_ptr->quants_bd.y_zbin[qIndex];
     mb_plane.round_qtx = pcs_ptr->quants_bd.y_round[qIndex];
     mb_plane.dequant_qtx = pcs_ptr->deq_bd.y_dequant_qtx[qIndex];
-#endif
     pcs_ptr->base_rdmult = svt_av1_compute_rd_mult_based_on_qindex((AomBitDepth)8/*scs_ptr->static_config.encoder_bit_depth*/, qIndex) / 6;
-#if TUNE_TPL_OIS
-    DECLARE_ALIGNED(16, uint8_t, left0_data[MAX_TX_SIZE * 2 + 32]);
-    DECLARE_ALIGNED(16, uint8_t, above0_data[MAX_TX_SIZE * 2 + 32]);
-    DECLARE_ALIGNED(16, uint8_t, left_data[MAX_TX_SIZE * 2 + 32]);
-    DECLARE_ALIGNED(16, uint8_t, above_data[MAX_TX_SIZE * 2 + 32]);
-
-    EbPictureBufferDesc *input_ptr =  pcs_ptr->enhanced_picture_ptr;
-    uint8_t *above_row;
-    uint8_t *left_col;
-    uint8_t *above0_row;
-    uint8_t *left0_col;
-#endif
     // Walk the first N entries in the sliding window
     for (uint32_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
         {
@@ -448,77 +426,8 @@ void tpl_mc_flow_dispenser(
                     int64_t best_inter_cost = INT64_MAX;
                     MV final_best_mv = { 0, 0 };
                     uint32_t max_inter_ref = MAX_PA_ME_MV;
-#if !TUNE_TPL_OIS
                     OisMbResults *ois_mb_results_ptr = pcs_ptr->ois_mb_results[(mb_origin_y >> 4) * picture_width_in_mb + (mb_origin_x >> 4)];
                     int64_t best_intra_cost = ois_mb_results_ptr->intra_cost;
-#else
-
-                    PredictionMode best_intra_mode = DC_PRED;
-                    int64_t        best_intra_cost = INT64_MAX;
-                    if (scs_ptr->in_loop_ois == 0) {
-                        OisMbResults *ois_mb_results_ptr = pcs_ptr->ois_mb_results[(mb_origin_y >> 4) * picture_width_in_mb + (mb_origin_x >> 4)];
-                        best_intra_mode       = ois_mb_results_ptr->intra_mode;
-                        best_intra_cost       = ois_mb_results_ptr->intra_cost;
-
-                    }
-                    else { // ois
-                        // always process as block16x16 even bsize or tx_size is 8x8
-                        TxSize tx_size = TX_16X16;
-                        bsize = 16;
-
-                        above0_row = above0_data + 16;
-                        left0_col = left0_data + 16;
-                        above_row = above_data + 16;
-                        left_col = left_data + 16;
-
-
-                        uint8_t *src = input_ptr->buffer_y + pcs_ptr->enhanced_picture_ptr->origin_x + mb_origin_x +
-                                       (pcs_ptr->enhanced_picture_ptr->origin_y + mb_origin_y) * input_ptr->stride_y;
-
-                        // Fill Neighbor Arrays
-                        update_neighbor_samples_array_open_loop_mb(above0_row - 1, left0_col - 1,
-                                                                   input_ptr, input_ptr->stride_y, mb_origin_x, mb_origin_y, bsize, bsize);
-                        uint8_t ois_intra_mode;
-                        uint8_t intra_mode_start = DC_PRED;
-                        EbBool   enable_paeth                = pcs_ptr->scs_ptr->static_config.enable_paeth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_paeth;
-                        EbBool   enable_smooth               = pcs_ptr->scs_ptr->static_config.enable_smooth == DEFAULT ? EB_TRUE : (EbBool) pcs_ptr->scs_ptr->static_config.enable_smooth;
-                        uint8_t intra_mode_end =
-#if ENABLE_TPL_TRAILING
-                            pcs_ptr->tpl_data.tpl_opt_flag
-#else
-                            pcs_ptr->tpl_opt_flag
-#endif
-                                ? DC_PRED
-                                : enable_paeth ? PAETH_PRED : enable_smooth ? SMOOTH_H_PRED : D67_PRED;
-
-                        for (ois_intra_mode = intra_mode_start; ois_intra_mode <= intra_mode_end; ++ois_intra_mode) {
-                            int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
-                            // Edge filter
-                            if(av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
-                                EB_MEMCPY(left_data,  left0_data,  sizeof(uint8_t)*(MAX_TX_SIZE * 2 + 32));
-                                EB_MEMCPY(above_data, above0_data, sizeof(uint8_t)*(MAX_TX_SIZE * 2 + 32));
-                                above_row = above_data + 16;
-                                left_col  = left_data + 16;
-                                filter_intra_edge(NULL, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, (int32_t)mb_origin_x, (int32_t)mb_origin_y, above_row, left_col);
-                            } else {
-                                above_row = above0_row;
-                                left_col  = left0_col;
-                            }
-                            // PRED
-                            intra_prediction_open_loop_mb(p_angle, ois_intra_mode,mb_origin_x, mb_origin_y, tx_size, above_row, left_col, predictor, 16);
-
-                            // Distortion
-                            eb_aom_subtract_block(16, 16, src_diff, 16, src, input_ptr->stride_y, predictor, 16);
-                            svt_av1_wht_fwd_txfm(src_diff, 16, coeff, 2/*TX_16X16*/, 8, 0);
-                            int64_t intra_cost = svt_aom_satd(coeff, 16 * 16);
-
-                            if (intra_cost < best_intra_cost) {
-                                best_intra_cost = intra_cost;
-                                best_intra_mode = ois_intra_mode;
-                            }
-                        }
-                }
-#endif
 
                     uint8_t best_mode = DC_PRED;
                     uint8_t *src_mb = input_picture_ptr->buffer_y + input_picture_ptr->origin_x + mb_origin_x +
@@ -685,21 +594,12 @@ void tpl_mc_flow_dispenser(
                             16,
                             input_picture_ptr->width,
                             input_picture_ptr->height);
-#if TUNE_TPL_OIS
-                        uint8_t ois_intra_mode = best_intra_mode;// ois_mb_results_ptr->intra_mode;
-                        int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
-                        // Edge filter
-                        if (av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
-                            filter_intra_edge(NULL, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, mb_origin_x, mb_origin_y, above_row, left_col);
-                        }
-#else
                         uint8_t ois_intra_mode = ois_mb_results_ptr->intra_mode;
                         int32_t p_angle = av1_is_directional_mode((PredictionMode)ois_intra_mode) ? mode_to_angle_map[(PredictionMode)ois_intra_mode] : 0;
                         // Edge filter
                         if (av1_is_directional_mode((PredictionMode)ois_intra_mode) && 1/*scs_ptr->seq_header.enable_intra_edge_filter*/) {
                             filter_intra_edge(ois_mb_results_ptr, ois_intra_mode, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, p_angle, mb_origin_x, mb_origin_y, above_row, left_col);
                         }
-#endif
                         // PRED
                         intra_prediction_open_loop_mb(p_angle, ois_intra_mode, mb_origin_x, mb_origin_y, tx_size, above_row, left_col, dst_buffer, dst_buffer_stride);
                     }
@@ -856,15 +756,9 @@ static AOM_INLINE void tpl_model_update_b(PictureParentControlSet *ref_pcs_ptr, 
         ((double)(tpl_stats_ptr->recrf_dist - tpl_stats_ptr->srcrf_dist) /
             tpl_stats_ptr->recrf_dist));
     int64_t delta_rate = tpl_stats_ptr->recrf_rate - tpl_stats_ptr->srcrf_rate;
-#if TUNE_TPL_RATE
-    int64_t mc_dep_rate = pcs_ptr->tpl_data.tpl_opt_flag ? 0 :
-        delta_rate_cost(tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->recrf_dist,
-            tpl_stats_ptr->srcrf_dist, pix_num);
-#else
     int64_t mc_dep_rate =
         delta_rate_cost(tpl_stats_ptr->mc_dep_rate, tpl_stats_ptr->recrf_dist,
             tpl_stats_ptr->srcrf_dist, pix_num);
-#endif
 
     for (block = 0; block < 4; ++block) {
         int grid_pos_row = grid_pos_row_base + bh * (block >> 1);

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.h
@@ -206,7 +206,11 @@ typedef struct {
  * Input Port Types
  **************************************/
 typedef enum RateControlInputPortTypes {
+#if FEATURE_INL_ME
+    RATE_CONTROL_INPUT_PORT_INLME = 0,
+#else
     RATE_CONTROL_INPUT_PORT_PICTURE_MANAGER = 0,
+#endif
     RATE_CONTROL_INPUT_PORT_PACKETIZATION   = 1,
     RATE_CONTROL_INPUT_PORT_ENTROPY_CODING  = 2,
     RATE_CONTROL_INPUT_PORT_TOTAL_COUNT     = 3,

--- a/Source/Lib/Encoder/Codec/EbRateControlTasks.h
+++ b/Source/Lib/Encoder/Codec/EbRateControlTasks.h
@@ -20,7 +20,11 @@
  * Tasks Types
  **************************************/
 typedef enum RateControlTaskTypes {
+#if FEATURE_INL_ME
+    RC_INPUT,
+#else
     RC_PICTURE_MANAGER_RESULT,
+#endif
     RC_PACKETIZATION_FEEDBACK_RESULT,
     RC_ENTROPY_CODING_ROW_FEEDBACK_RESULT,
     RC_INVALID_TASK

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.c
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.c
@@ -15,6 +15,9 @@
 #include "EbThreads.h"
 #include "EbReferenceObject.h"
 #include "EbPictureBufferDesc.h"
+#if FEATURE_INL_ME
+#include "EbUtility.h"
+#endif
 
 // TODO: is this just padding with zeros? Is this needed?
 void initialize_samples_neighboring_reference_picture16_bit(EbByte   recon_samples_buffer_ptr,
@@ -144,6 +147,15 @@ static void eb_reference_object_dctor(EbPtr p) {
             EB_DELETE(obj->downscaled_reference_picture16bit[denom_idx]);
         }
     }
+#if FEATURE_INL_ME
+    EB_DELETE(obj->quarter_reference_picture);
+    EB_DELETE(obj->sixteenth_reference_picture);
+#if TUNE_INL_ME_RECON_INPUT
+    EB_DELETE(obj->input_picture);
+    EB_DELETE(obj->quarter_input_picture);
+    EB_DELETE(obj->sixteenth_input_picture);
+#endif
+#endif
 }
 
 /*****************************************
@@ -159,6 +171,11 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
         &ref_init_ptr->reference_picture_desc_init_data;
     EbPictureBufferDescInitData picture_buffer_desc_init_data_16bit_ptr =
         *picture_buffer_desc_init_data_ptr;
+
+#if FEATURE_INL_ME
+    EbPictureBufferDescInitData hme_desc_init_data =
+        *picture_buffer_desc_init_data_ptr;
+#endif
 
     reference_object->dctor = eb_reference_object_dctor;
     //TODO:12bit
@@ -211,6 +228,20 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
         }
     }
 
+#if TUNE_INL_ME_RECON_INPUT
+        hme_desc_init_data.left_padding = 68;
+        hme_desc_init_data.right_padding = 68;
+        hme_desc_init_data.top_padding = 68;
+        hme_desc_init_data.bot_padding = 68;
+        hme_desc_init_data.split_mode = EB_FALSE;
+#if TUNE_INL_ME_MEM_OPT
+        hme_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK; //Only save 8bit luma
+        hme_desc_init_data.bit_depth = EB_8BIT;
+#endif
+        EB_NEW(reference_object->input_picture,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&hme_desc_init_data);
+#endif
     uint32_t mi_rows = reference_object->reference_picture->height >> MI_SIZE_LOG2;
     uint32_t mi_cols = reference_object->reference_picture->width >> MI_SIZE_LOG2;
 
@@ -219,6 +250,61 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
         const int mem_size = ((mi_rows + 1) >> 1) * ((mi_cols + 1) >> 1);
         EB_CALLOC_ALIGNED_ARRAY(reference_object->mvs, mem_size);
     }
+#if FEATURE_INL_ME
+    reference_object->quarter_reference_picture = NULL;
+    reference_object->sixteenth_reference_picture = NULL;
+    if (ref_init_ptr->hme_quarter_luma_recon) {
+        hme_desc_init_data.max_width = picture_buffer_desc_init_data_16bit_ptr.max_width >> 1;
+        hme_desc_init_data.max_height = picture_buffer_desc_init_data_16bit_ptr.max_height >> 1;
+        hme_desc_init_data.bit_depth = EB_8BIT;
+        hme_desc_init_data.color_format = EB_YUV420;
+        hme_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        hme_desc_init_data.left_padding = 64 >> 1;
+        hme_desc_init_data.right_padding = 64 >> 1;
+        hme_desc_init_data.top_padding = 64 >> 1;
+        hme_desc_init_data.bot_padding = 64 >> 1;
+        hme_desc_init_data.split_mode = EB_FALSE;
+        EB_NEW(reference_object->quarter_reference_picture,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&hme_desc_init_data);
+#if TUNE_INL_ME_RECON_INPUT
+        hme_desc_init_data.left_padding = 64 >> 1;
+        hme_desc_init_data.right_padding = 64 >> 1;
+        hme_desc_init_data.top_padding = 64 >> 1;
+        hme_desc_init_data.bot_padding = 64 >> 1;
+        EB_NEW(reference_object->quarter_input_picture,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&hme_desc_init_data);
+#endif
+    }
+    if (ref_init_ptr->hme_sixteenth_luma_recon) {
+        hme_desc_init_data.max_width = picture_buffer_desc_init_data_16bit_ptr.max_width >> 2;
+        hme_desc_init_data.max_height = picture_buffer_desc_init_data_16bit_ptr.max_height >> 2;
+        hme_desc_init_data.bit_depth = EB_8BIT;
+        hme_desc_init_data.color_format = EB_YUV420;
+        hme_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        hme_desc_init_data.left_padding = 64 >> 2;
+        hme_desc_init_data.right_padding = 64 >> 2;
+        hme_desc_init_data.top_padding = 64 >> 2;
+        hme_desc_init_data.bot_padding = 64 >> 2;
+        hme_desc_init_data.split_mode = EB_FALSE;
+        EB_NEW(reference_object->sixteenth_reference_picture,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&hme_desc_init_data);
+#if TUNE_INL_ME_RECON_INPUT
+        hme_desc_init_data.left_padding = 64 >> 2;
+        hme_desc_init_data.right_padding = 64 >> 2;
+        hme_desc_init_data.top_padding = 64 >> 2;
+        hme_desc_init_data.bot_padding = 64 >> 2;
+        EB_NEW(reference_object->sixteenth_input_picture,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)&hme_desc_init_data);
+#endif
+    }
+    reference_object->ds_pics.picture_ptr = reference_object->reference_picture;
+    reference_object->ds_pics.quarter_picture_ptr = reference_object->quarter_reference_picture;
+    reference_object->ds_pics.sixteenth_picture_ptr = reference_object->sixteenth_reference_picture;
+#endif
     memset(&reference_object->film_grain_params, 0, sizeof(reference_object->film_grain_params));
     EB_CREATE_MUTEX(reference_object->referenced_area_mutex);
 
@@ -246,6 +332,10 @@ EbErrorType eb_reference_object_creator(EbPtr *object_dbl_ptr, EbPtr object_init
 
 static void eb_pa_reference_object_dctor(EbPtr p) {
     EbPaReferenceObject *obj = (EbPaReferenceObject *)p;
+#if FEATURE_INL_ME
+    if (obj->dummy_obj)
+        return;
+#endif
     EB_DELETE(obj->input_padded_picture_ptr);
     EB_DELETE(obj->quarter_decimated_picture_ptr);
     EB_DELETE(obj->sixteenth_decimated_picture_ptr);
@@ -275,6 +365,14 @@ EbErrorType eb_pa_reference_object_ctor(EbPaReferenceObject *pa_ref_obj_,
         (EbPictureBufferDescInitData *)object_init_data_ptr;
 
     pa_ref_obj_->dctor = eb_pa_reference_object_dctor;
+#if FEATURE_INL_ME
+    EbPaReferenceObjectDescInitData *pa_ref_init_data_ptr =
+        (EbPaReferenceObjectDescInitData *)object_init_data_ptr;
+    pa_ref_obj_->dummy_obj = pa_ref_init_data_ptr->empty_pa_buffers;
+    if (pa_ref_init_data_ptr->empty_pa_buffers)
+        return EB_ErrorNone;
+#endif
+
 
     // Reference picture constructor
     EB_NEW(pa_ref_obj_->input_padded_picture_ptr,
@@ -321,3 +419,78 @@ EbErrorType eb_pa_reference_object_creator(EbPtr *object_dbl_ptr, EbPtr object_i
 
     return EB_ErrorNone;
 }
+#if FEATURE_INL_ME
+static void eb_down_scaled_object_dctor(EbPtr p) {
+    EbDownScaledObject *ds_obj = (EbDownScaledObject*)p;
+    EB_DELETE(ds_obj->quarter_picture_ptr);
+    EB_DELETE(ds_obj->sixteenth_picture_ptr);
+}
+
+static EbErrorType eb_down_scaled_object_ctor(EbDownScaledObject *ds_obj,
+                                              EbPtr               object_init_data_ptr) {
+    EbDownScaledObjectDescInitData *ds_desc_init_data_ptr =
+        (EbDownScaledObjectDescInitData *)object_init_data_ptr;
+
+    ds_obj->dctor = eb_down_scaled_object_dctor;
+
+    //ds_obj->picture_ptr = NULL;
+    if (ds_desc_init_data_ptr->enable_quarter_luma_input) {
+        EB_NEW(ds_obj->quarter_picture_ptr,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)(&ds_desc_init_data_ptr->quarter_picture_desc_init_data));
+    }
+
+    if (ds_desc_init_data_ptr->enable_sixteenth_luma_input) {
+        EB_NEW(ds_obj->sixteenth_picture_ptr,
+                eb_picture_buffer_desc_ctor,
+                (EbPtr)(&ds_desc_init_data_ptr->sixteenth_picture_desc_init_data));
+    }
+    return EB_ErrorNone;
+}
+
+EbErrorType eb_down_scaled_object_creator(EbPtr *object_dbl_ptr,
+                                          EbPtr object_init_data_ptr) {
+    EbDownScaledObject *obj;
+
+    *object_dbl_ptr = NULL;
+    EB_NEW(obj, eb_down_scaled_object_ctor, object_init_data_ptr);
+    *object_dbl_ptr = obj;
+
+    return EB_ErrorNone;
+}
+
+/************************************************
+* Release Pa Reference Objects
+** Check if reference pictures are needed
+** release them when appropriate
+************************************************/
+void release_pa_reference_objects(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr) {
+    // PA Reference Pictures
+    if (pcs_ptr->slice_type != I_SLICE) {
+        uint32_t num_of_list_to_search = (pcs_ptr->slice_type == P_SLICE) ? REF_LIST_0 : REF_LIST_1;
+
+        // List Loop
+        for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+            // Release PA Reference Pictures
+            uint8_t num_of_ref_pic_to_search =
+                (pcs_ptr->slice_type == P_SLICE)
+                    ? MIN(pcs_ptr->ref_list0_count, scs_ptr->reference_count)
+                    : (list_index == REF_LIST_0)
+                          ? MIN(pcs_ptr->ref_list0_count, scs_ptr->reference_count)
+                          : MIN(pcs_ptr->ref_list1_count, scs_ptr->reference_count);
+
+            for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
+                if (pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index] != NULL) {
+                    eb_release_object(pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]);
+                }
+            }
+        }
+    }
+
+    if (pcs_ptr->pa_reference_picture_wrapper_ptr != NULL) {
+        eb_release_object(pcs_ptr->pa_reference_picture_wrapper_ptr);
+    }
+
+    return;
+}
+#endif

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.c
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.c
@@ -234,7 +234,7 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
         hme_desc_init_data.top_padding = 68;
         hme_desc_init_data.bot_padding = 68;
         hme_desc_init_data.split_mode = EB_FALSE;
-#if TUNE_INL_ME_MEM_OPT
+#if TUNE_INL_ME_RECON_INPUT
         hme_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK; //Only save 8bit luma
         hme_desc_init_data.bit_depth = EB_8BIT;
 #endif

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.h
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.h
@@ -16,11 +16,24 @@
 #include "EbObject.h"
 #include "EbCabacContextModel.h"
 #include "EbCodingUnit.h"
+#if FEATURE_INL_ME
+#include "EbSequenceControlSet.h"
+#endif
 
 typedef struct EbReferenceObject {
     EbDctor              dctor;
     EbPictureBufferDesc *reference_picture;
     EbPictureBufferDesc *reference_picture16bit;
+#if FEATURE_INL_ME
+    EbPictureBufferDesc *quarter_reference_picture;
+    EbPictureBufferDesc *sixteenth_reference_picture;
+    EbDownScaledBufDescPtrArray ds_pics; // Pointer array for down scaled pictures
+#if TUNE_INL_ME_RECON_INPUT
+    EbPictureBufferDesc *input_picture;
+    EbPictureBufferDesc *quarter_input_picture;
+    EbPictureBufferDesc *sixteenth_input_picture;
+#endif
+#endif
     EbPictureBufferDesc *downscaled_reference_picture[NUM_SCALES];
     EbPictureBufferDesc *downscaled_reference_picture16bit[NUM_SCALES];
     uint64_t             ref_poc;
@@ -58,6 +71,11 @@ typedef struct EbReferenceObject {
 typedef struct EbReferenceObjectDescInitData {
     EbPictureBufferDescInitData reference_picture_desc_init_data;
     int8_t hbd_mode_decision;
+#if FEATURE_INL_ME
+    // whether enable 1/4,1/16 8bit luma for inloop me
+    uint8_t hme_quarter_luma_recon;
+    uint8_t hme_sixteenth_luma_recon;
+#endif
 } EbReferenceObjectDescInitData;
 
 typedef struct EbPaReferenceObject {
@@ -73,16 +91,26 @@ typedef struct EbPaReferenceObject {
     EbPictureBufferDesc *downscaled_sixteenth_decimated_picture_ptr[NUM_SCALES];
     EbPictureBufferDesc *downscaled_quarter_filtered_picture_ptr[NUM_SCALES];
     EbPictureBufferDesc *downscaled_sixteenth_filtered_picture_ptr[NUM_SCALES];
+#if !FEATURE_INL_ME
     uint16_t             variance[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     uint8_t              y_mean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     EB_SLICE             slice_type;
     uint32_t             dependent_pictures_count; //number of pic using this reference frame
+#endif
+
+#if FEATURE_INL_ME
+    uint64_t             picture_number;
+    uint8_t              dummy_obj;
+#endif
 } EbPaReferenceObject;
 
 typedef struct EbPaReferenceObjectDescInitData {
     EbPictureBufferDescInitData reference_picture_desc_init_data;
     EbPictureBufferDescInitData quarter_picture_desc_init_data;
     EbPictureBufferDescInitData sixteenth_picture_desc_init_data;
+#if FEATURE_INL_ME
+    uint8_t empty_pa_buffers;
+#endif
 } EbPaReferenceObjectDescInitData;
 
 /**************************************
@@ -92,5 +120,10 @@ extern EbErrorType eb_reference_object_creator(EbPtr *object_dbl_ptr, EbPtr obje
 
 extern EbErrorType eb_pa_reference_object_creator(EbPtr *object_dbl_ptr,
                                                   EbPtr  object_init_data_ptr);
+#if FEATURE_INL_ME
+extern EbErrorType eb_down_scaled_object_creator(EbPtr *object_dbl_ptr,
+                                                 EbPtr object_init_data_ptr);
+void release_pa_reference_objects(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr);
+#endif
 
 #endif //EbReferenceObject_h

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -467,6 +467,17 @@ void reset_pcs_av1(PictureParentControlSet *pcs_ptr) {
     frm_hdr->frame_refs_short_signaling = 0;
     pcs_ptr->allow_comp_inter_inter     = 0;
     //  int32_t all_one_sided_refs;
+#if FEATURE_INL_ME
+    pcs_ptr->tpl_me_done = 0;
+    pcs_ptr->me_data_wrapper_ptr = NULL;
+    pcs_ptr->down_scaled_picture_wrapper_ptr = NULL;
+    pcs_ptr->ds_pics.picture_ptr = NULL;
+    pcs_ptr->ds_pics.quarter_picture_ptr = NULL;
+    pcs_ptr->ds_pics.sixteenth_picture_ptr = NULL;
+#if TUNE_INL_TPL_ENHANCEMENT
+    pcs_ptr->max_number_of_pus_per_sb = SQUARE_PU_COUNT;
+#endif
+#endif
 }
 /***********************************************
 **** Copy the input buffer from the
@@ -1012,6 +1023,14 @@ void *resource_coordination_kernel(void *input_ptr) {
                 eb_object_inc_live_count(pcs_ptr->pa_reference_picture_wrapper_ptr, 1);
             else
                 eb_object_inc_live_count(pcs_ptr->pa_reference_picture_wrapper_ptr, 2);
+#if FEATURE_INL_ME
+            if (scs_ptr->in_loop_me) {
+                EbObjectWrapper *ds_wrapper;
+                eb_get_empty_object(scs_ptr->encode_context_ptr->down_scaled_picture_pool_fifo_ptr,
+                        &ds_wrapper);
+                pcs_ptr->down_scaled_picture_wrapper_ptr = ds_wrapper;
+            }
+#endif
             if (scs_ptr->static_config.unrestricted_motion_vector == 0) {
                 struct PictureParentControlSet *ppcs_ptr = pcs_ptr;
                 Av1Common *const                cm       = ppcs_ptr->av1_cm;

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -301,9 +301,6 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
 #if FEATURE_INL_ME
     dst->in_loop_me                     = src->in_loop_me;
 #endif
-#if TUNE_TPL_OIS
-    dst->in_loop_ois                     = src->in_loop_ois;
-#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -329,8 +329,10 @@ extern EbErrorType derive_input_resolution(EbInputResolution *input_resolution, 
 
 static void eb_sequence_control_set_instance_dctor(EbPtr p) {
     EbSequenceControlSetInstance *obj = (EbSequenceControlSetInstance *)p;
+#if !FEATURE_IN_LOOP_TPL
     if (obj->encode_context_ptr && obj->encode_context_ptr->mc_flow_rec_picture_buffer_saved)
         EB_FREE_ARRAY(obj->encode_context_ptr->mc_flow_rec_picture_buffer_saved);
+#endif
     EB_DELETE(obj->encode_context_ptr);
     EB_DELETE(obj->scs_ptr);
     EB_DESTROY_MUTEX(obj->config_mutex);
@@ -343,8 +345,10 @@ EbErrorType eb_sequence_control_set_instance_ctor(EbSequenceControlSetInstance *
 
     EB_NEW(object_ptr->encode_context_ptr, encode_context_ctor, NULL);
     scs_init_data.encode_context_ptr = object_ptr->encode_context_ptr;
+#if !FEATURE_IN_LOOP_TPL
     if (scs_init_data.encode_context_ptr)
         scs_init_data.encode_context_ptr->mc_flow_rec_picture_buffer_saved = NULL;
+#endif
 
     scs_init_data.sb_size = 64;
 

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -254,6 +254,9 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
     dst->motion_estimation_fifo_init_count = src->motion_estimation_fifo_init_count;
     dst->initial_rate_control_fifo_init_count = src->initial_rate_control_fifo_init_count;
     dst->picture_demux_fifo_init_count = src->picture_demux_fifo_init_count;
+#if FEATURE_INL_ME
+    dst->in_loop_me_fifo_init_count = src->in_loop_me_fifo_init_count;
+#endif
     dst->rate_control_tasks_fifo_init_count = src->rate_control_tasks_fifo_init_count;
     dst->rate_control_fifo_init_count = src->rate_control_fifo_init_count;
     dst->mode_decision_configuration_fifo_init_count =
@@ -295,6 +298,12 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
     dst->over_boundary_block_mode       = src->over_boundary_block_mode;
     dst->mfmv_enabled                   = src->mfmv_enabled;
     dst->scd_delay                      = src->scd_delay;
+#if FEATURE_INL_ME
+    dst->in_loop_me                     = src->in_loop_me;
+#endif
+#if TUNE_TPL_OIS
+    dst->in_loop_ois                     = src->in_loop_ois;
+#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -78,6 +78,16 @@ typedef struct SequenceControlSet {
     /*!< Down-sampling method @ ME and alt-ref temporal filtering
         (The signal changes per preset; 0: filtering, 1: decimation) Default is 0. */
     uint8_t down_sampling_method_me_search;
+#if FEATURE_INL_ME
+    /*!< Use in loop motion estimation
+         Default is 0. */
+    uint8_t in_loop_me;
+#endif
+#if TUNE_TPL_OIS
+    /*!< Use in loop motion OIS
+         Default is 1. */
+    uint8_t in_loop_ois;
+#endif
     /*!< Allow the usage of motion field motion vector in the stream
         (The signal changes per preset; 0: Enabled, 1: Disabled) Default is 1. */
     uint8_t mfmv_enabled;
@@ -169,6 +179,9 @@ typedef struct SequenceControlSet {
     uint32_t motion_estimation_fifo_init_count;
     uint32_t initial_rate_control_fifo_init_count;
     uint32_t picture_demux_fifo_init_count;
+#if FEATURE_INL_ME
+    uint32_t in_loop_me_fifo_init_count;
+#endif
     uint32_t rate_control_tasks_fifo_init_count;
     uint32_t rate_control_fifo_init_count;
     uint32_t mode_decision_configuration_fifo_init_count;
@@ -188,10 +201,19 @@ typedef struct SequenceControlSet {
     uint32_t dlf_process_init_count;
     uint32_t cdef_process_init_count;
     uint32_t rest_process_init_count;
+#if FEATURE_INL_ME
+    uint32_t inlme_process_init_count;
+#endif
     uint32_t total_process_init_count;
     int32_t  lap_enabled;
     TWO_PASS twopass;
     double   double_frame_rate;
+#if FIX_OPTIMIZE_BUILD_QUANTIZER
+    Quants quants_bd; // follows input bit depth
+    Dequants deq_bd;  // follows input bit depth
+    Quants quants_8bit;  // 8bit
+    Dequants deq_8bit; // 8bit
+#endif
 } SequenceControlSet;
 
 typedef struct EbSequenceControlSetInitData {

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -83,11 +83,6 @@ typedef struct SequenceControlSet {
          Default is 0. */
     uint8_t in_loop_me;
 #endif
-#if TUNE_TPL_OIS
-    /*!< Use in loop motion OIS
-         Default is 1. */
-    uint8_t in_loop_ois;
-#endif
     /*!< Allow the usage of motion field motion vector in the stream
         (The signal changes per preset; 0: Enabled, 1: Disabled) Default is 1. */
     uint8_t mfmv_enabled;
@@ -208,12 +203,6 @@ typedef struct SequenceControlSet {
     int32_t  lap_enabled;
     TWO_PASS twopass;
     double   double_frame_rate;
-#if FIX_OPTIMIZE_BUILD_QUANTIZER
-    Quants quants_bd; // follows input bit depth
-    Dequants deq_bd;  // follows input bit depth
-    Quants quants_8bit;  // 8bit
-    Dequants deq_8bit; // 8bit
-#endif
 } SequenceControlSet;
 
 typedef struct EbSequenceControlSetInitData {

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2963,7 +2963,8 @@ void pad_and_decimate_filtered_pic(
                          input_picture_ptr->height,
                          input_picture_ptr->origin_x,
                          input_picture_ptr->origin_y);
-#if FIX_PAD_CHROMA_AFTER_MCTF
+#if FEATURE_INL_ME
+        // Padding chroma after altref
         generate_padding(input_picture_ptr->buffer_cb,
                          input_picture_ptr->stride_cb,
                          input_picture_ptr->width >> scs_ptr->subsampling_x,

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -344,7 +344,11 @@ static void create_me_context_and_picture_control(
     context_ptr->me_context_ptr->alt_ref_reference_ptr =
         (EbPaReferenceObject *)
             picture_control_set_ptr_frame->pa_reference_picture_wrapper_ptr->object_ptr;
+#if !FEATURE_INL_ME
     context_ptr->me_context_ptr->me_alt_ref = EB_TRUE;
+#else
+    context_ptr->me_context_ptr->me_type = ME_MCTF;
+#endif
 
     // set the buffers with the original, quarter and sixteenth pixels version of the source frame
     EbPaReferenceObject *src_object =
@@ -446,6 +450,101 @@ static void create_me_context_and_picture_control(
     }
 }
 
+#if FEATURE_INL_ME
+static void create_me_context_and_picture_control_inl(
+    MotionEstimationContext_t *context_ptr, PictureParentControlSet *picture_control_set_ptr_frame,
+    PictureParentControlSet *picture_control_set_ptr_central,
+    EbPictureBufferDesc *input_picture_ptr_central, int blk_row, int blk_col, uint32_t ss_x,
+    uint32_t ss_y) {
+    // set reference picture for alt-refs
+    //context_ptr->me_context_ptr->alt_ref_reference_ptr_inl =
+    //    (EbDownScaledObject*)picture_control_set_ptr_frame->down_scaled_picture_wrapper_ptr->object_ptr;
+    //context_ptr->me_context_ptr->mctf_ref_desc_ptr_array = picture_control_set_ptr_frame->ds_pics;
+    context_ptr->me_context_ptr->me_ds_ref_array[0][0] = picture_control_set_ptr_frame->ds_pics;
+    context_ptr->me_context_ptr->me_type = ME_MCTF;
+
+    // set the buffers with the original, quarter and sixteenth pixels version of the source frame
+    EbDownScaledObject *src_ds_object =
+        (EbDownScaledObject*)
+            picture_control_set_ptr_central->down_scaled_picture_wrapper_ptr->object_ptr;
+
+    // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+    EbPictureBufferDesc *quarter_pic_ptr = src_ds_object->quarter_picture_ptr;
+
+    EbPictureBufferDesc *sixteenth_pic_ptr = src_ds_object->sixteenth_picture_ptr;
+
+
+    // Parts from MotionEstimationKernel()
+    uint32_t sb_origin_x = (uint32_t)(blk_col * BW);
+    uint32_t sb_origin_y = (uint32_t)(blk_row * BH);
+
+    uint32_t sb_width = (input_picture_ptr_central->width - sb_origin_x) < BLOCK_SIZE_64
+                            ? input_picture_ptr_central->width - sb_origin_x
+                            : BLOCK_SIZE_64;
+    uint32_t sb_height = (input_picture_ptr_central->height - sb_origin_y) < BLOCK_SIZE_64
+                             ? input_picture_ptr_central->height - sb_origin_y
+                             : BLOCK_SIZE_64;
+    // Load the SB from the input to the intermediate SB buffer
+    int buffer_index =
+        (input_picture_ptr_central->origin_y + sb_origin_y) * input_picture_ptr_central->stride_y +
+        input_picture_ptr_central->origin_x + sb_origin_x;
+
+    // set search method
+    context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
+
+    // set Lambda
+    context_ptr->me_context_ptr->lambda =
+        lambda_mode_decision_ra_sad[picture_control_set_ptr_central->picture_qp];
+
+    {
+        uint8_t *src_ptr = &(input_picture_ptr_central->buffer_y[buffer_index]);
+
+        //_MM_HINT_T0     //_MM_HINT_T1    //_MM_HINT_T2    //_MM_HINT_NTA
+        uint32_t i;
+        for (i = 0; i < sb_height; i++) {
+            char const *p = (char const *)(src_ptr + i * input_picture_ptr_central->stride_y);
+            _mm_prefetch(p, _MM_HINT_T2);
+        }
+    }
+    context_ptr->me_context_ptr->sb_src_ptr    = &(input_picture_ptr_central->buffer_y[buffer_index]);
+    context_ptr->me_context_ptr->sb_src_stride = input_picture_ptr_central->stride_y;
+
+    // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
+    buffer_index = (quarter_pic_ptr->origin_y + (sb_origin_y >> ss_y)) * quarter_pic_ptr->stride_y +
+                   quarter_pic_ptr->origin_x + (sb_origin_x >> ss_x);
+
+    for (uint32_t sb_row = 0; sb_row < (sb_height >> ss_y); sb_row++) {
+        EB_MEMCPY((&(context_ptr->me_context_ptr->quarter_sb_buffer
+                         [sb_row * context_ptr->me_context_ptr->quarter_sb_buffer_stride])),
+                  (&(quarter_pic_ptr->buffer_y[buffer_index + sb_row * quarter_pic_ptr->stride_y])),
+                  (sb_width >> ss_x) * sizeof(uint8_t));
+    }
+
+    // Load the 1/16 decimated SB from the 1/16 decimated input to the 1/16 intermediate SB buffer
+    buffer_index =
+        (sixteenth_pic_ptr->origin_y + (sb_origin_y >> 2)) * sixteenth_pic_ptr->stride_y +
+        sixteenth_pic_ptr->origin_x + (sb_origin_x >> 2);
+
+    {
+        uint8_t *frame_ptr = &(sixteenth_pic_ptr->buffer_y[buffer_index]);
+        uint8_t *local_ptr = context_ptr->me_context_ptr->sixteenth_sb_buffer;
+
+        if (context_ptr->me_context_ptr->hme_search_method == FULL_SAD_SEARCH) {
+            for (uint32_t sb_row = 0; sb_row < (sb_height >> 2); sb_row += 1) {
+                EB_MEMCPY(local_ptr, frame_ptr, (sb_width >> 2) * sizeof(uint8_t));
+                local_ptr += 16;
+                frame_ptr += sixteenth_pic_ptr->stride_y;
+            }
+        } else {
+            for (uint32_t sb_row = 0; sb_row < (sb_height >> 2); sb_row += 2) {
+                EB_MEMCPY(local_ptr, frame_ptr, (sb_width >> 2) * sizeof(uint8_t));
+                local_ptr += 16;
+                frame_ptr += sixteenth_pic_ptr->stride_y << 1;
+            }
+        }
+    }
+}
+#endif
 // Get sub-block filter weights for the 16 subblocks case
 static INLINE int get_subblock_filter_weight_16subblocks(unsigned int y, unsigned int x,
                                                          unsigned int block_height,
@@ -2358,6 +2457,11 @@ static EbErrorType produce_temporally_filtered_pic(
     int encoder_bit_depth =
         (int)picture_control_set_ptr_central->scs_ptr->static_config.encoder_bit_depth;
 
+#if FEATURE_INL_ME
+    SequenceControlSet *scs_ptr =
+        (SequenceControlSet *)picture_control_set_ptr_central->scs_ptr;
+#endif
+
     // chroma subsampling
     uint32_t ss_x          = picture_control_set_ptr_central->scs_ptr->subsampling_x;
     uint32_t ss_y          = picture_control_set_ptr_central->scs_ptr->subsampling_y;
@@ -2499,6 +2603,7 @@ static EbErrorType produce_temporally_filtered_pic(
 
                 } else {
                     // Initialize ME context
+#if !FEATURE_INL_ME
                     create_me_context_and_picture_control(
                         me_context_ptr,
                         list_picture_control_set_ptr[frame_index],
@@ -2508,6 +2613,52 @@ static EbErrorType produce_temporally_filtered_pic(
                         blk_col,
                         ss_x,
                         ss_y);
+#else
+                    // When in_loop_me is on, we should not use any PA related stuff
+                    if (scs_ptr->in_loop_me)
+                        create_me_context_and_picture_control_inl(
+                                me_context_ptr,
+                                list_picture_control_set_ptr[frame_index],
+                                list_picture_control_set_ptr[index_center],
+                                input_picture_ptr_central,
+                                blk_row,
+                                blk_col,
+                                ss_x,
+                                ss_y);
+                    else
+                        create_me_context_and_picture_control(
+                                me_context_ptr,
+                                list_picture_control_set_ptr[frame_index],
+                                list_picture_control_set_ptr[index_center],
+                                input_picture_ptr_central,
+                                blk_row,
+                                blk_col,
+                                ss_x,
+                                ss_y);
+                    context_ptr->num_of_list_to_search = 0;
+                    context_ptr->num_of_ref_pic_to_search[0] = 1;
+                    context_ptr->num_of_ref_pic_to_search[1] = 0;
+                    context_ptr->temporal_layer_index = picture_control_set_ptr_central->temporal_layer_index;
+                    context_ptr->is_used_as_reference_flag = picture_control_set_ptr_central->is_used_as_reference_flag;
+
+                    if (scs_ptr->in_loop_me) {
+                        //EbDownScaledObject* inl_downscaled_object = (EbDownScaledObject*)context_ptr->alt_ref_reference_ptr_inl;
+                        //context_ptr->me_ds_ref_array[0][0].picture_ptr = inl_downscaled_object->picture_ptr;
+                        //context_ptr->me_ds_ref_array[0][0].quarter_picture_ptr = inl_downscaled_object->quarter_picture_ptr;
+                        //context_ptr->me_ds_ref_array[0][0].sixteenth_picture_ptr = inl_downscaled_object->sixteenth_picture_ptr;
+                        //context_ptr->me_ds_ref_array[0][0] = context_ptr->mctf_ref_desc_ptr_array;
+                    } else {
+                        EbPaReferenceObject *reference_object = (EbPaReferenceObject *)context_ptr->alt_ref_reference_ptr;
+                        context_ptr->me_ds_ref_array[0][0].picture_ptr = reference_object->input_padded_picture_ptr;
+                        context_ptr->me_ds_ref_array[0][0].sixteenth_picture_ptr = (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
+                            reference_object->sixteenth_filtered_picture_ptr :
+                            reference_object->sixteenth_decimated_picture_ptr;
+                        context_ptr->me_ds_ref_array[0][0].quarter_picture_ptr = (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
+                            reference_object->quarter_filtered_picture_ptr :
+                            reference_object->quarter_decimated_picture_ptr;
+                        context_ptr->me_ds_ref_array[0][0].picture_number = reference_object->picture_number;
+                    }
+#endif
 
                     // Perform ME - context_ptr will store the outputs (MVs, buffers, etc)
                     // Block-based MC using open-loop HME + refinement
@@ -2765,6 +2916,35 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
     // TODO: apply further refinements to the filter parameters according to 1st pass statistics
 }
 
+#if FEATURE_INL_ME
+static void pad_and_decimate_filtered_pic_inl(
+    PictureParentControlSet *picture_control_set_ptr_central) {
+    // reference structures (padded pictures + downsampled versions)
+    SequenceControlSet *scs_ptr =
+        (SequenceControlSet *)picture_control_set_ptr_central->scs_wrapper_ptr->object_ptr;
+    EbPictureBufferDesc *input_picture_ptr =
+        picture_control_set_ptr_central->enhanced_picture_ptr;
+
+    pad_input_pictures(scs_ptr, input_picture_ptr);
+
+    EbDownScaledObject *ds_obj =
+        (EbDownScaledObject*)picture_control_set_ptr_central->down_scaled_picture_wrapper_ptr->object_ptr;
+
+    if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+        downsample_filtering_input_picture(
+                picture_control_set_ptr_central,
+                input_picture_ptr,
+                (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
+                (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
+    } else {
+        downsample_decimation_input_picture(
+                picture_control_set_ptr_central,
+                input_picture_ptr,
+                (EbPictureBufferDesc *)ds_obj->quarter_picture_ptr,
+                (EbPictureBufferDesc *)ds_obj->sixteenth_picture_ptr);
+    }
+}
+#endif
 void pad_and_decimate_filtered_pic(
     PictureParentControlSet *picture_control_set_ptr_central) {
     // reference structures (padded pictures + downsampled versions)
@@ -3073,7 +3253,14 @@ EbErrorType svt_av1_init_temporal_filtering(
         }
 
         // padding + decimation: even if highbd src, this is only performed on the 8 bit buffer (excluding the LSBs)
+#if FEATURE_INL_ME
+        if (picture_control_set_ptr_central->scs_ptr->in_loop_me)
+            pad_and_decimate_filtered_pic_inl(picture_control_set_ptr_central);
+        else
+            pad_and_decimate_filtered_pic(picture_control_set_ptr_central);
+#else
         pad_and_decimate_filtered_pic(picture_control_set_ptr_central);
+#endif
 
         // Normalize the filtered SSE. Add 8 bit precision.
         picture_control_set_ptr_central->filtered_sse =

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -457,9 +457,6 @@ static void create_me_context_and_picture_control_inl(
     EbPictureBufferDesc *input_picture_ptr_central, int blk_row, int blk_col, uint32_t ss_x,
     uint32_t ss_y) {
     // set reference picture for alt-refs
-    //context_ptr->me_context_ptr->alt_ref_reference_ptr_inl =
-    //    (EbDownScaledObject*)picture_control_set_ptr_frame->down_scaled_picture_wrapper_ptr->object_ptr;
-    //context_ptr->me_context_ptr->mctf_ref_desc_ptr_array = picture_control_set_ptr_frame->ds_pics;
     context_ptr->me_context_ptr->me_ds_ref_array[0][0] = picture_control_set_ptr_frame->ds_pics;
     context_ptr->me_context_ptr->me_type = ME_MCTF;
 
@@ -2641,13 +2638,7 @@ static EbErrorType produce_temporally_filtered_pic(
                     context_ptr->temporal_layer_index = picture_control_set_ptr_central->temporal_layer_index;
                     context_ptr->is_used_as_reference_flag = picture_control_set_ptr_central->is_used_as_reference_flag;
 
-                    if (scs_ptr->in_loop_me) {
-                        //EbDownScaledObject* inl_downscaled_object = (EbDownScaledObject*)context_ptr->alt_ref_reference_ptr_inl;
-                        //context_ptr->me_ds_ref_array[0][0].picture_ptr = inl_downscaled_object->picture_ptr;
-                        //context_ptr->me_ds_ref_array[0][0].quarter_picture_ptr = inl_downscaled_object->quarter_picture_ptr;
-                        //context_ptr->me_ds_ref_array[0][0].sixteenth_picture_ptr = inl_downscaled_object->sixteenth_picture_ptr;
-                        //context_ptr->me_ds_ref_array[0][0] = context_ptr->mctf_ref_desc_ptr_array;
-                    } else {
+                    if (!scs_ptr->in_loop_me) {
                         EbPaReferenceObject *reference_object = (EbPaReferenceObject *)context_ptr->alt_ref_reference_ptr;
                         context_ptr->me_ds_ref_array[0][0].picture_ptr = reference_object->input_padded_picture_ptr;
                         context_ptr->me_ds_ref_array[0][0].sixteenth_picture_ptr = (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2917,6 +2917,7 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
 }
 
 #if FEATURE_INL_ME
+//  Inloop padding + decimation
 static void pad_and_decimate_filtered_pic_inl(
     PictureParentControlSet *picture_control_set_ptr_central) {
     // reference structures (padded pictures + downsampled versions)

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2791,6 +2791,20 @@ void pad_and_decimate_filtered_pic(
                          input_picture_ptr->height,
                          input_picture_ptr->origin_x,
                          input_picture_ptr->origin_y);
+#if FIX_PAD_CHROMA_AFTER_MCTF
+        generate_padding(input_picture_ptr->buffer_cb,
+                         input_picture_ptr->stride_cb,
+                         input_picture_ptr->width >> scs_ptr->subsampling_x,
+                         input_picture_ptr->height >> scs_ptr->subsampling_y,
+                         input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                         input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+        generate_padding(input_picture_ptr->buffer_cr,
+                         input_picture_ptr->stride_cr,
+                         input_picture_ptr->width >> scs_ptr->subsampling_x,
+                         input_picture_ptr->height >> scs_ptr->subsampling_y,
+                         input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                         input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+#endif
         for (uint32_t row = 0; row < input_picture_ptr->height; row++)
             eb_memcpy(pa + row * padded_pic_ptr->stride_y,
                       in + row * input_picture_ptr->stride_y,

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -1783,7 +1783,7 @@ EbErrorType first_pass_signal_derivation_multi_processes(SequenceControlSet *   
     // 9: (1,1) ; No-override features
     // Level 0 , 1  : set ref_list0_count_try and ref_list1_count_try and Override MRP-related features
     // Level 2 .. 9 : Only set ref_list0_count_try and ref_list1_count_try
-#if !FIX_TPL_TRAILING_FRAME_BUG
+#if !ENABLE_TPL_TRAILING
     pcs_ptr->tpl_opt_flag = 1;
 #endif
 #if ENABLE_TPL_TRAILING

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -1783,8 +1783,12 @@ EbErrorType first_pass_signal_derivation_multi_processes(SequenceControlSet *   
     // 9: (1,1) ; No-override features
     // Level 0 , 1  : set ref_list0_count_try and ref_list1_count_try and Override MRP-related features
     // Level 2 .. 9 : Only set ref_list0_count_try and ref_list1_count_try
-
+#if !FIX_TPL_TRAILING_FRAME_BUG
     pcs_ptr->tpl_opt_flag = 1;
+#endif
+#if ENABLE_TPL_TRAILING
+    pcs_ptr->tpl_trailing_frame_count = 0;
+#endif
     return return_error;
 }
 void set_txt_cycle_reduction_controls(ModeDecisionContext *mdctxt, uint8_t txt_cycles_red_mode);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -546,7 +546,27 @@ EbErrorType load_default_buffer_configuration_settings(
         //References. Min to sustain flow (RA-5L-MRP-ON) 7 pictures from previous MGs + 10 needed for curr mini-GoP
         min_ref = 17;
 
+
+#if FEATURE_INL_ME
+        if (scs_ptr->static_config.look_ahead_distance > 0)
+            min_me = min_parent;
+        else if (scs_ptr->static_config.enable_tpl_la)
+#if TUNE_INL_TPL_ENHANCEMENT
+#if ENABLE_TPL_TRAILING
+            // For TPL, in addition to frames in the minigop size, we might have upto SCD_LAD trailing frames. min_me is increaseed accordingly
+            min_me = mg_size + 1 + SCD_LAD;
+#else
+            //Now we only use minigop size for TPL, if enabled trailing frames, need to increase min_me accordingly
+        min_me = mg_size + 1;
+#endif
+#else
+            min_me = mg_size + 1 + 3; //TODO add Constant for 3
+#endif
+        else
+            min_me = 1;
+#else
         min_me = scs_ptr->static_config.look_ahead_distance==0 ? 1 : min_parent;
+#endif
 
         //Pa-References.Min to sustain flow (RA-5L-MRP-ON) -->TODO: derive numbers for other GOP Structures.
         min_paref = 25 + scs_ptr->scd_delay + eos_delay + (scs_ptr->static_config.enable_tpl_la ? needed_lad_pictures : 0);
@@ -605,6 +625,9 @@ EbErrorType load_default_buffer_configuration_settings(
     scs_ptr->picture_analysis_fifo_init_count            = 300;
     scs_ptr->picture_decision_fifo_init_count            = 300;
     scs_ptr->initial_rate_control_fifo_init_count        = 300;
+#if FEATURE_INL_ME
+    scs_ptr->in_loop_me_fifo_init_count                  = 300;
+#endif
     scs_ptr->picture_demux_fifo_init_count               = 300;
     scs_ptr->rate_control_tasks_fifo_init_count          = 300;
     scs_ptr->rate_control_fifo_init_count                = 301;
@@ -622,6 +645,10 @@ EbErrorType load_default_buffer_configuration_settings(
         scs_ptr->total_process_init_count += (scs_ptr->picture_analysis_process_init_count            = MAX(MIN(15, core_count >> 1), core_count / 6));
         scs_ptr->total_process_init_count += (scs_ptr->motion_estimation_process_init_count =  MAX(MIN(20, core_count >> 1), core_count / 3));//1);//
         scs_ptr->total_process_init_count += (scs_ptr->source_based_operations_process_init_count     = MAX(MIN(3, core_count >> 1), core_count / 12));
+#if FEATURE_INL_ME
+        // TODO: Tune the count here
+        scs_ptr->total_process_init_count += (scs_ptr->inlme_process_init_count                       = MAX(MIN(20, core_count >> 1), core_count / 3));
+#endif
         scs_ptr->total_process_init_count += (scs_ptr->mode_decision_configuration_process_init_count = MAX(MIN(3, core_count >> 1), core_count / 12));
         scs_ptr->total_process_init_count += (scs_ptr->enc_dec_process_init_count                     = MAX(MIN(40, core_count >> 1), core_count));
         scs_ptr->total_process_init_count += (scs_ptr->entropy_coding_process_init_count              = MAX(MIN(3, core_count >> 1), core_count / 12));
@@ -636,6 +663,9 @@ EbErrorType load_default_buffer_configuration_settings(
         scs_ptr->total_process_init_count += (scs_ptr->picture_analysis_process_init_count            = 1);
         scs_ptr->total_process_init_count += (scs_ptr->motion_estimation_process_init_count           = 1);
         scs_ptr->total_process_init_count += (scs_ptr->source_based_operations_process_init_count     = 1);
+#if FEATURE_INL_ME
+        scs_ptr->total_process_init_count += (scs_ptr->inlme_process_init_count                       = 1);
+#endif
         scs_ptr->total_process_init_count += (scs_ptr->mode_decision_configuration_process_init_count = 1);
         scs_ptr->total_process_init_count += (scs_ptr->enc_dec_process_init_count                     = 1);
         scs_ptr->total_process_init_count += (scs_ptr->entropy_coding_process_init_count              = 1);
@@ -665,7 +695,11 @@ EbErrorType load_default_buffer_configuration_settings(
 }
  // Rate Control
 static RateControlPorts rate_control_ports[] = {
+#if FEATURE_INL_ME
+    {RATE_CONTROL_INPUT_PORT_INLME,                 0},
+#else
     {RATE_CONTROL_INPUT_PORT_PICTURE_MANAGER,       0},
+#endif
     {RATE_CONTROL_INPUT_PORT_PACKETIZATION,         0},
     {RATE_CONTROL_INPUT_PORT_ENTROPY_CODING,        0},
     {RATE_CONTROL_INPUT_PORT_INVALID,               0}
@@ -756,6 +790,11 @@ static void eb_enc_handle_stop_threads(EbEncHandle *enc_handle_ptr)
     // Picture Manager
     EB_DESTROY_THREAD(enc_handle_ptr->picture_manager_thread_handle);
 
+#if FEATURE_INL_ME
+    // Inloop ME
+    EB_DESTROY_THREAD_ARRAY(enc_handle_ptr->ime_thread_handle_array, control_set_ptr->inlme_process_init_count);
+#endif
+
     // Rate Control
     EB_DESTROY_THREAD(enc_handle_ptr->rate_control_thread_handle);
 
@@ -794,6 +833,9 @@ static void eb_enc_handle_dctor(EbPtr p)
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->me_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->picture_control_set_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->pa_reference_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
+#if FEATURE_INL_ME
+    EB_DELETE_PTR_ARRAY(enc_handle_ptr->down_scaled_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
+#endif
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->overlay_input_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
     EB_DELETE(enc_handle_ptr->input_buffer_resource_ptr);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->output_stream_buffer_resource_ptr_array, enc_handle_ptr->encode_instance_total_count);
@@ -804,6 +846,9 @@ static void eb_enc_handle_dctor(EbPtr p)
     EB_DELETE(enc_handle_ptr->motion_estimation_results_resource_ptr);
     EB_DELETE(enc_handle_ptr->initial_rate_control_results_resource_ptr);
     EB_DELETE(enc_handle_ptr->picture_demux_results_resource_ptr);
+#if FEATURE_INL_ME
+    EB_DELETE(enc_handle_ptr->pic_mgr_res_srm);
+#endif
     EB_DELETE(enc_handle_ptr->rate_control_tasks_resource_ptr);
     EB_DELETE(enc_handle_ptr->rate_control_results_resource_ptr);
     EB_DELETE(enc_handle_ptr->enc_dec_tasks_resource_ptr);
@@ -817,6 +862,9 @@ static void eb_enc_handle_dctor(EbPtr p)
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->picture_analysis_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->picture_analysis_process_init_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->motion_estimation_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->motion_estimation_process_init_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->source_based_operations_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->source_based_operations_process_init_count);
+#if FEATURE_INL_ME
+    EB_DELETE_PTR_ARRAY(enc_handle_ptr->inlme_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->inlme_process_init_count);
+#endif
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->mode_decision_configuration_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->mode_decision_configuration_process_init_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->enc_dec_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->enc_dec_process_init_count);
     EB_DELETE_PTR_ARRAY(enc_handle_ptr->dlf_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->dlf_process_init_count);
@@ -947,6 +995,175 @@ EbErrorType rest_results_creator(
     return EB_ErrorNone;
 }
 
+#if FEATURE_INL_ME
+static int create_down_scaled_buf_descs(EbEncHandle *enc_handle_ptr, uint32_t instance_index)
+{
+    SequenceControlSet* scs_ptr = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr;
+    EbPictureBufferDescInitData       quart_pic_buf_desc_init_data;
+    EbPictureBufferDescInitData       sixteenth_pic_buf_desc_init_data;
+    EbDownScaledObjectDescInitData eb_down_scale_obj_init_data;
+    quart_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width >> 1;
+    quart_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height >> 1;
+    quart_pic_buf_desc_init_data.bit_depth = EB_8BIT;
+    quart_pic_buf_desc_init_data.color_format = EB_YUV420;
+    quart_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+    quart_pic_buf_desc_init_data.left_padding = scs_ptr->sb_sz >> 1;
+    quart_pic_buf_desc_init_data.right_padding = scs_ptr->sb_sz >> 1;
+    quart_pic_buf_desc_init_data.top_padding = scs_ptr->sb_sz >> 1;
+    quart_pic_buf_desc_init_data.bot_padding = scs_ptr->sb_sz >> 1;
+    quart_pic_buf_desc_init_data.split_mode = EB_FALSE;
+    //useless, don't need to store two, just use one
+    quart_pic_buf_desc_init_data.down_sampled_filtered = EB_FALSE;
+    quart_pic_buf_desc_init_data.mfmv = 0;
+    quart_pic_buf_desc_init_data.is_16bit_pipeline=EB_FALSE;
+
+    sixteenth_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width >> 2;
+    sixteenth_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height >> 2;
+    sixteenth_pic_buf_desc_init_data.bit_depth = EB_8BIT;
+    sixteenth_pic_buf_desc_init_data.color_format = EB_YUV420;
+    sixteenth_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+    sixteenth_pic_buf_desc_init_data.left_padding = scs_ptr->sb_sz >> 2;
+    sixteenth_pic_buf_desc_init_data.right_padding = scs_ptr->sb_sz >> 2;
+    sixteenth_pic_buf_desc_init_data.top_padding = scs_ptr->sb_sz >> 2;
+    sixteenth_pic_buf_desc_init_data.bot_padding = scs_ptr->sb_sz >> 2;
+    sixteenth_pic_buf_desc_init_data.split_mode = EB_FALSE;
+    //useless
+    sixteenth_pic_buf_desc_init_data.down_sampled_filtered = EB_FALSE;
+    sixteenth_pic_buf_desc_init_data.mfmv = 0;
+    sixteenth_pic_buf_desc_init_data.is_16bit_pipeline = EB_FALSE;
+
+    eb_down_scale_obj_init_data.quarter_picture_desc_init_data = quart_pic_buf_desc_init_data;
+    eb_down_scale_obj_init_data.sixteenth_picture_desc_init_data = sixteenth_pic_buf_desc_init_data;
+    //TODO: Need 1/4 and 1/16 for alt-ref
+    eb_down_scale_obj_init_data.enable_quarter_luma_input = 1;//(scs_ptr->gm_level == GM_DOWN) ? 1 : 0;
+    eb_down_scale_obj_init_data.enable_sixteenth_luma_input = 1;//(scs_ptr->gm_level == GM_DOWN16) ? 1 : 0;
+    EB_NEW(enc_handle_ptr->down_scaled_picture_pool_ptr_array[instance_index],
+            eb_system_resource_ctor,
+            scs_ptr->input_buffer_fifo_init_count,
+            EB_PictureDecisionProcessInitCount,
+            0,
+            eb_down_scaled_object_creator,
+            &(eb_down_scale_obj_init_data),
+            NULL);
+    // Set the SequenceControlSet Picture Pool Fifo Ptrs
+    enc_handle_ptr->scs_instance_array[instance_index]->encode_context_ptr->down_scaled_picture_pool_fifo_ptr =
+        eb_system_resource_get_producer_fifo(enc_handle_ptr->down_scaled_picture_pool_ptr_array[instance_index], 0);
+    return 0;
+}
+
+static int create_pa_ref_buf_descs(EbEncHandle *enc_handle_ptr, uint32_t instance_index, uint8_t in_loop_me)
+{
+        SequenceControlSet* scs_ptr = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr;
+        EbPaReferenceObjectDescInitData   eb_pa_ref_obj_ect_desc_init_data_structure;
+        eb_pa_ref_obj_ect_desc_init_data_structure.empty_pa_buffers = in_loop_me;
+        EbPictureBufferDescInitData       ref_pic_buf_desc_init_data;
+        EbPictureBufferDescInitData       quart_pic_buf_desc_init_data;
+        EbPictureBufferDescInitData       sixteenth_pic_buf_desc_init_data;
+        // PA Reference Picture Buffers
+        // Currently, only Luma samples are needed in the PA
+        ref_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width;
+        ref_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height;
+        ref_pic_buf_desc_init_data.bit_depth = EB_8BIT;
+        ref_pic_buf_desc_init_data.color_format = EB_YUV420; //use 420 for picture analysis
+        ref_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        ref_pic_buf_desc_init_data.left_padding = scs_ptr->sb_sz + ME_FILTER_TAP;
+        ref_pic_buf_desc_init_data.right_padding = scs_ptr->sb_sz + ME_FILTER_TAP;
+        ref_pic_buf_desc_init_data.top_padding = scs_ptr->sb_sz + ME_FILTER_TAP;
+        ref_pic_buf_desc_init_data.bot_padding = scs_ptr->sb_sz + ME_FILTER_TAP;
+        ref_pic_buf_desc_init_data.split_mode = EB_FALSE;
+        quart_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width >> 1;
+        quart_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height >> 1;
+        quart_pic_buf_desc_init_data.bit_depth = EB_8BIT;
+        quart_pic_buf_desc_init_data.color_format = EB_YUV420;
+        quart_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        quart_pic_buf_desc_init_data.left_padding = scs_ptr->sb_sz >> 1;
+        quart_pic_buf_desc_init_data.right_padding = scs_ptr->sb_sz >> 1;
+        quart_pic_buf_desc_init_data.top_padding = scs_ptr->sb_sz >> 1;
+        quart_pic_buf_desc_init_data.bot_padding = scs_ptr->sb_sz >> 1;
+        quart_pic_buf_desc_init_data.split_mode = EB_FALSE;
+        quart_pic_buf_desc_init_data.down_sampled_filtered = (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ? EB_TRUE : EB_FALSE;
+        sixteenth_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width >> 2;
+        sixteenth_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height >> 2;
+        sixteenth_pic_buf_desc_init_data.bit_depth = EB_8BIT;
+        sixteenth_pic_buf_desc_init_data.color_format = EB_YUV420;
+        sixteenth_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        sixteenth_pic_buf_desc_init_data.left_padding = scs_ptr->sb_sz >> 2;
+        sixteenth_pic_buf_desc_init_data.right_padding = scs_ptr->sb_sz >> 2;
+        sixteenth_pic_buf_desc_init_data.top_padding = scs_ptr->sb_sz >> 2;
+        sixteenth_pic_buf_desc_init_data.bot_padding = scs_ptr->sb_sz >> 2;
+        sixteenth_pic_buf_desc_init_data.split_mode = EB_FALSE;
+        sixteenth_pic_buf_desc_init_data.down_sampled_filtered = (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ? EB_TRUE : EB_FALSE;
+
+        eb_pa_ref_obj_ect_desc_init_data_structure.reference_picture_desc_init_data = ref_pic_buf_desc_init_data;
+        eb_pa_ref_obj_ect_desc_init_data_structure.quarter_picture_desc_init_data = quart_pic_buf_desc_init_data;
+        eb_pa_ref_obj_ect_desc_init_data_structure.sixteenth_picture_desc_init_data = sixteenth_pic_buf_desc_init_data;
+        // Reference Picture Buffers
+        EB_NEW(enc_handle_ptr->pa_reference_picture_pool_ptr_array[instance_index],
+            eb_system_resource_ctor,
+            scs_ptr->pa_reference_picture_buffer_init_count,
+            EB_PictureDecisionProcessInitCount,
+            0,
+            eb_pa_reference_object_creator,
+            &(eb_pa_ref_obj_ect_desc_init_data_structure),
+            NULL);
+        // Set the SequenceControlSet Picture Pool Fifo Ptrs
+        enc_handle_ptr->scs_instance_array[instance_index]->encode_context_ptr->pa_reference_picture_pool_fifo_ptr =
+            eb_system_resource_get_producer_fifo(enc_handle_ptr->pa_reference_picture_pool_ptr_array[instance_index], 0);
+        return 0;
+}
+
+static int create_ref_buf_descs(EbEncHandle *enc_handle_ptr, uint32_t instance_index)
+{
+    EbReferenceObjectDescInitData     eb_ref_obj_ect_desc_init_data_structure;
+    EbPictureBufferDescInitData       ref_pic_buf_desc_init_data;
+    SequenceControlSet* scs_ptr = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr;
+    EbBool is_16bit = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
+    // Initialize the various Picture types
+    ref_pic_buf_desc_init_data.max_width = scs_ptr->max_input_luma_width;
+    ref_pic_buf_desc_init_data.max_height = scs_ptr->max_input_luma_height;
+    ref_pic_buf_desc_init_data.bit_depth = scs_ptr->encoder_bit_depth;
+    ref_pic_buf_desc_init_data.color_format = scs_ptr->static_config.encoder_color_format;
+    ref_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+
+    ref_pic_buf_desc_init_data.left_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.right_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.top_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.bot_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.mfmv = scs_ptr->mfmv_enabled;
+    ref_pic_buf_desc_init_data.is_16bit_pipeline = scs_ptr->static_config.is_16bit_pipeline;
+    // Hsan: split_mode is set @ eb_reference_object_ctor() as both unpacked reference and packed reference are needed for a 10BIT input; unpacked reference @ MD, and packed reference @ EP
+
+    ref_pic_buf_desc_init_data.split_mode = EB_FALSE;
+    ref_pic_buf_desc_init_data.down_sampled_filtered = EB_FALSE;
+
+    if (is_16bit)
+        ref_pic_buf_desc_init_data.bit_depth = EB_10BIT;
+
+    eb_ref_obj_ect_desc_init_data_structure.reference_picture_desc_init_data = ref_pic_buf_desc_init_data;
+    eb_ref_obj_ect_desc_init_data_structure.hbd_mode_decision =
+        scs_ptr->static_config.enable_hbd_mode_decision;
+
+    // TODO: Need to put hme_decimation/enable_hme_flag into init stage to figure out whether we need down scaled_recon or not
+    eb_ref_obj_ect_desc_init_data_structure.hme_quarter_luma_recon = scs_ptr->in_loop_me;
+    eb_ref_obj_ect_desc_init_data_structure.hme_sixteenth_luma_recon = scs_ptr->in_loop_me;
+
+    // Reference Picture Buffers
+    EB_NEW(
+            enc_handle_ptr->reference_picture_pool_ptr_array[instance_index],
+            eb_system_resource_ctor,
+            scs_ptr->reference_picture_buffer_init_count,//enc_handle_ptr->ref_pic_pool_total_count,
+            EB_PictureManagerProcessInitCount,
+            0,
+            eb_reference_object_creator,
+            &(eb_ref_obj_ect_desc_init_data_structure),
+            NULL);
+
+    enc_handle_ptr->scs_instance_array[instance_index]->encode_context_ptr->reference_picture_pool_fifo_ptr =
+        eb_system_resource_get_producer_fifo(enc_handle_ptr->reference_picture_pool_ptr_array[instance_index], 0);
+    return 0;
+}
+#endif
+
 void init_fn_ptr(void);
 void eb_av1_init_wedge_masks(void);
 /**********************************
@@ -961,7 +1178,9 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     uint32_t instance_index;
     uint32_t process_index;
     uint32_t max_picture_width;
+#if !FEATURE_INL_ME
     EbBool is_16bit = (EbBool)(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
+#endif
     EbColorFormat color_format = enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.encoder_color_format;
     SequenceControlSet* control_set_ptr;
 
@@ -1108,12 +1327,20 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
 
     // Allocate Resource Arrays
     EB_ALLOC_PTR_ARRAY(enc_handle_ptr->reference_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
+#if FEATURE_INL_ME
+    if (enc_handle_ptr->scs_instance_array[0]->scs_ptr->in_loop_me)
+        EB_ALLOC_PTR_ARRAY(enc_handle_ptr->down_scaled_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
+#endif
     EB_ALLOC_PTR_ARRAY(enc_handle_ptr->pa_reference_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
 
     EB_ALLOC_PTR_ARRAY(enc_handle_ptr->overlay_input_picture_pool_ptr_array, enc_handle_ptr->encode_instance_total_count);
 
     // Rate Control
+#if FEATURE_INL_ME
+    rate_control_ports[0].count = enc_handle_ptr->scs_instance_array[0]->scs_ptr->inlme_process_init_count;
+#else
     rate_control_ports[0].count = EB_PictureManagerProcessInitCount;
+#endif
     rate_control_ports[1].count = EB_PacketizationProcessInitCount;
     rate_control_ports[2].count = enc_handle_ptr->scs_instance_array[0]->scs_ptr->entropy_coding_process_init_count;
     rate_control_ports[3].count = 0;
@@ -1122,6 +1349,7 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     enc_dec_ports[ENCDEC_INPUT_PORT_ENCDEC].count = enc_handle_ptr->scs_instance_array[0]->scs_ptr->enc_dec_process_init_count;
 
     for (instance_index = 0; instance_index < enc_handle_ptr->encode_instance_total_count; ++instance_index) {
+#if !FEATURE_INL_ME
         EbReferenceObjectDescInitData     eb_ref_obj_ect_desc_init_data_structure;
         EbPaReferenceObjectDescInitData   eb_pa_ref_obj_ect_desc_init_data_structure;
         EbPictureBufferDescInitData       ref_pic_buf_desc_init_data;
@@ -1214,7 +1442,15 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
         // Set the SequenceControlSet Picture Pool Fifo Ptrs
         enc_handle_ptr->scs_instance_array[instance_index]->encode_context_ptr->reference_picture_pool_fifo_ptr = eb_system_resource_get_producer_fifo(enc_handle_ptr->reference_picture_pool_ptr_array[instance_index], 0);
         enc_handle_ptr->scs_instance_array[instance_index]->encode_context_ptr->pa_reference_picture_pool_fifo_ptr = eb_system_resource_get_producer_fifo(enc_handle_ptr->pa_reference_picture_pool_ptr_array[instance_index], 0);
-
+#else
+        create_ref_buf_descs(enc_handle_ptr, instance_index);
+        if (enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr->in_loop_me) {
+            create_down_scaled_buf_descs(enc_handle_ptr, instance_index);
+            create_pa_ref_buf_descs(enc_handle_ptr, instance_index, 1); // create dummy pa surfaces
+        } else {
+            create_pa_ref_buf_descs(enc_handle_ptr, instance_index, 0);
+        }
+#endif
         if (enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.enable_overlays) {
             // Overlay Input Picture Buffers
             EB_NEW(
@@ -1371,6 +1607,23 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
             NULL);
 
     }
+
+#if FEATURE_INL_ME
+    // Picture Mgr Results
+    {
+        PictureManagerResultInitData picture_manager_result_init_data;
+        EB_NEW(
+            enc_handle_ptr->pic_mgr_res_srm,
+            eb_system_resource_ctor,
+            enc_handle_ptr->scs_instance_array[0]->scs_ptr->in_loop_me_fifo_init_count,
+            1, // One Producer = PicMgr
+            enc_handle_ptr->scs_instance_array[0]->scs_ptr->inlme_process_init_count,
+            picture_manager_result_creator,
+            &picture_manager_result_init_data,
+            NULL);
+
+    }
+#endif
 
     // Rate Control Tasks
     {
@@ -1571,11 +1824,32 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     }
 
     // Picture Manager Context
+#if FEATURE_INL_ME
+    EB_NEW(
+        enc_handle_ptr->picture_manager_context_ptr,
+        picture_manager_context_ctor,
+        enc_handle_ptr,
+        0);
+#else
     EB_NEW(
         enc_handle_ptr->picture_manager_context_ptr,
         picture_manager_context_ctor,
         enc_handle_ptr,
         rate_control_port_lookup(RATE_CONTROL_INPUT_PORT_PICTURE_MANAGER, 0));
+#endif
+
+#if FEATURE_INL_ME
+    // In-Loop ME Context
+    EB_ALLOC_PTR_ARRAY(enc_handle_ptr->inlme_context_ptr_array, enc_handle_ptr->scs_instance_array[0]->scs_ptr->inlme_process_init_count);
+
+    for (process_index = 0; process_index < enc_handle_ptr->scs_instance_array[0]->scs_ptr->inlme_process_init_count; ++process_index) {
+        EB_NEW(
+            enc_handle_ptr->inlme_context_ptr_array[process_index],
+            ime_context_ctor,
+            enc_handle_ptr,
+            process_index);
+    }
+#endif
 
     // Rate Control Context
     EB_NEW(
@@ -1704,6 +1978,13 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     // Picture Manager
     EB_CREATE_THREAD(enc_handle_ptr->picture_manager_thread_handle, picture_manager_kernel, enc_handle_ptr->picture_manager_context_ptr);
 
+#if FEATURE_INL_ME
+    // Close Loop Motion Estimation
+    EB_CREATE_THREAD_ARRAY(enc_handle_ptr->ime_thread_handle_array, control_set_ptr->inlme_process_init_count,
+            inloop_me_kernel,
+            enc_handle_ptr->inlme_context_ptr_array);
+#endif
+
     // Rate Control
     EB_CREATE_THREAD(enc_handle_ptr->rate_control_thread_handle, rate_control_kernel, enc_handle_ptr->rate_control_context_ptr);
 
@@ -1765,6 +2046,9 @@ EB_API EbErrorType svt_av1_enc_deinit(EbComponentType *svt_enc_component){
         eb_shutdown_process(handle->motion_estimation_results_resource_ptr);
         eb_shutdown_process(handle->initial_rate_control_results_resource_ptr);
         eb_shutdown_process(handle->picture_demux_results_resource_ptr);
+#if FEATURE_INL_ME
+        eb_shutdown_process(handle->pic_mgr_res_srm);
+#endif
         eb_shutdown_process(handle->rate_control_tasks_resource_ptr);
         eb_shutdown_process(handle->rate_control_results_resource_ptr);
         eb_shutdown_process(handle->enc_dec_tasks_resource_ptr);
@@ -2005,6 +2289,16 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
         else
             scs_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
 
+#if FEATURE_INL_ME
+    if (scs_ptr->static_config.rate_control_mode != 0 && !use_input_stat(scs_ptr))
+        scs_ptr->in_loop_me = 0;
+    else
+        scs_ptr->in_loop_me = 1;
+#endif
+#if TUNE_TPL_OIS
+        // Open loop intra done with TPL, data is not stored
+        scs_ptr->in_loop_ois = 1;
+#endif
 
     // Set over_boundary_block_mode     Settings
     // 0                            0: not allowed

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -95,8 +95,14 @@
 #define ENCDEC_INPUT_PORT_MDC                                0
 #define ENCDEC_INPUT_PORT_ENCDEC                             1
 #define ENCDEC_INPUT_PORT_INVALID                           -1
+#if !FEATURE_NEW_DELAY
 #define SCD_LAD                                             12
+#endif
+#if ENABLE_TPL_ZERO_LAD
+#define TPL_LAD                                              0
+#else
 #define TPL_LAD                                              16
+#endif
 
 /**************************************
  * Globals

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2297,10 +2297,6 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     else
         scs_ptr->in_loop_me = 1;
 #endif
-#if TUNE_TPL_OIS
-        // Open loop intra done with TPL, data is not stored
-        scs_ptr->in_loop_ois = 1;
-#endif
 
     // Set over_boundary_block_mode     Settings
     // 0                            0: not allowed

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2248,7 +2248,9 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
         scs_ptr->static_config.intra_refresh_type     = 2;
     }
     else if (use_input_stat(scs_ptr)) {
+#if !ENABLE_TPL_ZERO_LAD
         scs_ptr->static_config.look_ahead_distance = 16;
+#endif
         scs_ptr->static_config.enable_tpl_la = 1;
         scs_ptr->static_config.intra_refresh_type     = 2;
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.h
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.h
@@ -55,6 +55,9 @@ struct _EbEncHandle {
     // Picture Buffers
     EbSystemResource **reference_picture_pool_ptr_array;
     EbSystemResource **pa_reference_picture_pool_ptr_array;
+#if FEATURE_INL_ME
+    EbSystemResource **down_scaled_picture_pool_ptr_array;
+#endif
 
     // Overlay input picture
     EbSystemResource **overlay_input_picture_pool_ptr_array;
@@ -67,6 +70,9 @@ struct _EbEncHandle {
     EbHandle  initial_rate_control_thread_handle;
     EbHandle *source_based_operations_thread_handle_array;
     EbHandle  picture_manager_thread_handle;
+#if FEATURE_INL_ME
+    EbHandle *ime_thread_handle_array;
+#endif
     EbHandle  rate_control_thread_handle;
     EbHandle *mode_decision_configuration_thread_handle_array;
     EbHandle *enc_dec_thread_handle_array;
@@ -85,6 +91,9 @@ struct _EbEncHandle {
     EbThreadContext * initial_rate_control_context_ptr;
     EbThreadContext **source_based_operations_context_ptr_array;
     EbThreadContext * picture_manager_context_ptr;
+#if FEATURE_INL_ME
+    EbThreadContext **inlme_context_ptr_array;
+#endif
     EbThreadContext * rate_control_context_ptr;
     EbThreadContext **mode_decision_configuration_context_ptr_array;
     EbThreadContext **enc_dec_context_ptr_array;
@@ -105,6 +114,9 @@ struct _EbEncHandle {
     EbSystemResource * motion_estimation_results_resource_ptr;
     EbSystemResource * initial_rate_control_results_resource_ptr;
     EbSystemResource * picture_demux_results_resource_ptr;
+#if FEATURE_INL_ME
+    EbSystemResource * pic_mgr_res_srm;
+#endif
     EbSystemResource * rate_control_tasks_resource_ptr;
     EbSystemResource * rate_control_results_resource_ptr;
     EbSystemResource * enc_dec_tasks_resource_ptr;


### PR DESCRIPTION
# Description

- Move Motion Estimation and TPL inloop
- same BDR/speed performance 
- reduce memory footprint

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)

@anaghdin 
@chkngit 
@lijing0010 
@okhlif 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [x] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A


PSNR Y | PSNR  U | PSNR  V | Speed Dev | memeory   reduction
-- | -- | -- | -- | --
-0.05% | -1.64% | -1.34% | -0.09% | -31.89%




# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
