### PR TITLE
Actions: Remove set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          echo "::set-env name=CCACHE_DIR::$HOME/.ccache"
+          printf '%s\n' "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           sudo apt-get update
           sudo apt-get install -y ${{ env.native_deps }} ${{ matrix.packages }}
       - name: Configure SVT-AV1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,8 +39,9 @@ jobs:
           brew update
           brew upgrade -f
           brew install -f yasm ccache cmake
-          printf '%s\n' "::set-env name=PATH::/usr/local/opt/ccache/libexec:$PATH" \
-            "::set-env name=CCACHE_DIR::$HOME/.ccache"
+          printf '%s\n' \
+            "PATH=/usr/local/opt/ccache/libexec:$PATH" \
+            "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           clang -v
       - name: Run CMake
         run: cmake -S "$GITHUB_WORKSPACE" -B Build -G"${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
@@ -117,8 +118,8 @@ jobs:
             brew install -q yasm ccache cmake ninja
           } || brew update-reset
           printf '%s\n' \
-            "::set-env name=PATH::/usr/local/opt/ccache/libexec:$PATH" \
-            "::set-env name=CCACHE_DIR::$HOME/.ccache"
+            "PATH=/usr/local/opt/ccache/libexec:$PATH" \
+            "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           clang -v
           rm -rf macos-build
       - name: Run CMake

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -45,7 +45,7 @@ jobs:
           update: true
 
       - name: Set ccache dir
-        run: Write-Output "::set-env name=CCACHE_DIR::$PWD/.ccache"
+        run: echo "CCACHE_DIR=$PWD/.ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Clone SVT-AV1
         uses: actions/checkout@v2

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check dependencies
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          echo "::set-env name=CCACHE_DIR::$HOME/.ccache"
+          printf '%s\n' "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           $CC --version
           yasm --version
           cmake --version
@@ -145,8 +145,9 @@ jobs:
             ninja-build \
             python3{,-{pip,setuptools,wheel}}
           pip3 install --user meson
-          printf '%s\n' "::set-env name=CCACHE_DIR::$HOME/.ccache" \
-            "::set-env name=PATH::$PATH:$HOME/.local/bin"
+          printf '%s\n' \
+            "CCACHE_DIR=$HOME/.ccache" \
+            "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
       - name: Configure SVT-AV1
         run: cmake -S "$GITHUB_WORKSPACE" -B Build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr
       - name: Build and install SVT-AV1

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          echo "::set-env name=CCACHE_DIR::$HOME/.ccache"
+          printf '%s\n' "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           sudo apt-get update
           sudo apt-get install -y yasm ninja-build ccache
 


### PR DESCRIPTION
Signed-off-by: Luis Garcia <luigi311.lg@gmail.com>

# Description
Remove set-env since it is deprecated and replaced it with the new GITHUB_ENV version 

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Luis Garcia @luigi311 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
