### PR TITLE
Small speed improvement

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
@@ -6862,9 +6862,9 @@ static void idct64x64_avx2(__m256i *in, __m256i *out, int32_t bit, int32_t do_co
     }
 }
 
-void eb_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r,
-                                        uint16_t *output_w, int32_t stride_w, TxType tx_type,
-                                        int32_t bd) {
+void svt_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r,
+                                       uint16_t *output_w, int32_t stride_w, TxType tx_type,
+                                       int32_t bd) {
     __m256i       in[64 * 64 / 8], out[64 * 64 / 8];
     const int8_t *shift   = eb_inv_txfm_shift_ls[TX_64X64];
     const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
@@ -6883,7 +6883,7 @@ void eb_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, 
         break;
 
     default:
-        eb_av1_inv_txfm2d_add_64x64_c(input, output_r, stride_r, output_w, stride_w, tx_type, bd);
+        svt_av1_inv_txfm2d_add_64x64_c(input, output_r, stride_r, output_w, stride_w, tx_type, bd);
         break;
     }
 }

--- a/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
@@ -1118,6 +1118,46 @@ void eb_av1_inv_txfm2d_add_8x8_avx2(const int32_t *input, uint16_t *output_r, in
     const int32_t txh_idx = get_txh_idx(TX_8X8);
 
     switch (tx_type) {
+    case DCT_DCT:
+        load_buffer_8x8(input, in);
+        transpose_8x8_avx2(in, out);
+        idct8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        transpose_8x8_avx2(in, out);
+        round_shift_8x8(out, -shift[0]);
+        idct8_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_8x8(in, -shift[1]);
+        write_buffer_8x8(in, output_r, stride_r, output_w, stride_w, 0, 0, bd);
+        break;
+    case DCT_ADST:
+        load_buffer_8x8(input, in);
+        transpose_8x8_avx2(in, out);
+        iadst8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        transpose_8x8_avx2(in, out);
+        round_shift_8x8(out, -shift[0]);
+        idct8_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_8x8(in, -shift[1]);
+        write_buffer_8x8(in, output_r, stride_r, output_w, stride_w, 0, 0, bd);
+        break;
+    case ADST_DCT:
+        load_buffer_8x8(input, in);
+        transpose_8x8_avx2(in, out);
+        idct8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        transpose_8x8_avx2(in, out);
+        round_shift_8x8(out, -shift[0]);
+        iadst8_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_8x8(in, -shift[1]);
+        write_buffer_8x8(in, output_r, stride_r, output_w, stride_w, 0, 0, bd);
+        break;
+    case ADST_ADST:
+        load_buffer_8x8(input, in);
+        transpose_8x8_avx2(in, out);
+        iadst8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        transpose_8x8_avx2(in, out);
+        round_shift_8x8(out, -shift[0]);
+        iadst8_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_8x8(in, -shift[1]);
+        write_buffer_8x8(in, output_r, stride_r, output_w, stride_w, 0, 0, bd);
+        break;
     case IDTX:
         load_buffer_8x8(input, in);
         // Operations can be joined together without losing precision
@@ -1235,6 +1275,44 @@ static INLINE void write_buffer_16x16(__m256i *in, uint16_t *output_r, int32_t s
         v0 = _mm256_packus_epi32(v0, v1);
 
         _mm256_storeu_si256((__m256i *)output_w, v0);
+
+        output_r += stride_r;
+        output_w += stride_w;
+        i += 2;
+    }
+}
+
+static INLINE void write_buffer_16x16_new(__m256i *in, uint16_t *output_r, int32_t stride_r,
+                                          uint16_t *output_w, int32_t stride_w, int32_t bd) {
+    __m128i u0_a, u0_b;
+    __m256i u1_a, u1_b;
+    __m256i v0_a, v0_b;
+    __m128i p, q, r, s;
+
+    int32_t i = 0;
+
+    while (i < 32) {
+        u0_a = _mm_loadu_si128((const __m128i *)output_r);
+        u0_b = _mm_loadu_si128((const __m128i *)(output_r + 8));
+
+        u1_a = _mm256_cvtepu16_epi32(u0_a);
+        u1_b = _mm256_cvtepu16_epi32(u0_b);
+        v0_a = in[i];
+        v0_b = in[i + 1];
+
+        v0_a = _mm256_add_epi32(v0_a, u1_a);
+        v0_b = _mm256_add_epi32(v0_b, u1_b);
+
+        p    = _mm256_castsi256_si128(v0_a);
+        q    = _mm256_extracti128_si256(v0_a, 0x1);
+        r    = _mm256_castsi256_si128(v0_b);
+        s    = _mm256_extracti128_si256(v0_b, 0x1);
+        p    = _mm_packus_epi32(p, q);
+        r    = _mm_packus_epi32(r, s);
+        u1_a = _mm256_castsi128_si256(p);
+        u1_a = _mm256_insertf128_si256(u1_a, r, 0x1);
+        u1_a = highbd_clamp_epi16_avx2(u1_a, bd);
+        _mm256_storeu_si256((__m256i *)output_w, u1_a);
 
         output_r += stride_r;
         output_w += stride_w;
@@ -1605,6 +1683,46 @@ void eb_av1_inv_txfm2d_add_16x16_avx2(const int32_t *input, uint16_t *output_r, 
     const int32_t txh_idx = get_txh_idx(TX_16X16);
 
     switch (tx_type) {
+    case DCT_DCT:
+        load_buffer_16x16(input, in);
+        transpose_16x16_avx2(in, out);
+        idct16_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx], shift);
+        round_shift_16x16(in, -shift[0]);
+        transpose_16x16_avx2(in, out);
+        idct16_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx], shift);
+        round_shift_16x16(in, -shift[1]);
+        write_buffer_16x16_new(in, output_r, stride_r, output_w, stride_w, bd);
+        break;
+    case DCT_ADST:
+        load_buffer_16x16(input, in);
+        transpose_16x16_avx2(in, out);
+        iadst16_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        round_shift_16x16(in, -shift[0]);
+        transpose_16x16_avx2(in, out);
+        idct16_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx], shift);
+        round_shift_16x16(in, -shift[1]);
+        write_buffer_16x16_new(in, output_r, stride_r, output_w, stride_w, bd);
+        break;
+    case ADST_DCT:
+        load_buffer_16x16(input, in);
+        transpose_16x16_avx2(in, out);
+        idct16_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx], shift);
+        round_shift_16x16(in, -shift[0]);
+        transpose_16x16_avx2(in, out);
+        iadst16_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_16x16(in, -shift[1]);
+        write_buffer_16x16_new(in, output_r, stride_r, output_w, stride_w, bd);
+        break;
+    case ADST_ADST:
+        load_buffer_16x16(input, in);
+        transpose_16x16_avx2(in, out);
+        iadst16_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
+        round_shift_16x16(in, -shift[0]);
+        transpose_16x16_avx2(in, out);
+        iadst16_col_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx]);
+        round_shift_16x16(in, -shift[1]);
+        write_buffer_16x16_new(in, output_r, stride_r, output_w, stride_w, bd);
+        break;
     case IDTX:
         load_buffer_16x16(input, in);
         iidentity16_and_round_shift_avx2(in, -shift[0]);
@@ -6145,4 +6263,627 @@ void eb_av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *output_r, i
 
     eb_av1_highbd_inv_txfm2d_add_universe_avx2(
         input, output_r, stride_r, output_w, stride_w, tx_type, tx_size, eob, bd);
+}
+
+static void load_buffer_64x64_lower_32x32_avx2(const int32_t *coeff, __m256i *in) {
+    int32_t i, j;
+
+    __m256i zero = _mm256_setzero_si256();
+
+    for (i = 0; i < 32; ++i) {
+        for (j = 0; j < 4; ++j) {
+            in[8 * i + j]     = _mm256_loadu_si256((const __m256i *)(coeff + 32 * i + 8 * j));
+            in[8 * i + j + 4] = zero;
+        }
+    }
+
+    for (i = 0; i < 256; ++i) in[256 + i] = zero;
+}
+
+static INLINE void transpose_8nx8n(const __m256i *input, __m256i *output, const int32_t width,
+                                   const int32_t height) {
+    const int32_t numcol = height >> 3;
+    const int32_t numrow = width >> 3;
+    __m256i       out1[8];
+    for (int32_t j = 0; j < numrow; j++) {
+        for (int32_t i = 0; i < numcol; i++) {
+            TRANSPOSE_4X4_AVX2(input[i * width + j + (numrow * 0)],
+                               input[i * width + j + (numrow * 1)],
+                               input[i * width + j + (numrow * 2)],
+                               input[i * width + j + (numrow * 3)],
+                               out1[0],
+                               out1[1],
+                               out1[4],
+                               out1[5]);
+            TRANSPOSE_4X4_AVX2(input[i * width + j + (numrow * 4)],
+                               input[i * width + j + (numrow * 5)],
+                               input[i * width + j + (numrow * 6)],
+                               input[i * width + j + (numrow * 7)],
+                               out1[2],
+                               out1[3],
+                               out1[6],
+                               out1[7]);
+            output[j * height + i + (numcol * 0)] = _mm256_permute2x128_si256(
+                out1[0], out1[2], 0x20);
+            output[j * height + i + (numcol * 1)] = _mm256_permute2x128_si256(
+                out1[1], out1[3], 0x20);
+            output[j * height + i + (numcol * 2)] = _mm256_permute2x128_si256(
+                out1[4], out1[6], 0x20);
+            output[j * height + i + (numcol * 3)] = _mm256_permute2x128_si256(
+                out1[5], out1[7], 0x20);
+            output[j * height + i + (numcol * 4)] = _mm256_permute2x128_si256(
+                out1[0], out1[2], 0x31);
+            output[j * height + i + (numcol * 5)] = _mm256_permute2x128_si256(
+                out1[1], out1[3], 0x31);
+            output[j * height + i + (numcol * 6)] = _mm256_permute2x128_si256(
+                out1[4], out1[6], 0x31);
+            output[j * height + i + (numcol * 7)] = _mm256_permute2x128_si256(
+                out1[5], out1[7], 0x31);
+        }
+    }
+}
+
+static void round_shift_64x64_avx2(__m256i *in, const int8_t shift) {
+    uint8_t ushift = (uint8_t)shift;
+    __m256i rnding = _mm256_set1_epi32(1 << (ushift - 1));
+
+    for (int32_t i = 0; i < 512; i += 4) {
+        in[i]     = _mm256_add_epi32(in[i], rnding);
+        in[i + 1] = _mm256_add_epi32(in[i + 1], rnding);
+        in[i + 2] = _mm256_add_epi32(in[i + 2], rnding);
+        in[i + 3] = _mm256_add_epi32(in[i + 3], rnding);
+
+        in[i]     = _mm256_srai_epi32(in[i], ushift);
+        in[i + 1] = _mm256_srai_epi32(in[i + 1], ushift);
+        in[i + 2] = _mm256_srai_epi32(in[i + 2], ushift);
+        in[i + 3] = _mm256_srai_epi32(in[i + 3], ushift);
+    }
+}
+
+static void assign_32x32_input_from_64x64(const __m256i *in, __m256i *in32x32, int32_t col) {
+    int32_t i;
+    for (i = 0; i < 32 * 32 / 8; i += 4) {
+        in32x32[i]     = in[col];
+        in32x32[i + 1] = in[col + 1];
+        in32x32[i + 2] = in[col + 2];
+        in32x32[i + 3] = in[col + 3];
+        col += 8;
+    }
+}
+
+static void assign_16x16_input_from_32x32(const __m256i *in, __m256i *in16x16, int32_t col) {
+    int32_t i;
+    for (i = 0; i < 32; i += 2) {
+        in16x16[i]     = in[col];
+        in16x16[i + 1] = in[col + 1];
+        col += 4;
+    }
+}
+
+static void write_buffer_32x32_new(__m256i *in, uint16_t *output_r, int32_t stride_r,
+                                   uint16_t *output_w, int32_t stride_w, int32_t bd) {
+    __m256i   in16x16[32];
+    uint16_t *left_up_r    = &output_r[0];
+    uint16_t *right_up_r   = &output_r[16];
+    uint16_t *left_down_r  = &output_r[16 * stride_r];
+    uint16_t *right_down_r = &output_r[16 * stride_r + 16];
+    uint16_t *left_up_w    = &output_w[0];
+    uint16_t *right_up_w   = &output_w[16];
+    uint16_t *left_down_w  = &output_w[16 * stride_w];
+    uint16_t *right_down_w = &output_w[16 * stride_w + 16];
+
+    // Left-up quarter
+    assign_16x16_input_from_32x32(in, in16x16, 0);
+    write_buffer_16x16_new(in16x16, left_up_r, stride_r, left_up_w, stride_w, bd);
+
+    // Right-up quarter
+    assign_16x16_input_from_32x32(in, in16x16, 32 / 2 / 8);
+    write_buffer_16x16_new(in16x16, right_up_r, stride_r, right_up_w, stride_w, bd);
+
+    // Left-down quarter
+    assign_16x16_input_from_32x32(in, in16x16, 32 * 32 / 2 / 8);
+    write_buffer_16x16_new(in16x16, left_down_r, stride_r, left_down_w, stride_w, bd);
+
+    // Right-down quarter
+    assign_16x16_input_from_32x32(in, in16x16, 32 * 32 / 2 / 8 + 32 / 2 / 8);
+    write_buffer_16x16_new(in16x16, right_down_r, stride_r, right_down_w, stride_w, bd);
+}
+
+static void write_buffer_64x64_avx2(__m256i *in, uint16_t *output_r, int32_t stride_r,
+                                   uint16_t *output_w, int32_t stride_w, int32_t bd) {
+    __m256i   in32x32[32 * 32 / 8];
+    uint16_t *left_up_r    = &output_r[0];
+    uint16_t *right_up_r   = &output_r[32];
+    uint16_t *left_down_r  = &output_r[32 * stride_r];
+    uint16_t *right_down_r = &output_r[32 * stride_r + 32];
+    uint16_t *left_up_w    = &output_w[0];
+    uint16_t *right_up_w   = &output_w[32];
+    uint16_t *left_down_w  = &output_w[32 * stride_w];
+    uint16_t *right_down_w = &output_w[32 * stride_w + 32];
+
+    // Left-up quarter
+    assign_32x32_input_from_64x64(in, in32x32, 0);
+    write_buffer_32x32_new(in32x32, left_up_r, stride_r, left_up_w, stride_w, bd);
+
+    // Right-up quarter
+    assign_32x32_input_from_64x64(in, in32x32, 64 / 2 / 8);
+    write_buffer_32x32_new(in32x32, right_up_r, stride_r, right_up_w, stride_w, bd);
+
+    // Left-down quarter
+    assign_32x32_input_from_64x64(in, in32x32, 64 * 64 / 2 / 8);
+    write_buffer_32x32_new(in32x32, left_down_r, stride_r, left_down_w, stride_w, bd);
+
+    // Right-down quarter
+    assign_32x32_input_from_64x64(in, in32x32, 64 * 64 / 2 / 8 + 64 / 2 / 8);
+    write_buffer_32x32_new(in32x32, right_down_r, stride_r, right_down_w, stride_w, bd);
+}
+
+static void idct64x64_avx2(__m256i *in, __m256i *out, int32_t bit, int32_t do_cols, int32_t bd) {
+    int32_t        i, j;
+    const int32_t *cospi     = cospi_arr(bit);
+    const __m256i  rnding    = _mm256_set1_epi32(1 << (bit - 1));
+    const int32_t  log_range = AOMMAX(16, bd + (do_cols ? 6 : 8));
+    const __m256i  clamp_lo  = _mm256_set1_epi32(-(1 << (log_range - 1)));
+    const __m256i  clamp_hi  = _mm256_set1_epi32((1 << (log_range - 1)) - 1);
+    int32_t        col;
+
+    const __m256i cospi1  = _mm256_set1_epi32(cospi[1]);
+    const __m256i cospi2  = _mm256_set1_epi32(cospi[2]);
+    const __m256i cospi3  = _mm256_set1_epi32(cospi[3]);
+    const __m256i cospi4  = _mm256_set1_epi32(cospi[4]);
+    const __m256i cospi5  = _mm256_set1_epi32(cospi[5]);
+    const __m256i cospi6  = _mm256_set1_epi32(cospi[6]);
+    const __m256i cospi7  = _mm256_set1_epi32(cospi[7]);
+    const __m256i cospi8  = _mm256_set1_epi32(cospi[8]);
+    const __m256i cospi9  = _mm256_set1_epi32(cospi[9]);
+    const __m256i cospi10 = _mm256_set1_epi32(cospi[10]);
+    const __m256i cospi11 = _mm256_set1_epi32(cospi[11]);
+    const __m256i cospi12 = _mm256_set1_epi32(cospi[12]);
+    const __m256i cospi13 = _mm256_set1_epi32(cospi[13]);
+    const __m256i cospi14 = _mm256_set1_epi32(cospi[14]);
+    const __m256i cospi15 = _mm256_set1_epi32(cospi[15]);
+    const __m256i cospi16 = _mm256_set1_epi32(cospi[16]);
+    const __m256i cospi17 = _mm256_set1_epi32(cospi[17]);
+    const __m256i cospi18 = _mm256_set1_epi32(cospi[18]);
+    const __m256i cospi19 = _mm256_set1_epi32(cospi[19]);
+    const __m256i cospi20 = _mm256_set1_epi32(cospi[20]);
+    const __m256i cospi21 = _mm256_set1_epi32(cospi[21]);
+    const __m256i cospi22 = _mm256_set1_epi32(cospi[22]);
+    const __m256i cospi23 = _mm256_set1_epi32(cospi[23]);
+    const __m256i cospi24 = _mm256_set1_epi32(cospi[24]);
+    const __m256i cospi25 = _mm256_set1_epi32(cospi[25]);
+    const __m256i cospi26 = _mm256_set1_epi32(cospi[26]);
+    const __m256i cospi27 = _mm256_set1_epi32(cospi[27]);
+    const __m256i cospi28 = _mm256_set1_epi32(cospi[28]);
+    const __m256i cospi29 = _mm256_set1_epi32(cospi[29]);
+    const __m256i cospi30 = _mm256_set1_epi32(cospi[30]);
+    const __m256i cospi31 = _mm256_set1_epi32(cospi[31]);
+    const __m256i cospi32 = _mm256_set1_epi32(cospi[32]);
+    const __m256i cospi35 = _mm256_set1_epi32(cospi[35]);
+    const __m256i cospi36 = _mm256_set1_epi32(cospi[36]);
+    const __m256i cospi38 = _mm256_set1_epi32(cospi[38]);
+    const __m256i cospi39 = _mm256_set1_epi32(cospi[39]);
+    const __m256i cospi40 = _mm256_set1_epi32(cospi[40]);
+    const __m256i cospi43 = _mm256_set1_epi32(cospi[43]);
+    const __m256i cospi44 = _mm256_set1_epi32(cospi[44]);
+    const __m256i cospi46 = _mm256_set1_epi32(cospi[46]);
+    const __m256i cospi47 = _mm256_set1_epi32(cospi[47]);
+    const __m256i cospi48 = _mm256_set1_epi32(cospi[48]);
+    const __m256i cospi51 = _mm256_set1_epi32(cospi[51]);
+    const __m256i cospi52 = _mm256_set1_epi32(cospi[52]);
+    const __m256i cospi54 = _mm256_set1_epi32(cospi[54]);
+    const __m256i cospi55 = _mm256_set1_epi32(cospi[55]);
+    const __m256i cospi56 = _mm256_set1_epi32(cospi[56]);
+    const __m256i cospi59 = _mm256_set1_epi32(cospi[59]);
+    const __m256i cospi60 = _mm256_set1_epi32(cospi[60]);
+    const __m256i cospi62 = _mm256_set1_epi32(cospi[62]);
+    const __m256i cospi63 = _mm256_set1_epi32(cospi[63]);
+
+    const __m256i cospim4  = _mm256_set1_epi32(-cospi[4]);
+    const __m256i cospim8  = _mm256_set1_epi32(-cospi[8]);
+    const __m256i cospim12 = _mm256_set1_epi32(-cospi[12]);
+    const __m256i cospim16 = _mm256_set1_epi32(-cospi[16]);
+    const __m256i cospim20 = _mm256_set1_epi32(-cospi[20]);
+    const __m256i cospim24 = _mm256_set1_epi32(-cospi[24]);
+    const __m256i cospim28 = _mm256_set1_epi32(-cospi[28]);
+    const __m256i cospim32 = _mm256_set1_epi32(-cospi[32]);
+    const __m256i cospim33 = _mm256_set1_epi32(-cospi[33]);
+    const __m256i cospim34 = _mm256_set1_epi32(-cospi[34]);
+    const __m256i cospim36 = _mm256_set1_epi32(-cospi[36]);
+    const __m256i cospim37 = _mm256_set1_epi32(-cospi[37]);
+    const __m256i cospim40 = _mm256_set1_epi32(-cospi[40]);
+    const __m256i cospim41 = _mm256_set1_epi32(-cospi[41]);
+    const __m256i cospim42 = _mm256_set1_epi32(-cospi[42]);
+    const __m256i cospim44 = _mm256_set1_epi32(-cospi[44]);
+    const __m256i cospim45 = _mm256_set1_epi32(-cospi[45]);
+    const __m256i cospim48 = _mm256_set1_epi32(-cospi[48]);
+    const __m256i cospim49 = _mm256_set1_epi32(-cospi[49]);
+    const __m256i cospim50 = _mm256_set1_epi32(-cospi[50]);
+    const __m256i cospim52 = _mm256_set1_epi32(-cospi[52]);
+    const __m256i cospim53 = _mm256_set1_epi32(-cospi[53]);
+    const __m256i cospim56 = _mm256_set1_epi32(-cospi[56]);
+    const __m256i cospim57 = _mm256_set1_epi32(-cospi[57]);
+    const __m256i cospim58 = _mm256_set1_epi32(-cospi[58]);
+    const __m256i cospim60 = _mm256_set1_epi32(-cospi[60]);
+    const __m256i cospim61 = _mm256_set1_epi32(-cospi[61]);
+
+    for (col = 0; col < (do_cols ? 64 / 8 : 32 / 8); ++col) {
+        __m256i u[64], v[64];
+
+        // stage 1
+        u[32] = in[1 * 8 + col];
+        u[34] = in[17 * 8 + col];
+        u[36] = in[9 * 8 + col];
+        u[38] = in[25 * 8 + col];
+        u[40] = in[5 * 8 + col];
+        u[42] = in[21 * 8 + col];
+        u[44] = in[13 * 8 + col];
+        u[46] = in[29 * 8 + col];
+        u[48] = in[3 * 8 + col];
+        u[50] = in[19 * 8 + col];
+        u[52] = in[11 * 8 + col];
+        u[54] = in[27 * 8 + col];
+        u[56] = in[7 * 8 + col];
+        u[58] = in[23 * 8 + col];
+        u[60] = in[15 * 8 + col];
+        u[62] = in[31 * 8 + col];
+
+        v[16] = in[2 * 8 + col];
+        v[18] = in[18 * 8 + col];
+        v[20] = in[10 * 8 + col];
+        v[22] = in[26 * 8 + col];
+        v[24] = in[6 * 8 + col];
+        v[26] = in[22 * 8 + col];
+        v[28] = in[14 * 8 + col];
+        v[30] = in[30 * 8 + col];
+
+        u[8]  = in[4 * 8 + col];
+        u[10] = in[20 * 8 + col];
+        u[12] = in[12 * 8 + col];
+        u[14] = in[28 * 8 + col];
+
+        v[4] = in[8 * 8 + col];
+        v[6] = in[24 * 8 + col];
+
+        u[0] = in[0 * 8 + col];
+        u[2] = in[16 * 8 + col];
+
+        // stage 2
+        v[32] = half_btf_0_avx2(&cospi63, &u[32], &rnding, bit);
+        v[33] = half_btf_0_avx2(&cospim33, &u[62], &rnding, bit);
+        v[34] = half_btf_0_avx2(&cospi47, &u[34], &rnding, bit);
+        v[35] = half_btf_0_avx2(&cospim49, &u[60], &rnding, bit);
+        v[36] = half_btf_0_avx2(&cospi55, &u[36], &rnding, bit);
+        v[37] = half_btf_0_avx2(&cospim41, &u[58], &rnding, bit);
+        v[38] = half_btf_0_avx2(&cospi39, &u[38], &rnding, bit);
+        v[39] = half_btf_0_avx2(&cospim57, &u[56], &rnding, bit);
+        v[40] = half_btf_0_avx2(&cospi59, &u[40], &rnding, bit);
+        v[41] = half_btf_0_avx2(&cospim37, &u[54], &rnding, bit);
+        v[42] = half_btf_0_avx2(&cospi43, &u[42], &rnding, bit);
+        v[43] = half_btf_0_avx2(&cospim53, &u[52], &rnding, bit);
+        v[44] = half_btf_0_avx2(&cospi51, &u[44], &rnding, bit);
+        v[45] = half_btf_0_avx2(&cospim45, &u[50], &rnding, bit);
+        v[46] = half_btf_0_avx2(&cospi35, &u[46], &rnding, bit);
+        v[47] = half_btf_0_avx2(&cospim61, &u[48], &rnding, bit);
+        v[48] = half_btf_0_avx2(&cospi3, &u[48], &rnding, bit);
+        v[49] = half_btf_0_avx2(&cospi29, &u[46], &rnding, bit);
+        v[50] = half_btf_0_avx2(&cospi19, &u[50], &rnding, bit);
+        v[51] = half_btf_0_avx2(&cospi13, &u[44], &rnding, bit);
+        v[52] = half_btf_0_avx2(&cospi11, &u[52], &rnding, bit);
+        v[53] = half_btf_0_avx2(&cospi21, &u[42], &rnding, bit);
+        v[54] = half_btf_0_avx2(&cospi27, &u[54], &rnding, bit);
+        v[55] = half_btf_0_avx2(&cospi5, &u[40], &rnding, bit);
+        v[56] = half_btf_0_avx2(&cospi7, &u[56], &rnding, bit);
+        v[57] = half_btf_0_avx2(&cospi25, &u[38], &rnding, bit);
+        v[58] = half_btf_0_avx2(&cospi23, &u[58], &rnding, bit);
+        v[59] = half_btf_0_avx2(&cospi9, &u[36], &rnding, bit);
+        v[60] = half_btf_0_avx2(&cospi15, &u[60], &rnding, bit);
+        v[61] = half_btf_0_avx2(&cospi17, &u[34], &rnding, bit);
+        v[62] = half_btf_0_avx2(&cospi31, &u[62], &rnding, bit);
+        v[63] = half_btf_0_avx2(&cospi1, &u[32], &rnding, bit);
+
+        // stage 3
+        u[16] = half_btf_0_avx2(&cospi62, &v[16], &rnding, bit);
+        u[17] = half_btf_0_avx2(&cospim34, &v[30], &rnding, bit);
+        u[18] = half_btf_0_avx2(&cospi46, &v[18], &rnding, bit);
+        u[19] = half_btf_0_avx2(&cospim50, &v[28], &rnding, bit);
+        u[20] = half_btf_0_avx2(&cospi54, &v[20], &rnding, bit);
+        u[21] = half_btf_0_avx2(&cospim42, &v[26], &rnding, bit);
+        u[22] = half_btf_0_avx2(&cospi38, &v[22], &rnding, bit);
+        u[23] = half_btf_0_avx2(&cospim58, &v[24], &rnding, bit);
+        u[24] = half_btf_0_avx2(&cospi6, &v[24], &rnding, bit);
+        u[25] = half_btf_0_avx2(&cospi26, &v[22], &rnding, bit);
+        u[26] = half_btf_0_avx2(&cospi22, &v[26], &rnding, bit);
+        u[27] = half_btf_0_avx2(&cospi10, &v[20], &rnding, bit);
+        u[28] = half_btf_0_avx2(&cospi14, &v[28], &rnding, bit);
+        u[29] = half_btf_0_avx2(&cospi18, &v[18], &rnding, bit);
+        u[30] = half_btf_0_avx2(&cospi30, &v[30], &rnding, bit);
+        u[31] = half_btf_0_avx2(&cospi2, &v[16], &rnding, bit);
+
+        for (i = 32; i < 64; i += 4) {
+            addsub_avx2(v[i + 0], v[i + 1], &u[i + 0], &u[i + 1], &clamp_lo, &clamp_hi);
+            addsub_avx2(v[i + 3], v[i + 2], &u[i + 3], &u[i + 2], &clamp_lo, &clamp_hi);
+        }
+
+        // stage 4
+        v[8]  = half_btf_0_avx2(&cospi60, &u[8], &rnding, bit);
+        v[9]  = half_btf_0_avx2(&cospim36, &u[14], &rnding, bit);
+        v[10] = half_btf_0_avx2(&cospi44, &u[10], &rnding, bit);
+        v[11] = half_btf_0_avx2(&cospim52, &u[12], &rnding, bit);
+        v[12] = half_btf_0_avx2(&cospi12, &u[12], &rnding, bit);
+        v[13] = half_btf_0_avx2(&cospi20, &u[10], &rnding, bit);
+        v[14] = half_btf_0_avx2(&cospi28, &u[14], &rnding, bit);
+        v[15] = half_btf_0_avx2(&cospi4, &u[8], &rnding, bit);
+
+        for (i = 16; i < 32; i += 4) {
+            addsub_avx2(u[i + 0], u[i + 1], &v[i + 0], &v[i + 1], &clamp_lo, &clamp_hi);
+            addsub_avx2(u[i + 3], u[i + 2], &v[i + 3], &v[i + 2], &clamp_lo, &clamp_hi);
+        }
+
+        for (i = 32; i < 64; i += 4) {
+            v[i + 0] = u[i + 0];
+            v[i + 3] = u[i + 3];
+        }
+
+        v[33] = half_btf_avx2(&cospim4, &u[33], &cospi60, &u[62], &rnding, bit);
+        v[34] = half_btf_avx2(&cospim60, &u[34], &cospim4, &u[61], &rnding, bit);
+        v[37] = half_btf_avx2(&cospim36, &u[37], &cospi28, &u[58], &rnding, bit);
+        v[38] = half_btf_avx2(&cospim28, &u[38], &cospim36, &u[57], &rnding, bit);
+        v[41] = half_btf_avx2(&cospim20, &u[41], &cospi44, &u[54], &rnding, bit);
+        v[42] = half_btf_avx2(&cospim44, &u[42], &cospim20, &u[53], &rnding, bit);
+        v[45] = half_btf_avx2(&cospim52, &u[45], &cospi12, &u[50], &rnding, bit);
+        v[46] = half_btf_avx2(&cospim12, &u[46], &cospim52, &u[49], &rnding, bit);
+        v[49] = half_btf_avx2(&cospim52, &u[46], &cospi12, &u[49], &rnding, bit);
+        v[50] = half_btf_avx2(&cospi12, &u[45], &cospi52, &u[50], &rnding, bit);
+        v[53] = half_btf_avx2(&cospim20, &u[42], &cospi44, &u[53], &rnding, bit);
+        v[54] = half_btf_avx2(&cospi44, &u[41], &cospi20, &u[54], &rnding, bit);
+        v[57] = half_btf_avx2(&cospim36, &u[38], &cospi28, &u[57], &rnding, bit);
+        v[58] = half_btf_avx2(&cospi28, &u[37], &cospi36, &u[58], &rnding, bit);
+        v[61] = half_btf_avx2(&cospim4, &u[34], &cospi60, &u[61], &rnding, bit);
+        v[62] = half_btf_avx2(&cospi60, &u[33], &cospi4, &u[62], &rnding, bit);
+
+        // stage 5
+        u[4] = half_btf_0_avx2(&cospi56, &v[4], &rnding, bit);
+        u[5] = half_btf_0_avx2(&cospim40, &v[6], &rnding, bit);
+        u[6] = half_btf_0_avx2(&cospi24, &v[6], &rnding, bit);
+        u[7] = half_btf_0_avx2(&cospi8, &v[4], &rnding, bit);
+
+        for (i = 8; i < 16; i += 4) {
+            addsub_avx2(v[i + 0], v[i + 1], &u[i + 0], &u[i + 1], &clamp_lo, &clamp_hi);
+            addsub_avx2(v[i + 3], v[i + 2], &u[i + 3], &u[i + 2], &clamp_lo, &clamp_hi);
+        }
+
+        for (i = 16; i < 32; i += 4) {
+            u[i + 0] = v[i + 0];
+            u[i + 3] = v[i + 3];
+        }
+
+        u[17] = half_btf_avx2(&cospim8, &v[17], &cospi56, &v[30], &rnding, bit);
+        u[18] = half_btf_avx2(&cospim56, &v[18], &cospim8, &v[29], &rnding, bit);
+        u[21] = half_btf_avx2(&cospim40, &v[21], &cospi24, &v[26], &rnding, bit);
+        u[22] = half_btf_avx2(&cospim24, &v[22], &cospim40, &v[25], &rnding, bit);
+        u[25] = half_btf_avx2(&cospim40, &v[22], &cospi24, &v[25], &rnding, bit);
+        u[26] = half_btf_avx2(&cospi24, &v[21], &cospi40, &v[26], &rnding, bit);
+        u[29] = half_btf_avx2(&cospim8, &v[18], &cospi56, &v[29], &rnding, bit);
+        u[30] = half_btf_avx2(&cospi56, &v[17], &cospi8, &v[30], &rnding, bit);
+
+        for (i = 32; i < 64; i += 8) {
+            addsub_avx2(v[i + 0], v[i + 3], &u[i + 0], &u[i + 3], &clamp_lo, &clamp_hi);
+            addsub_avx2(v[i + 1], v[i + 2], &u[i + 1], &u[i + 2], &clamp_lo, &clamp_hi);
+
+            addsub_avx2(v[i + 7], v[i + 4], &u[i + 7], &u[i + 4], &clamp_lo, &clamp_hi);
+            addsub_avx2(v[i + 6], v[i + 5], &u[i + 6], &u[i + 5], &clamp_lo, &clamp_hi);
+        }
+
+        // stage 6
+        v[0] = half_btf_0_avx2(&cospi32, &u[0], &rnding, bit);
+        v[1] = half_btf_0_avx2(&cospi32, &u[0], &rnding, bit);
+        v[2] = half_btf_0_avx2(&cospi48, &u[2], &rnding, bit);
+        v[3] = half_btf_0_avx2(&cospi16, &u[2], &rnding, bit);
+
+        addsub_avx2(u[4], u[5], &v[4], &v[5], &clamp_lo, &clamp_hi);
+        addsub_avx2(u[7], u[6], &v[7], &v[6], &clamp_lo, &clamp_hi);
+
+        for (i = 8; i < 16; i += 4) {
+            v[i + 0] = u[i + 0];
+            v[i + 3] = u[i + 3];
+        }
+
+        v[9]  = half_btf_avx2(&cospim16, &u[9], &cospi48, &u[14], &rnding, bit);
+        v[10] = half_btf_avx2(&cospim48, &u[10], &cospim16, &u[13], &rnding, bit);
+        v[13] = half_btf_avx2(&cospim16, &u[10], &cospi48, &u[13], &rnding, bit);
+        v[14] = half_btf_avx2(&cospi48, &u[9], &cospi16, &u[14], &rnding, bit);
+
+        for (i = 16; i < 32; i += 8) {
+            addsub_avx2(u[i + 0], u[i + 3], &v[i + 0], &v[i + 3], &clamp_lo, &clamp_hi);
+            addsub_avx2(u[i + 1], u[i + 2], &v[i + 1], &v[i + 2], &clamp_lo, &clamp_hi);
+
+            addsub_avx2(u[i + 7], u[i + 4], &v[i + 7], &v[i + 4], &clamp_lo, &clamp_hi);
+            addsub_avx2(u[i + 6], u[i + 5], &v[i + 6], &v[i + 5], &clamp_lo, &clamp_hi);
+        }
+
+        for (i = 32; i < 64; i += 8) {
+            v[i + 0] = u[i + 0];
+            v[i + 1] = u[i + 1];
+            v[i + 6] = u[i + 6];
+            v[i + 7] = u[i + 7];
+        }
+
+        v[34] = half_btf_avx2(&cospim8, &u[34], &cospi56, &u[61], &rnding, bit);
+        v[35] = half_btf_avx2(&cospim8, &u[35], &cospi56, &u[60], &rnding, bit);
+        v[36] = half_btf_avx2(&cospim56, &u[36], &cospim8, &u[59], &rnding, bit);
+        v[37] = half_btf_avx2(&cospim56, &u[37], &cospim8, &u[58], &rnding, bit);
+        v[42] = half_btf_avx2(&cospim40, &u[42], &cospi24, &u[53], &rnding, bit);
+        v[43] = half_btf_avx2(&cospim40, &u[43], &cospi24, &u[52], &rnding, bit);
+        v[44] = half_btf_avx2(&cospim24, &u[44], &cospim40, &u[51], &rnding, bit);
+        v[45] = half_btf_avx2(&cospim24, &u[45], &cospim40, &u[50], &rnding, bit);
+        v[50] = half_btf_avx2(&cospim40, &u[45], &cospi24, &u[50], &rnding, bit);
+        v[51] = half_btf_avx2(&cospim40, &u[44], &cospi24, &u[51], &rnding, bit);
+        v[52] = half_btf_avx2(&cospi24, &u[43], &cospi40, &u[52], &rnding, bit);
+        v[53] = half_btf_avx2(&cospi24, &u[42], &cospi40, &u[53], &rnding, bit);
+        v[58] = half_btf_avx2(&cospim8, &u[37], &cospi56, &u[58], &rnding, bit);
+        v[59] = half_btf_avx2(&cospim8, &u[36], &cospi56, &u[59], &rnding, bit);
+        v[60] = half_btf_avx2(&cospi56, &u[35], &cospi8, &u[60], &rnding, bit);
+        v[61] = half_btf_avx2(&cospi56, &u[34], &cospi8, &u[61], &rnding, bit);
+
+        // stage 7
+        addsub_avx2(v[0], v[3], &u[0], &u[3], &clamp_lo, &clamp_hi);
+        addsub_avx2(v[1], v[2], &u[1], &u[2], &clamp_lo, &clamp_hi);
+
+        u[4] = v[4];
+        u[7] = v[7];
+        u[5] = half_btf_avx2(&cospim32, &v[5], &cospi32, &v[6], &rnding, bit);
+        u[6] = half_btf_avx2(&cospi32, &v[5], &cospi32, &v[6], &rnding, bit);
+
+        addsub_avx2(v[8], v[11], &u[8], &u[11], &clamp_lo, &clamp_hi);
+        addsub_avx2(v[9], v[10], &u[9], &u[10], &clamp_lo, &clamp_hi);
+        addsub_avx2(v[15], v[12], &u[15], &u[12], &clamp_lo, &clamp_hi);
+        addsub_avx2(v[14], v[13], &u[14], &u[13], &clamp_lo, &clamp_hi);
+
+        for (i = 16; i < 32; i += 8) {
+            u[i + 0] = v[i + 0];
+            u[i + 1] = v[i + 1];
+            u[i + 6] = v[i + 6];
+            u[i + 7] = v[i + 7];
+        }
+
+        u[18] = half_btf_avx2(&cospim16, &v[18], &cospi48, &v[29], &rnding, bit);
+        u[19] = half_btf_avx2(&cospim16, &v[19], &cospi48, &v[28], &rnding, bit);
+        u[20] = half_btf_avx2(&cospim48, &v[20], &cospim16, &v[27], &rnding, bit);
+        u[21] = half_btf_avx2(&cospim48, &v[21], &cospim16, &v[26], &rnding, bit);
+        u[26] = half_btf_avx2(&cospim16, &v[21], &cospi48, &v[26], &rnding, bit);
+        u[27] = half_btf_avx2(&cospim16, &v[20], &cospi48, &v[27], &rnding, bit);
+        u[28] = half_btf_avx2(&cospi48, &v[19], &cospi16, &v[28], &rnding, bit);
+        u[29] = half_btf_avx2(&cospi48, &v[18], &cospi16, &v[29], &rnding, bit);
+
+        for (i = 32; i < 64; i += 16) {
+            for (j = i; j < i + 4; j++) {
+                addsub_avx2(v[j], v[j ^ 7], &u[j], &u[j ^ 7], &clamp_lo, &clamp_hi);
+                addsub_avx2(v[j ^ 15], v[j ^ 8], &u[j ^ 15], &u[j ^ 8], &clamp_lo, &clamp_hi);
+            }
+        }
+
+        // stage 8
+        for (i = 0; i < 4; ++i)
+            addsub_avx2(u[i], u[7 - i], &v[i], &v[7 - i], &clamp_lo, &clamp_hi);
+        v[8]  = u[8];
+        v[9]  = u[9];
+        v[14] = u[14];
+        v[15] = u[15];
+
+        v[10] = half_btf_avx2(&cospim32, &u[10], &cospi32, &u[13], &rnding, bit);
+        v[11] = half_btf_avx2(&cospim32, &u[11], &cospi32, &u[12], &rnding, bit);
+        v[12] = half_btf_avx2(&cospi32, &u[11], &cospi32, &u[12], &rnding, bit);
+        v[13] = half_btf_avx2(&cospi32, &u[10], &cospi32, &u[13], &rnding, bit);
+
+        for (i = 16; i < 20; ++i) {
+            addsub_avx2(u[i], u[i ^ 7], &v[i], &v[i ^ 7], &clamp_lo, &clamp_hi);
+            addsub_avx2(u[i ^ 15], u[i ^ 8], &v[i ^ 15], &v[i ^ 8], &clamp_lo, &clamp_hi);
+        }
+
+        for (i = 32; i < 36; ++i) {
+            v[i]      = u[i];
+            v[i + 12] = u[i + 12];
+            v[i + 16] = u[i + 16];
+            v[i + 28] = u[i + 28];
+        }
+
+        v[36] = half_btf_avx2(&cospim16, &u[36], &cospi48, &u[59], &rnding, bit);
+        v[37] = half_btf_avx2(&cospim16, &u[37], &cospi48, &u[58], &rnding, bit);
+        v[38] = half_btf_avx2(&cospim16, &u[38], &cospi48, &u[57], &rnding, bit);
+        v[39] = half_btf_avx2(&cospim16, &u[39], &cospi48, &u[56], &rnding, bit);
+        v[40] = half_btf_avx2(&cospim48, &u[40], &cospim16, &u[55], &rnding, bit);
+        v[41] = half_btf_avx2(&cospim48, &u[41], &cospim16, &u[54], &rnding, bit);
+        v[42] = half_btf_avx2(&cospim48, &u[42], &cospim16, &u[53], &rnding, bit);
+        v[43] = half_btf_avx2(&cospim48, &u[43], &cospim16, &u[52], &rnding, bit);
+        v[52] = half_btf_avx2(&cospim16, &u[43], &cospi48, &u[52], &rnding, bit);
+        v[53] = half_btf_avx2(&cospim16, &u[42], &cospi48, &u[53], &rnding, bit);
+        v[54] = half_btf_avx2(&cospim16, &u[41], &cospi48, &u[54], &rnding, bit);
+        v[55] = half_btf_avx2(&cospim16, &u[40], &cospi48, &u[55], &rnding, bit);
+        v[56] = half_btf_avx2(&cospi48, &u[39], &cospi16, &u[56], &rnding, bit);
+        v[57] = half_btf_avx2(&cospi48, &u[38], &cospi16, &u[57], &rnding, bit);
+        v[58] = half_btf_avx2(&cospi48, &u[37], &cospi16, &u[58], &rnding, bit);
+        v[59] = half_btf_avx2(&cospi48, &u[36], &cospi16, &u[59], &rnding, bit);
+
+        // stage 9
+        for (i = 0; i < 8; ++i)
+            addsub_avx2(v[i], v[15 - i], &u[i], &u[15 - i], &clamp_lo, &clamp_hi);
+        for (i = 16; i < 20; ++i) {
+            u[i]      = v[i];
+            u[i + 12] = v[i + 12];
+        }
+
+        u[20] = half_btf_avx2(&cospim32, &v[20], &cospi32, &v[27], &rnding, bit);
+        u[21] = half_btf_avx2(&cospim32, &v[21], &cospi32, &v[26], &rnding, bit);
+        u[22] = half_btf_avx2(&cospim32, &v[22], &cospi32, &v[25], &rnding, bit);
+        u[23] = half_btf_avx2(&cospim32, &v[23], &cospi32, &v[24], &rnding, bit);
+        u[24] = half_btf_avx2(&cospi32, &v[23], &cospi32, &v[24], &rnding, bit);
+        u[25] = half_btf_avx2(&cospi32, &v[22], &cospi32, &v[25], &rnding, bit);
+        u[26] = half_btf_avx2(&cospi32, &v[21], &cospi32, &v[26], &rnding, bit);
+        u[27] = half_btf_avx2(&cospi32, &v[20], &cospi32, &v[27], &rnding, bit);
+
+        for (i = 32; i < 40; i++)
+            addsub_avx2(v[i], v[i ^ 15], &u[i], &u[i ^ 15], &clamp_lo, &clamp_hi);
+        for (i = 48; i < 56; i++)
+            addsub_avx2(v[i ^ 15], v[i], &u[i ^ 15], &u[i], &clamp_lo, &clamp_hi);
+        // stage 10
+        for (i = 0; i < 16; i++)
+            addsub_avx2(u[i], u[31 - i], &v[i], &v[31 - i], &clamp_lo, &clamp_hi);
+        for (i = 32; i < 40; i++) v[i] = u[i];
+
+        v[40] = half_btf_avx2(&cospim32, &u[40], &cospi32, &u[55], &rnding, bit);
+        v[41] = half_btf_avx2(&cospim32, &u[41], &cospi32, &u[54], &rnding, bit);
+        v[42] = half_btf_avx2(&cospim32, &u[42], &cospi32, &u[53], &rnding, bit);
+        v[43] = half_btf_avx2(&cospim32, &u[43], &cospi32, &u[52], &rnding, bit);
+        v[44] = half_btf_avx2(&cospim32, &u[44], &cospi32, &u[51], &rnding, bit);
+        v[45] = half_btf_avx2(&cospim32, &u[45], &cospi32, &u[50], &rnding, bit);
+        v[46] = half_btf_avx2(&cospim32, &u[46], &cospi32, &u[49], &rnding, bit);
+        v[47] = half_btf_avx2(&cospim32, &u[47], &cospi32, &u[48], &rnding, bit);
+        v[48] = half_btf_avx2(&cospi32, &u[47], &cospi32, &u[48], &rnding, bit);
+        v[49] = half_btf_avx2(&cospi32, &u[46], &cospi32, &u[49], &rnding, bit);
+        v[50] = half_btf_avx2(&cospi32, &u[45], &cospi32, &u[50], &rnding, bit);
+        v[51] = half_btf_avx2(&cospi32, &u[44], &cospi32, &u[51], &rnding, bit);
+        v[52] = half_btf_avx2(&cospi32, &u[43], &cospi32, &u[52], &rnding, bit);
+        v[53] = half_btf_avx2(&cospi32, &u[42], &cospi32, &u[53], &rnding, bit);
+        v[54] = half_btf_avx2(&cospi32, &u[41], &cospi32, &u[54], &rnding, bit);
+        v[55] = half_btf_avx2(&cospi32, &u[40], &cospi32, &u[55], &rnding, bit);
+
+        for (i = 56; i < 64; i++) v[i] = u[i];
+
+        // stage 11
+        for (i = 0; i < 32; i++) {
+            addsub_avx2(v[i],
+                        v[63 - i],
+                        &out[8 * (i) + col],
+                        &out[8 * (63 - i) + col],
+                        &clamp_lo,
+                        &clamp_hi);
+        }
+    }
+}
+
+void eb_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r,
+                                        uint16_t *output_w, int32_t stride_w, TxType tx_type,
+                                        int32_t bd) {
+    __m256i       in[64 * 64 / 8], out[64 * 64 / 8];
+    const int8_t *shift   = eb_inv_txfm_shift_ls[TX_64X64];
+    const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
+    const int32_t txh_idx = tx_size_high_log2[TX_64X64] - tx_size_high_log2[0];
+
+    switch (tx_type) {
+    case DCT_DCT:
+        load_buffer_64x64_lower_32x32_avx2(input, in);
+        transpose_8nx8n(in, out, 64, 64);
+        idct64x64_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx], 0, bd);
+        transpose_8nx8n(in, out, 64, 64);
+        round_shift_64x64_avx2(out, -shift[0]);
+        idct64x64_avx2(out, in, inv_cos_bit_col[txw_idx][txh_idx], 1, bd);
+        round_shift_64x64_avx2(in, -shift[1]);
+        write_buffer_64x64_avx2(in, output_r, stride_r, output_w, stride_w, bd);
+        break;
+
+    default:
+        eb_av1_inv_txfm2d_add_64x64_c(input, output_r, stride_r, output_w, stride_w, tx_type, bd);
+        break;
+    }
 }

--- a/Source/Lib/Common/ASM_AVX512/highbd_inv_txfm_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_inv_txfm_avx512.c
@@ -1981,9 +1981,9 @@ static void write_buffer_64x64_avx512(__m512i *in, uint16_t *output_r, int32_t s
         in32x32, right_down_r, stride_r, right_down_w, stride_w, fliplr, flipud, bd);
 }
 
-void eb_av1_inv_txfm2d_add_64x64_avx512(const int32_t *coeff, uint16_t *output_r, int32_t stride_r,
-                                        uint16_t *output_w, int32_t stride_w, TxType tx_type,
-                                        int32_t bd) {
+void svt_av1_inv_txfm2d_add_64x64_avx512(const int32_t *coeff, uint16_t *output_r, int32_t stride_r,
+                                         uint16_t *output_w, int32_t stride_w, TxType tx_type,
+                                         int32_t bd) {
     __m512i       in[64 * 64 / 16], out[64 * 64 / 16];
     const int8_t *shift   = eb_inv_txfm_shift_ls[TX_64X64];
     const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
@@ -2002,7 +2002,7 @@ void eb_av1_inv_txfm2d_add_64x64_avx512(const int32_t *coeff, uint16_t *output_r
         break;
 
     default:
-        eb_av1_inv_txfm2d_add_64x64_c(coeff, output_r, stride_r, output_w, stride_w, tx_type, bd);
+        svt_av1_inv_txfm2d_add_64x64_c(coeff, output_r, stride_r, output_w, stride_w, tx_type, bd);
         break;
     }
 }

--- a/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
+++ b/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
@@ -2425,9 +2425,9 @@ static void idct64x64_sse4_1(__m128i *in, __m128i *out, int32_t bit, int32_t do_
     }
 }
 
-void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r,
-                                        uint16_t *output_w, int32_t stride_w, TxType tx_type,
-                                        int32_t bd) {
+void svt_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r,
+                                         uint16_t *output_w, int32_t stride_w, TxType tx_type,
+                                         int32_t bd) {
     __m128i       in[64 * 64 / 4], out[64 * 64 / 4];
     const int8_t *shift   = eb_inv_txfm_shift_ls[TX_64X64];
     const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
@@ -2446,7 +2446,7 @@ void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r
         break;
 
     default:
-        eb_av1_inv_txfm2d_add_64x64_c(input, output_r, stride_r, output_w, stride_w, tx_type, bd);
+        svt_av1_inv_txfm2d_add_64x64_c(input, output_r, stride_r, output_w, stride_w, tx_type, bd);
         break;
     }
 }

--- a/Source/Lib/Common/Codec/EbInvTransforms.c
+++ b/Source/Lib/Common/Codec/EbInvTransforms.c
@@ -2569,9 +2569,9 @@ void eb_av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output_r, int
             input, output_r, stride_r, output_w, stride_w, txfm_buf, tx_type, TX_32X32, bd);
 }
 
-void eb_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output_r, int32_t stride_r,
-                                   uint16_t *output_w, int32_t stride_w, TxType tx_type,
-                                   int32_t bd) {
+void svt_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output_r, int32_t stride_r,
+                                    uint16_t *output_w, int32_t stride_w, TxType tx_type,
+                                    int32_t bd) {
     // Remap 32x32 input into a modified 64x64 by:
     // - Copying over these values in top-left 32x32 locations.
     // - Setting the rest of the locations to 0.
@@ -2946,13 +2946,13 @@ static void highbd_inv_txfm_add_64x64(const TranLow *input, uint8_t *dest_r, int
     const TxType   tx_type = txfm_param->tx_type;
     const int32_t *src     = cast_to_int32(input);
     assert(tx_type == DCT_DCT);
-    eb_av1_inv_txfm2d_add_64x64(src,
-                                CONVERT_TO_SHORTPTR(dest_r),
-                                stride_r,
-                                CONVERT_TO_SHORTPTR(dest_w),
-                                stride_w,
-                                tx_type,
-                                bd);
+    svt_av1_inv_txfm2d_add_64x64(src,
+                                 CONVERT_TO_SHORTPTR(dest_r),
+                                 stride_r,
+                                 CONVERT_TO_SHORTPTR(dest_w),
+                                 stride_w,
+                                 tx_type,
+                                 bd);
 }
 
 static void highbd_inv_txfm_add_4x8(const TranLow *input, uint8_t *dest_r, int32_t stride_r,

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -275,7 +275,7 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_c;
     eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_c;
     eb_av1_inv_txfm2d_add_4x4 = eb_av1_inv_txfm2d_add_4x4_c;
-    eb_av1_inv_txfm2d_add_64x64 = eb_av1_inv_txfm2d_add_64x64_c;
+    svt_av1_inv_txfm2d_add_64x64 = svt_av1_inv_txfm2d_add_64x64_c;
     eb_av1_inv_txfm2d_add_8x8 = eb_av1_inv_txfm2d_add_8x8_c;
 
     eb_av1_inv_txfm2d_add_8x16 = eb_av1_inv_txfm2d_add_8x16_c;
@@ -842,10 +842,10 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_16x4 = eb_av1_inv_txfm2d_add_16x4_sse4_1;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_avx2;
-    SET_SSE41_AVX2(eb_av1_inv_txfm2d_add_64x64,
-                   eb_av1_inv_txfm2d_add_64x64_c,
-                   eb_av1_inv_txfm2d_add_64x64_sse4_1,
-                   eb_av1_inv_txfm2d_add_64x64_avx2);
+    SET_SSE41_AVX2(svt_av1_inv_txfm2d_add_64x64,
+                   svt_av1_inv_txfm2d_add_64x64_c,
+                   svt_av1_inv_txfm2d_add_64x64_sse4_1,
+                   svt_av1_inv_txfm2d_add_64x64_avx2);
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x64 = eb_av1_highbd_inv_txfm_add_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_64x16 = eb_av1_highbd_inv_txfm_add_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x64 = eb_av1_highbd_inv_txfm_add_avx2;
@@ -856,7 +856,7 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     if (flags & HAS_AVX512F) {
         eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_avx512;
         eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_avx512;
-        eb_av1_inv_txfm2d_add_64x64 = eb_av1_inv_txfm2d_add_64x64_avx512;
+        svt_av1_inv_txfm2d_add_64x64 = svt_av1_inv_txfm2d_add_64x64_avx512;
         eb_av1_inv_txfm2d_add_16x64 = eb_av1_inv_txfm2d_add_16x64_avx512;
         eb_av1_inv_txfm2d_add_64x16 = eb_av1_inv_txfm2d_add_64x16_avx512;
         eb_av1_inv_txfm2d_add_32x64 = eb_av1_inv_txfm2d_add_32x64_avx512;

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -842,7 +842,10 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_16x4 = eb_av1_inv_txfm2d_add_16x4_sse4_1;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_avx2;
-    if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_64x64 = eb_av1_inv_txfm2d_add_64x64_sse4_1;
+    SET_SSE41_AVX2(eb_av1_inv_txfm2d_add_64x64,
+                   eb_av1_inv_txfm2d_add_64x64_c,
+                   eb_av1_inv_txfm2d_add_64x64_sse4_1,
+                   eb_av1_inv_txfm2d_add_64x64_avx2);
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x64 = eb_av1_highbd_inv_txfm_add_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_64x16 = eb_av1_highbd_inv_txfm_add_avx2;
     if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x64 = eb_av1_highbd_inv_txfm_add_avx2;

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -905,7 +905,10 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
                         svt_residual_kernel8bit_avx2,
                         svt_residual_kernel8bit_avx512);
 
-        SET_SSE2(svt_residual_kernel16bit, svt_residual_kernel16bit_c, svt_residual_kernel16bit_sse2_intrin);
+        SET_SSE2_AVX2(svt_residual_kernel16bit,
+                      svt_residual_kernel16bit_c,
+                      svt_residual_kernel16bit_sse2_intrin,
+                      svt_residual_kernel16bit_avx2);
         SET_SSE2(svt_picture_average_kernel,
                  svt_picture_average_kernel_c,
                  svt_picture_average_kernel_sse2_intrin);

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -1141,6 +1141,7 @@ extern "C" {
     void eb_av1_inv_txfm2d_add_32x32_avx512(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
 
     void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
     void eb_av1_inv_txfm2d_add_64x64_avx512(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
 
     void eb_av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -1227,6 +1227,10 @@ extern "C" {
         uint32_t pred_stride, int16_t *residual,
         uint32_t residual_stride, uint32_t area_width,
         uint32_t area_height);
+    extern void svt_residual_kernel16bit_avx2(uint16_t *input, uint32_t input_stride, uint16_t *pred,
+        uint32_t pred_stride, int16_t *residual,
+        uint32_t residual_stride, uint32_t area_width,
+        uint32_t area_height);
     void avc_style_luma_interpolation_filter_helper_ssse3(EbByte ref_pic, uint32_t src_stride,
         EbByte dst, uint32_t dst_stride,
         uint32_t pu_width, uint32_t pu_height,

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -134,8 +134,8 @@ extern "C" {
     RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x16)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
     void eb_av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
     RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_32x32)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
-    void eb_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_64x64)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    void svt_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*svt_av1_inv_txfm2d_add_64x64)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
     void eb_av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
     RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_8x16)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
     void eb_av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
@@ -1140,9 +1140,9 @@ extern "C" {
     void eb_av1_inv_txfm2d_add_32x32_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
     void eb_av1_inv_txfm2d_add_32x32_avx512(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
 
-    void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
-    void eb_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
-    void eb_av1_inv_txfm2d_add_64x64_avx512(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    void svt_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    void svt_av1_inv_txfm2d_add_64x64_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
+    void svt_av1_inv_txfm2d_add_64x64_avx512(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
 
     void eb_av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 

--- a/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -537,24 +537,24 @@ static void fdct8x8_avx2(const __m256i *in, __m256i *out, int8_t bit, const int3
     v[1] = _mm256_mullo_epi32(v[1], cospi32);
     u[0] = _mm256_add_epi32(v[0], v[1]);
     u[0] = _mm256_add_epi32(u[0], rnding);
-    u[0] = _mm256_srai_epi32(u[0], bit);
+    out[0 * col_num] = _mm256_srai_epi32(u[0], bit);
 
     u[1] = _mm256_sub_epi32(v[0], v[1]);
     u[1] = _mm256_add_epi32(u[1], rnding);
-    u[1] = _mm256_srai_epi32(u[1], bit);
+    out[4 * col_num] = _mm256_srai_epi32(u[1], bit);
 
     // type 1
     v[0] = _mm256_mullo_epi32(v[2], cospi48);
     v[1] = _mm256_mullo_epi32(v[3], cospi16);
     u[2] = _mm256_add_epi32(v[0], v[1]);
     u[2] = _mm256_add_epi32(u[2], rnding);
-    u[2] = _mm256_srai_epi32(u[2], bit);
+    out[2 * col_num] = _mm256_srai_epi32(u[2], bit);
 
     v[0] = _mm256_mullo_epi32(v[2], cospi16);
     v[1] = _mm256_mullo_epi32(v[3], cospi48);
     u[3] = _mm256_sub_epi32(v[1], v[0]);
     u[3] = _mm256_add_epi32(u[3], rnding);
-    u[3] = _mm256_srai_epi32(u[3], bit);
+    out[6 * col_num] = _mm256_srai_epi32(u[3], bit);
 
     u[4] = _mm256_add_epi32(v[4], v[5]);
     u[5] = _mm256_sub_epi32(v[4], v[5]);
@@ -586,11 +586,6 @@ static void fdct8x8_avx2(const __m256i *in, __m256i *out, int8_t bit, const int3
     v[0]             = _mm256_sub_epi32(v[1], v[0]);
     v[0]             = _mm256_add_epi32(v[0], rnding);
     out[3 * col_num] = _mm256_srai_epi32(v[0], bit);
-
-    out[0 * col_num] = u[0];
-    out[4 * col_num] = u[1];
-    out[2 * col_num] = u[2];
-    out[6 * col_num] = u[3];
 }
 
 static void fadst8x8_avx2(const __m256i *in, __m256i *out, int8_t bit, const int32_t col_num) {
@@ -1814,8 +1809,6 @@ static void fdct16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, const in
         v[5] = _mm256_sub_epi32(u[2], u[5]);
         v[3] = _mm256_add_epi32(u[3], u[4]);
         v[4] = _mm256_sub_epi32(u[3], u[4]);
-        v[8] = u[8];
-        v[9] = u[9];
 
         v[10] = _mm256_mullo_epi32(u[10], cospim32);
         x     = _mm256_mullo_epi32(u[13], cospi32);
@@ -1840,15 +1833,12 @@ static void fdct16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, const in
         v[12] = _mm256_sub_epi32(v[12], x);
         v[12] = _mm256_add_epi32(v[12], rnding);
         v[12] = _mm256_srai_epi32(v[12], bit);
-        v[14] = u[14];
-        v[15] = u[15];
 
         // stage 3
         u[0] = _mm256_add_epi32(v[0], v[3]);
         u[3] = _mm256_sub_epi32(v[0], v[3]);
         u[1] = _mm256_add_epi32(v[1], v[2]);
         u[2] = _mm256_sub_epi32(v[1], v[2]);
-        u[4] = v[4];
 
         u[5] = _mm256_mullo_epi32(v[5], cospim32);
         x    = _mm256_mullo_epi32(v[6], cospi32);
@@ -1862,44 +1852,42 @@ static void fdct16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, const in
         u[6] = _mm256_add_epi32(u[6], rnding);
         u[6] = _mm256_srai_epi32(u[6], bit);
 
-        u[7]  = v[7];
-        u[8]  = _mm256_add_epi32(v[8], v[11]);
-        u[11] = _mm256_sub_epi32(v[8], v[11]);
-        u[9]  = _mm256_add_epi32(v[9], v[10]);
-        u[10] = _mm256_sub_epi32(v[9], v[10]);
-        u[12] = _mm256_sub_epi32(v[15], v[12]);
-        u[15] = _mm256_add_epi32(v[15], v[12]);
-        u[13] = _mm256_sub_epi32(v[14], v[13]);
-        u[14] = _mm256_add_epi32(v[14], v[13]);
+        u[11] = _mm256_sub_epi32(u[8], v[11]);
+        u[8]  = _mm256_add_epi32(u[8], v[11]);
+        u[10] = _mm256_sub_epi32(u[9], v[10]);
+        u[9]  = _mm256_add_epi32(u[9], v[10]);
+        u[12] = _mm256_sub_epi32(u[15], v[12]);
+        u[15] = _mm256_add_epi32(u[15], v[12]);
+        u[13] = _mm256_sub_epi32(u[14], v[13]);
+        u[14] = _mm256_add_epi32(u[14], v[13]);
 
         // stage 4
         u[0] = _mm256_mullo_epi32(u[0], cospi32);
         u[1] = _mm256_mullo_epi32(u[1], cospi32);
         v[0] = _mm256_add_epi32(u[0], u[1]);
         v[0] = _mm256_add_epi32(v[0], rnding);
-        v[0] = _mm256_srai_epi32(v[0], bit);
+        out[0 * col_num + col] = _mm256_srai_epi32(v[0], bit);
 
         v[1] = _mm256_sub_epi32(u[0], u[1]);
         v[1] = _mm256_add_epi32(v[1], rnding);
-        v[1] = _mm256_srai_epi32(v[1], bit);
+        out[8 * col_num + col] = _mm256_srai_epi32(v[1], bit);
 
         v[2] = _mm256_mullo_epi32(u[2], cospi48);
         x    = _mm256_mullo_epi32(u[3], cospi16);
         v[2] = _mm256_add_epi32(v[2], x);
         v[2] = _mm256_add_epi32(v[2], rnding);
-        v[2] = _mm256_srai_epi32(v[2], bit);
+        out[4 * col_num + col] = _mm256_srai_epi32(v[2], bit);
 
         v[3] = _mm256_mullo_epi32(u[2], cospi16);
         x    = _mm256_mullo_epi32(u[3], cospi48);
         v[3] = _mm256_sub_epi32(x, v[3]);
         v[3] = _mm256_add_epi32(v[3], rnding);
-        v[3] = _mm256_srai_epi32(v[3], bit);
+        out[12 * col_num + col] = _mm256_srai_epi32(v[3], bit);
 
-        v[4] = _mm256_add_epi32(u[4], u[5]);
-        v[5] = _mm256_sub_epi32(u[4], u[5]);
-        v[6] = _mm256_sub_epi32(u[7], u[6]);
-        v[7] = _mm256_add_epi32(u[7], u[6]);
-        v[8] = u[8];
+        v[5] = _mm256_sub_epi32(v[4], u[5]);
+        v[4] = _mm256_add_epi32(v[4], u[5]);
+        v[6] = _mm256_sub_epi32(v[7], u[6]);
+        v[7] = _mm256_add_epi32(v[7], u[6]);
 
         v[9] = _mm256_mullo_epi32(u[9], cospim16);
         x    = _mm256_mullo_epi32(u[14], cospi48);
@@ -1925,123 +1913,88 @@ static void fdct16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, const in
         v[13] = _mm256_add_epi32(v[13], rnding);
         v[13] = _mm256_srai_epi32(v[13], bit);
 
-        v[11] = u[11];
-        v[12] = u[12];
-        v[15] = u[15];
-
         // stage 5
-        u[0] = v[0];
-        u[1] = v[1];
-        u[2] = v[2];
-        u[3] = v[3];
-
         u[4] = _mm256_mullo_epi32(v[4], cospi56);
         x    = _mm256_mullo_epi32(v[7], cospi8);
         u[4] = _mm256_add_epi32(u[4], x);
         u[4] = _mm256_add_epi32(u[4], rnding);
-        u[4] = _mm256_srai_epi32(u[4], bit);
+        out[2 * col_num + col] = _mm256_srai_epi32(u[4], bit);
 
         u[7] = _mm256_mullo_epi32(v[4], cospi8);
         x    = _mm256_mullo_epi32(v[7], cospi56);
         u[7] = _mm256_sub_epi32(x, u[7]);
         u[7] = _mm256_add_epi32(u[7], rnding);
-        u[7] = _mm256_srai_epi32(u[7], bit);
+        out[14 * col_num + col] = _mm256_srai_epi32(u[7], bit);
 
         u[5] = _mm256_mullo_epi32(v[5], cospi24);
         x    = _mm256_mullo_epi32(v[6], cospi40);
         u[5] = _mm256_add_epi32(u[5], x);
         u[5] = _mm256_add_epi32(u[5], rnding);
-        u[5] = _mm256_srai_epi32(u[5], bit);
+        out[10 * col_num + col] = _mm256_srai_epi32(u[5], bit);
 
         u[6] = _mm256_mullo_epi32(v[5], cospi40);
         x    = _mm256_mullo_epi32(v[6], cospi24);
         u[6] = _mm256_sub_epi32(x, u[6]);
         u[6] = _mm256_add_epi32(u[6], rnding);
-        u[6] = _mm256_srai_epi32(u[6], bit);
+        out[6 * col_num + col] = _mm256_srai_epi32(u[6], bit);
 
-        u[8]  = _mm256_add_epi32(v[8], v[9]);
-        u[9]  = _mm256_sub_epi32(v[8], v[9]);
-        u[10] = _mm256_sub_epi32(v[11], v[10]);
-        u[11] = _mm256_add_epi32(v[11], v[10]);
-        u[12] = _mm256_add_epi32(v[12], v[13]);
-        u[13] = _mm256_sub_epi32(v[12], v[13]);
-        u[14] = _mm256_sub_epi32(v[15], v[14]);
-        u[15] = _mm256_add_epi32(v[15], v[14]);
+        u[9]  = _mm256_sub_epi32(u[8], v[9]);
+        u[8]  = _mm256_add_epi32(u[8], v[9]);
+        u[10] = _mm256_sub_epi32(u[11], v[10]);
+        u[11] = _mm256_add_epi32(u[11], v[10]);
+        u[13] = _mm256_sub_epi32(u[12], v[13]);
+        u[12] = _mm256_add_epi32(u[12], v[13]);
+        u[14] = _mm256_sub_epi32(u[15], v[14]);
+        u[15] = _mm256_add_epi32(u[15], v[14]);
 
         // stage 6
-        v[0] = u[0];
-        v[1] = u[1];
-        v[2] = u[2];
-        v[3] = u[3];
-        v[4] = u[4];
-        v[5] = u[5];
-        v[6] = u[6];
-        v[7] = u[7];
-
         v[8] = _mm256_mullo_epi32(u[8], cospi60);
         x    = _mm256_mullo_epi32(u[15], cospi4);
         v[8] = _mm256_add_epi32(v[8], x);
         v[8] = _mm256_add_epi32(v[8], rnding);
-        v[8] = _mm256_srai_epi32(v[8], bit);
+        out[1 * col_num + col] = _mm256_srai_epi32(v[8], bit);
 
         v[15] = _mm256_mullo_epi32(u[8], cospi4);
         x     = _mm256_mullo_epi32(u[15], cospi60);
         v[15] = _mm256_sub_epi32(x, v[15]);
         v[15] = _mm256_add_epi32(v[15], rnding);
-        v[15] = _mm256_srai_epi32(v[15], bit);
+        out[15 * col_num + col] = _mm256_srai_epi32(v[15], bit);
 
         v[9] = _mm256_mullo_epi32(u[9], cospi28);
         x    = _mm256_mullo_epi32(u[14], cospi36);
         v[9] = _mm256_add_epi32(v[9], x);
         v[9] = _mm256_add_epi32(v[9], rnding);
-        v[9] = _mm256_srai_epi32(v[9], bit);
+        out[9 * col_num + col] = _mm256_srai_epi32(v[9], bit);
 
         v[14] = _mm256_mullo_epi32(u[9], cospi36);
         x     = _mm256_mullo_epi32(u[14], cospi28);
         v[14] = _mm256_sub_epi32(x, v[14]);
         v[14] = _mm256_add_epi32(v[14], rnding);
-        v[14] = _mm256_srai_epi32(v[14], bit);
+        out[7 * col_num + col] = _mm256_srai_epi32(v[14], bit);
 
         v[10] = _mm256_mullo_epi32(u[10], cospi44);
         x     = _mm256_mullo_epi32(u[13], cospi20);
         v[10] = _mm256_add_epi32(v[10], x);
         v[10] = _mm256_add_epi32(v[10], rnding);
-        v[10] = _mm256_srai_epi32(v[10], bit);
+        out[5 * col_num + col] = _mm256_srai_epi32(v[10], bit);
 
         v[13] = _mm256_mullo_epi32(u[10], cospi20);
         x     = _mm256_mullo_epi32(u[13], cospi44);
         v[13] = _mm256_sub_epi32(x, v[13]);
         v[13] = _mm256_add_epi32(v[13], rnding);
-        v[13] = _mm256_srai_epi32(v[13], bit);
+        out[11 * col_num + col] = _mm256_srai_epi32(v[13], bit);
 
         v[11] = _mm256_mullo_epi32(u[11], cospi12);
         x     = _mm256_mullo_epi32(u[12], cospi52);
         v[11] = _mm256_add_epi32(v[11], x);
         v[11] = _mm256_add_epi32(v[11], rnding);
-        v[11] = _mm256_srai_epi32(v[11], bit);
+        out[13 * col_num + col] = _mm256_srai_epi32(v[11], bit);
 
         v[12] = _mm256_mullo_epi32(u[11], cospi52);
         x     = _mm256_mullo_epi32(u[12], cospi12);
         v[12] = _mm256_sub_epi32(x, v[12]);
         v[12] = _mm256_add_epi32(v[12], rnding);
-        v[12] = _mm256_srai_epi32(v[12], bit);
-
-        out[0 * col_num + col]  = v[0];
-        out[1 * col_num + col]  = v[8];
-        out[2 * col_num + col]  = v[4];
-        out[3 * col_num + col]  = v[12];
-        out[4 * col_num + col]  = v[2];
-        out[5 * col_num + col]  = v[10];
-        out[6 * col_num + col]  = v[6];
-        out[7 * col_num + col]  = v[14];
-        out[8 * col_num + col]  = v[1];
-        out[9 * col_num + col]  = v[9];
-        out[10 * col_num + col] = v[5];
-        out[11 * col_num + col] = v[13];
-        out[12 * col_num + col] = v[3];
-        out[13 * col_num + col] = v[11];
-        out[14 * col_num + col] = v[7];
-        out[15 * col_num + col] = v[15];
+        out[3 * col_num + col] = _mm256_srai_epi32(v[12], bit);
     }
 }
 
@@ -2792,10 +2745,6 @@ static void av1_fdct32_new_avx2(const __m256i *input, __m256i *output, int8_t co
         buf0[9]  = _mm256_sub_epi32(buf1[6], buf1[9]);
         buf0[7]  = _mm256_add_epi32(buf1[7], buf1[8]);
         buf0[8]  = _mm256_sub_epi32(buf1[7], buf1[8]);
-        buf0[16] = buf1[16];
-        buf0[17] = buf1[17];
-        buf0[18] = buf1[18];
-        buf0[19] = buf1[19];
         btf_32_type0_avx2_new(
             cospi_m32, cospi_p32, buf1[20], buf1[27], buf0[20], buf0[27], __rounding, cos_bit);
         btf_32_type0_avx2_new(
@@ -2804,10 +2753,6 @@ static void av1_fdct32_new_avx2(const __m256i *input, __m256i *output, int8_t co
             cospi_m32, cospi_p32, buf1[22], buf1[25], buf0[22], buf0[25], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m32, cospi_p32, buf1[23], buf1[24], buf0[23], buf0[24], __rounding, cos_bit);
-        buf0[28] = buf1[28];
-        buf0[29] = buf1[29];
-        buf0[30] = buf1[30];
-        buf0[31] = buf1[31];
 
         // stage 3
         buf1[0] = _mm256_add_epi32(buf0[0], buf0[7]);
@@ -2818,50 +2763,42 @@ static void av1_fdct32_new_avx2(const __m256i *input, __m256i *output, int8_t co
         buf1[5] = _mm256_sub_epi32(buf0[2], buf0[5]);
         buf1[3] = _mm256_add_epi32(buf0[3], buf0[4]);
         buf1[4] = _mm256_sub_epi32(buf0[3], buf0[4]);
-        buf1[8] = buf0[8];
-        buf1[9] = buf0[9];
         btf_32_type0_avx2_new(
             cospi_m32, cospi_p32, buf0[10], buf0[13], buf1[10], buf1[13], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m32, cospi_p32, buf0[11], buf0[12], buf1[11], buf1[12], __rounding, cos_bit);
-        buf1[14] = buf0[14];
-        buf1[15] = buf0[15];
-        buf1[16] = _mm256_add_epi32(buf0[16], buf0[23]);
-        buf1[23] = _mm256_sub_epi32(buf0[16], buf0[23]);
-        buf1[17] = _mm256_add_epi32(buf0[17], buf0[22]);
-        buf1[22] = _mm256_sub_epi32(buf0[17], buf0[22]);
-        buf1[18] = _mm256_add_epi32(buf0[18], buf0[21]);
-        buf1[21] = _mm256_sub_epi32(buf0[18], buf0[21]);
-        buf1[19] = _mm256_add_epi32(buf0[19], buf0[20]);
-        buf1[20] = _mm256_sub_epi32(buf0[19], buf0[20]);
-        buf1[24] = _mm256_sub_epi32(buf0[31], buf0[24]);
-        buf1[31] = _mm256_add_epi32(buf0[31], buf0[24]);
-        buf1[25] = _mm256_sub_epi32(buf0[30], buf0[25]);
-        buf1[30] = _mm256_add_epi32(buf0[30], buf0[25]);
-        buf1[26] = _mm256_sub_epi32(buf0[29], buf0[26]);
-        buf1[29] = _mm256_add_epi32(buf0[29], buf0[26]);
-        buf1[27] = _mm256_sub_epi32(buf0[28], buf0[27]);
-        buf1[28] = _mm256_add_epi32(buf0[28], buf0[27]);
+        buf1[23] = _mm256_sub_epi32(buf1[16], buf0[23]);
+        buf1[16] = _mm256_add_epi32(buf1[16], buf0[23]);
+        buf1[22] = _mm256_sub_epi32(buf1[17], buf0[22]);
+        buf1[17] = _mm256_add_epi32(buf1[17], buf0[22]);
+        buf1[21] = _mm256_sub_epi32(buf1[18], buf0[21]);
+        buf1[18] = _mm256_add_epi32(buf1[18], buf0[21]);
+        buf1[20] = _mm256_sub_epi32(buf1[19], buf0[20]);
+        buf1[19] = _mm256_add_epi32(buf1[19], buf0[20]);
+        buf1[24] = _mm256_sub_epi32(buf1[31], buf0[24]);
+        buf1[31] = _mm256_add_epi32(buf1[31], buf0[24]);
+        buf1[25] = _mm256_sub_epi32(buf1[30], buf0[25]);
+        buf1[30] = _mm256_add_epi32(buf1[30], buf0[25]);
+        buf1[26] = _mm256_sub_epi32(buf1[29], buf0[26]);
+        buf1[29] = _mm256_add_epi32(buf1[29], buf0[26]);
+        buf1[27] = _mm256_sub_epi32(buf1[28], buf0[27]);
+        buf1[28] = _mm256_add_epi32(buf1[28], buf0[27]);
 
         // stage 4
         buf0[0] = _mm256_add_epi32(buf1[0], buf1[3]);
         buf0[3] = _mm256_sub_epi32(buf1[0], buf1[3]);
         buf0[1] = _mm256_add_epi32(buf1[1], buf1[2]);
         buf0[2] = _mm256_sub_epi32(buf1[1], buf1[2]);
-        buf0[4] = buf1[4];
         btf_32_type0_avx2_new(
             cospi_m32, cospi_p32, buf1[5], buf1[6], buf0[5], buf0[6], __rounding, cos_bit);
-        buf0[7]  = buf1[7];
-        buf0[8]  = _mm256_add_epi32(buf1[8], buf1[11]);
-        buf0[11] = _mm256_sub_epi32(buf1[8], buf1[11]);
-        buf0[9]  = _mm256_add_epi32(buf1[9], buf1[10]);
-        buf0[10] = _mm256_sub_epi32(buf1[9], buf1[10]);
-        buf0[12] = _mm256_sub_epi32(buf1[15], buf1[12]);
-        buf0[15] = _mm256_add_epi32(buf1[15], buf1[12]);
-        buf0[13] = _mm256_sub_epi32(buf1[14], buf1[13]);
-        buf0[14] = _mm256_add_epi32(buf1[14], buf1[13]);
-        buf0[16] = buf1[16];
-        buf0[17] = buf1[17];
+        buf0[11] = _mm256_sub_epi32(buf0[8], buf1[11]);
+        buf0[8]  = _mm256_add_epi32(buf0[8], buf1[11]);
+        buf0[10] = _mm256_sub_epi32(buf0[9], buf1[10]);
+        buf0[9]  = _mm256_add_epi32(buf0[9], buf1[10]);
+        buf0[12] = _mm256_sub_epi32(buf0[15], buf1[12]);
+        buf0[15] = _mm256_add_epi32(buf0[15], buf1[12]);
+        buf0[13] = _mm256_sub_epi32(buf0[14], buf1[13]);
+        buf0[14] = _mm256_add_epi32(buf0[14], buf1[13]);
         btf_32_type0_avx2_new(
             cospi_m16, cospi_p48, buf1[18], buf1[29], buf0[18], buf0[29], __rounding, cos_bit);
         btf_32_type0_avx2_new(
@@ -2870,182 +2807,102 @@ static void av1_fdct32_new_avx2(const __m256i *input, __m256i *output, int8_t co
             cospi_m48, cospi_m16, buf1[20], buf1[27], buf0[20], buf0[27], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m48, cospi_m16, buf1[21], buf1[26], buf0[21], buf0[26], __rounding, cos_bit);
-        buf0[22] = buf1[22];
-        buf0[23] = buf1[23];
-        buf0[24] = buf1[24];
-        buf0[25] = buf1[25];
-        buf0[30] = buf1[30];
-        buf0[31] = buf1[31];
 
         // stage 5
         btf_32_type0_avx2_new(
-            cospi_p32, cospi_p32, buf0[0], buf0[1], buf1[0], buf1[1], __rounding, cos_bit);
+            cospi_p32, cospi_p32, buf0[0], buf0[1], out[0 * stride], out[16 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p48, cospi_p16, buf0[2], buf0[3], buf1[2], buf1[3], __rounding, cos_bit);
-        buf1[4] = _mm256_add_epi32(buf0[4], buf0[5]);
-        buf1[5] = _mm256_sub_epi32(buf0[4], buf0[5]);
-        buf1[6] = _mm256_sub_epi32(buf0[7], buf0[6]);
-        buf1[7] = _mm256_add_epi32(buf0[7], buf0[6]);
-        buf1[8] = buf0[8];
+            cospi_p48, cospi_p16, buf0[2], buf0[3], out[8 * stride], out[24 * stride], __rounding, cos_bit);
+        buf1[5] = _mm256_sub_epi32(buf1[4], buf0[5]);
+        buf1[4] = _mm256_add_epi32(buf1[4], buf0[5]);
+        buf1[6] = _mm256_sub_epi32(buf1[7], buf0[6]);
+        buf1[7] = _mm256_add_epi32(buf1[7], buf0[6]);
         btf_32_type0_avx2_new(
             cospi_m16, cospi_p48, buf0[9], buf0[14], buf1[9], buf1[14], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m48, cospi_m16, buf0[10], buf0[13], buf1[10], buf1[13], __rounding, cos_bit);
-        buf1[11] = buf0[11];
-        buf1[12] = buf0[12];
-        buf1[15] = buf0[15];
-        buf1[16] = _mm256_add_epi32(buf0[16], buf0[19]);
-        buf1[19] = _mm256_sub_epi32(buf0[16], buf0[19]);
-        buf1[17] = _mm256_add_epi32(buf0[17], buf0[18]);
-        buf1[18] = _mm256_sub_epi32(buf0[17], buf0[18]);
-        buf1[20] = _mm256_sub_epi32(buf0[23], buf0[20]);
-        buf1[23] = _mm256_add_epi32(buf0[23], buf0[20]);
-        buf1[21] = _mm256_sub_epi32(buf0[22], buf0[21]);
-        buf1[22] = _mm256_add_epi32(buf0[22], buf0[21]);
-        buf1[24] = _mm256_add_epi32(buf0[24], buf0[27]);
-        buf1[27] = _mm256_sub_epi32(buf0[24], buf0[27]);
-        buf1[25] = _mm256_add_epi32(buf0[25], buf0[26]);
-        buf1[26] = _mm256_sub_epi32(buf0[25], buf0[26]);
-        buf1[28] = _mm256_sub_epi32(buf0[31], buf0[28]);
-        buf1[31] = _mm256_add_epi32(buf0[31], buf0[28]);
-        buf1[29] = _mm256_sub_epi32(buf0[30], buf0[29]);
-        buf1[30] = _mm256_add_epi32(buf0[30], buf0[29]);
+        buf1[19] = _mm256_sub_epi32(buf1[16], buf0[19]);
+        buf1[16] = _mm256_add_epi32(buf1[16], buf0[19]);
+        buf1[18] = _mm256_sub_epi32(buf1[17], buf0[18]);
+        buf1[17] = _mm256_add_epi32(buf1[17], buf0[18]);
+        buf1[20] = _mm256_sub_epi32(buf1[23], buf0[20]);
+        buf1[23] = _mm256_add_epi32(buf1[23], buf0[20]);
+        buf1[21] = _mm256_sub_epi32(buf1[22], buf0[21]);
+        buf1[22] = _mm256_add_epi32(buf1[22], buf0[21]);
+        buf1[27] = _mm256_sub_epi32(buf1[24], buf0[27]);
+        buf1[24] = _mm256_add_epi32(buf1[24], buf0[27]);
+        buf1[26] = _mm256_sub_epi32(buf1[25], buf0[26]);
+        buf1[25] = _mm256_add_epi32(buf1[25], buf0[26]);
+        buf1[28] = _mm256_sub_epi32(buf1[31], buf0[28]);
+        buf1[31] = _mm256_add_epi32(buf1[31], buf0[28]);
+        buf1[29] = _mm256_sub_epi32(buf1[30], buf0[29]);
+        buf1[30] = _mm256_add_epi32(buf1[30], buf0[29]);
 
         // stage 6
-        buf0[0] = buf1[0];
-        buf0[1] = buf1[1];
-        buf0[2] = buf1[2];
-        buf0[3] = buf1[3];
         btf_32_type1_avx2_new(
-            cospi_p56, cospi_p08, buf1[4], buf1[7], buf0[4], buf0[7], __rounding, cos_bit);
+            cospi_p56, cospi_p08, buf1[4], buf1[7], out[4 * stride], out[28 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p24, cospi_p40, buf1[5], buf1[6], buf0[5], buf0[6], __rounding, cos_bit);
-        buf0[8]  = _mm256_add_epi32(buf1[8], buf1[9]);
-        buf0[9]  = _mm256_sub_epi32(buf1[8], buf1[9]);
-        buf0[10] = _mm256_sub_epi32(buf1[11], buf1[10]);
-        buf0[11] = _mm256_add_epi32(buf1[11], buf1[10]);
-        buf0[12] = _mm256_add_epi32(buf1[12], buf1[13]);
-        buf0[13] = _mm256_sub_epi32(buf1[12], buf1[13]);
-        buf0[14] = _mm256_sub_epi32(buf1[15], buf1[14]);
-        buf0[15] = _mm256_add_epi32(buf1[15], buf1[14]);
-        buf0[16] = buf1[16];
+            cospi_p24, cospi_p40, buf1[5], buf1[6], out[20 * stride], out[12 * stride], __rounding, cos_bit);
+        buf0[9]  = _mm256_sub_epi32(buf0[8], buf1[9]);
+        buf0[8]  = _mm256_add_epi32(buf0[8], buf1[9]);
+        buf0[10] = _mm256_sub_epi32(buf0[11], buf1[10]);
+        buf0[11] = _mm256_add_epi32(buf0[11], buf1[10]);
+        buf0[13] = _mm256_sub_epi32(buf0[12], buf1[13]);
+        buf0[12] = _mm256_add_epi32(buf0[12], buf1[13]);
+        buf0[14] = _mm256_sub_epi32(buf0[15], buf1[14]);
+        buf0[15] = _mm256_add_epi32(buf0[15], buf1[14]);
         btf_32_type0_avx2_new(
             cospi_m08, cospi_p56, buf1[17], buf1[30], buf0[17], buf0[30], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m56, cospi_m08, buf1[18], buf1[29], buf0[18], buf0[29], __rounding, cos_bit);
-        buf0[19] = buf1[19];
-        buf0[20] = buf1[20];
         btf_32_type0_avx2_new(
             cospi_m40, cospi_p24, buf1[21], buf1[26], buf0[21], buf0[26], __rounding, cos_bit);
         btf_32_type0_avx2_new(
             cospi_m24, cospi_m40, buf1[22], buf1[25], buf0[22], buf0[25], __rounding, cos_bit);
-        buf0[23] = buf1[23];
-        buf0[24] = buf1[24];
-        buf0[27] = buf1[27];
-        buf0[28] = buf1[28];
-        buf0[31] = buf1[31];
 
         // stage 7
-        buf1[0] = buf0[0];
-        buf1[1] = buf0[1];
-        buf1[2] = buf0[2];
-        buf1[3] = buf0[3];
-        buf1[4] = buf0[4];
-        buf1[5] = buf0[5];
-        buf1[6] = buf0[6];
-        buf1[7] = buf0[7];
         btf_32_type1_avx2_new(
-            cospi_p60, cospi_p04, buf0[8], buf0[15], buf1[8], buf1[15], __rounding, cos_bit);
+            cospi_p60, cospi_p04, buf0[8], buf0[15], out[2 * stride], out[30 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p28, cospi_p36, buf0[9], buf0[14], buf1[9], buf1[14], __rounding, cos_bit);
+            cospi_p28, cospi_p36, buf0[9], buf0[14], out[18 * stride], out[14 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p44, cospi_p20, buf0[10], buf0[13], buf1[10], buf1[13], __rounding, cos_bit);
+            cospi_p44, cospi_p20, buf0[10], buf0[13], out[10 * stride], out[22 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p12, cospi_p52, buf0[11], buf0[12], buf1[11], buf1[12], __rounding, cos_bit);
-        buf1[16] = _mm256_add_epi32(buf0[16], buf0[17]);
-        buf1[17] = _mm256_sub_epi32(buf0[16], buf0[17]);
-        buf1[18] = _mm256_sub_epi32(buf0[19], buf0[18]);
-        buf1[19] = _mm256_add_epi32(buf0[19], buf0[18]);
-        buf1[20] = _mm256_add_epi32(buf0[20], buf0[21]);
-        buf1[21] = _mm256_sub_epi32(buf0[20], buf0[21]);
-        buf1[22] = _mm256_sub_epi32(buf0[23], buf0[22]);
-        buf1[23] = _mm256_add_epi32(buf0[23], buf0[22]);
-        buf1[24] = _mm256_add_epi32(buf0[24], buf0[25]);
-        buf1[25] = _mm256_sub_epi32(buf0[24], buf0[25]);
-        buf1[26] = _mm256_sub_epi32(buf0[27], buf0[26]);
-        buf1[27] = _mm256_add_epi32(buf0[27], buf0[26]);
-        buf1[28] = _mm256_add_epi32(buf0[28], buf0[29]);
-        buf1[29] = _mm256_sub_epi32(buf0[28], buf0[29]);
-        buf1[30] = _mm256_sub_epi32(buf0[31], buf0[30]);
-        buf1[31] = _mm256_add_epi32(buf0[31], buf0[30]);
+            cospi_p12, cospi_p52, buf0[11], buf0[12], out[26 * stride], out[6 * stride], __rounding, cos_bit);
+        buf1[17] = _mm256_sub_epi32(buf1[16], buf0[17]);
+        buf1[16] = _mm256_add_epi32(buf1[16], buf0[17]);
+        buf1[18] = _mm256_sub_epi32(buf1[19], buf0[18]);
+        buf1[19] = _mm256_add_epi32(buf1[19], buf0[18]);
+        buf1[21] = _mm256_sub_epi32(buf1[20], buf0[21]);
+        buf1[20] = _mm256_add_epi32(buf1[20], buf0[21]);
+        buf1[22] = _mm256_sub_epi32(buf1[23], buf0[22]);
+        buf1[23] = _mm256_add_epi32(buf1[23], buf0[22]);
+        buf1[25] = _mm256_sub_epi32(buf1[24], buf0[25]);
+        buf1[24] = _mm256_add_epi32(buf1[24], buf0[25]);
+        buf1[26] = _mm256_sub_epi32(buf1[27], buf0[26]);
+        buf1[27] = _mm256_add_epi32(buf1[27], buf0[26]);
+        buf1[29] = _mm256_sub_epi32(buf1[28], buf0[29]);
+        buf1[28] = _mm256_add_epi32(buf1[28], buf0[29]);
+        buf1[30] = _mm256_sub_epi32(buf1[31], buf0[30]);
+        buf1[31] = _mm256_add_epi32(buf1[31], buf0[30]);
 
         // stage 8
-        buf0[0]  = buf1[0];
-        buf0[1]  = buf1[1];
-        buf0[2]  = buf1[2];
-        buf0[3]  = buf1[3];
-        buf0[4]  = buf1[4];
-        buf0[5]  = buf1[5];
-        buf0[6]  = buf1[6];
-        buf0[7]  = buf1[7];
-        buf0[8]  = buf1[8];
-        buf0[9]  = buf1[9];
-        buf0[10] = buf1[10];
-        buf0[11] = buf1[11];
-        buf0[12] = buf1[12];
-        buf0[13] = buf1[13];
-        buf0[14] = buf1[14];
-        buf0[15] = buf1[15];
         btf_32_type1_avx2_new(
-            cospi_p62, cospi_p02, buf1[16], buf1[31], buf0[16], buf0[31], __rounding, cos_bit);
+            cospi_p62, cospi_p02, buf1[16], buf1[31], out[1 * stride], out[31 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p30, cospi_p34, buf1[17], buf1[30], buf0[17], buf0[30], __rounding, cos_bit);
+            cospi_p30, cospi_p34, buf1[17], buf1[30], out[17 * stride], out[15 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p46, cospi_p18, buf1[18], buf1[29], buf0[18], buf0[29], __rounding, cos_bit);
+            cospi_p46, cospi_p18, buf1[18], buf1[29], out[9 * stride], out[23 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p14, cospi_p50, buf1[19], buf1[28], buf0[19], buf0[28], __rounding, cos_bit);
+            cospi_p14, cospi_p50, buf1[19], buf1[28], out[25 * stride], out[7 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p54, cospi_p10, buf1[20], buf1[27], buf0[20], buf0[27], __rounding, cos_bit);
+            cospi_p54, cospi_p10, buf1[20], buf1[27], out[5 * stride], out[27 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p22, cospi_p42, buf1[21], buf1[26], buf0[21], buf0[26], __rounding, cos_bit);
+            cospi_p22, cospi_p42, buf1[21], buf1[26], out[21 * stride], out[11 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p38, cospi_p26, buf1[22], buf1[25], buf0[22], buf0[25], __rounding, cos_bit);
+            cospi_p38, cospi_p26, buf1[22], buf1[25], out[13 * stride], out[19 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p06, cospi_p58, buf1[23], buf1[24], buf0[23], buf0[24], __rounding, cos_bit);
-
-        // stage 9
-        out[0 * stride]  = buf0[0];
-        out[1 * stride]  = buf0[16];
-        out[2 * stride]  = buf0[8];
-        out[3 * stride]  = buf0[24];
-        out[4 * stride]  = buf0[4];
-        out[5 * stride]  = buf0[20];
-        out[6 * stride]  = buf0[12];
-        out[7 * stride]  = buf0[28];
-        out[8 * stride]  = buf0[2];
-        out[9 * stride]  = buf0[18];
-        out[10 * stride] = buf0[10];
-        out[11 * stride] = buf0[26];
-        out[12 * stride] = buf0[6];
-        out[13 * stride] = buf0[22];
-        out[14 * stride] = buf0[14];
-        out[15 * stride] = buf0[30];
-        out[16 * stride] = buf0[1];
-        out[17 * stride] = buf0[17];
-        out[18 * stride] = buf0[9];
-        out[19 * stride] = buf0[25];
-        out[20 * stride] = buf0[5];
-        out[21 * stride] = buf0[21];
-        out[22 * stride] = buf0[13];
-        out[23 * stride] = buf0[29];
-        out[24 * stride] = buf0[3];
-        out[25 * stride] = buf0[19];
-        out[26 * stride] = buf0[11];
-        out[27 * stride] = buf0[27];
-        out[28 * stride] = buf0[7];
-        out[29 * stride] = buf0[23];
-        out[30 * stride] = buf0[15];
-        out[31 * stride] = buf0[31];
+            cospi_p06, cospi_p58, buf1[23], buf1[24], out[29 * stride], out[3 * stride], __rounding, cos_bit);
     }
 }
 
@@ -3211,7 +3068,7 @@ static void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t co
         x1[32] = _mm256_sub_epi32(in[31 * stride], in[32 * stride]);
 
         // stage 2
-        __m256i x2[64];
+        __m256i x2[48];
         x2[0]  = _mm256_add_epi32(x1[0], x1[31]);
         x2[31] = _mm256_sub_epi32(x1[0], x1[31]);
         x2[1]  = _mm256_add_epi32(x1[1], x1[30]);
@@ -3244,41 +3101,25 @@ static void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t co
         x2[17] = _mm256_sub_epi32(x1[14], x1[17]);
         x2[15] = _mm256_add_epi32(x1[15], x1[16]);
         x2[16] = _mm256_sub_epi32(x1[15], x1[16]);
-        x2[32] = x1[32];
-        x2[33] = x1[33];
-        x2[34] = x1[34];
-        x2[35] = x1[35];
-        x2[36] = x1[36];
-        x2[37] = x1[37];
-        x2[38] = x1[38];
-        x2[39] = x1[39];
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[40], x1[55], x2[40], x2[55], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[40], x1[55], x2[32], x2[47], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[41], x1[54], x2[41], x2[54], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[41], x1[54], x2[33], x2[46], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[42], x1[53], x2[42], x2[53], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[42], x1[53], x2[34], x2[45], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[43], x1[52], x2[43], x2[52], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[43], x1[52], x2[35], x2[44], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[44], x1[51], x2[44], x2[51], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[44], x1[51], x2[36], x2[43], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[45], x1[50], x2[45], x2[50], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[45], x1[50], x2[37], x2[42], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[46], x1[49], x2[46], x2[49], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x1[46], x1[49], x2[38], x2[41], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x1[47], x1[48], x2[47], x2[48], __rounding, cos_bit);
-        x2[56] = x1[56];
-        x2[57] = x1[57];
-        x2[58] = x1[58];
-        x2[59] = x1[59];
-        x2[60] = x1[60];
-        x2[61] = x1[61];
-        x2[62] = x1[62];
-        x2[63] = x1[63];
+            cospi_m32, cospi_p32, x1[47], x1[48], x2[39], x2[40], __rounding, cos_bit);
 
         // stage 3
-        __m256i x3[64];
+        __m256i x3[56];
         x3[0]  = _mm256_add_epi32(x2[0], x2[15]);
         x3[15] = _mm256_sub_epi32(x2[0], x2[15]);
         x3[1]  = _mm256_add_epi32(x2[1], x2[14]);
@@ -3295,57 +3136,49 @@ static void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t co
         x3[9]  = _mm256_sub_epi32(x2[6], x2[9]);
         x3[7]  = _mm256_add_epi32(x2[7], x2[8]);
         x3[8]  = _mm256_sub_epi32(x2[7], x2[8]);
-        x3[16] = x2[16];
-        x3[17] = x2[17];
-        x3[18] = x2[18];
-        x3[19] = x2[19];
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x2[20], x2[27], x3[20], x3[27], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x2[20], x2[27], x3[16], x3[23], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x2[21], x2[26], x3[21], x3[26], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x2[21], x2[26], x3[17], x3[22], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x2[22], x2[25], x3[22], x3[25], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x2[22], x2[25], x3[18], x3[21], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x2[23], x2[24], x3[23], x3[24], __rounding, cos_bit);
-        x3[28] = x2[28];
-        x3[29] = x2[29];
-        x3[30] = x2[30];
-        x3[31] = x2[31];
-        x3[32] = _mm256_add_epi32(x2[32], x2[47]);
-        x3[47] = _mm256_sub_epi32(x2[32], x2[47]);
-        x3[33] = _mm256_add_epi32(x2[33], x2[46]);
-        x3[46] = _mm256_sub_epi32(x2[33], x2[46]);
-        x3[34] = _mm256_add_epi32(x2[34], x2[45]);
-        x3[45] = _mm256_sub_epi32(x2[34], x2[45]);
-        x3[35] = _mm256_add_epi32(x2[35], x2[44]);
-        x3[44] = _mm256_sub_epi32(x2[35], x2[44]);
-        x3[36] = _mm256_add_epi32(x2[36], x2[43]);
-        x3[43] = _mm256_sub_epi32(x2[36], x2[43]);
-        x3[37] = _mm256_add_epi32(x2[37], x2[42]);
-        x3[42] = _mm256_sub_epi32(x2[37], x2[42]);
-        x3[38] = _mm256_add_epi32(x2[38], x2[41]);
-        x3[41] = _mm256_sub_epi32(x2[38], x2[41]);
-        x3[39] = _mm256_add_epi32(x2[39], x2[40]);
-        x3[40] = _mm256_sub_epi32(x2[39], x2[40]);
-        x3[48] = _mm256_sub_epi32(x2[63], x2[48]);
-        x3[63] = _mm256_add_epi32(x2[63], x2[48]);
-        x3[49] = _mm256_sub_epi32(x2[62], x2[49]);
-        x3[62] = _mm256_add_epi32(x2[62], x2[49]);
-        x3[50] = _mm256_sub_epi32(x2[61], x2[50]);
-        x3[61] = _mm256_add_epi32(x2[61], x2[50]);
-        x3[51] = _mm256_sub_epi32(x2[60], x2[51]);
-        x3[60] = _mm256_add_epi32(x2[60], x2[51]);
-        x3[52] = _mm256_sub_epi32(x2[59], x2[52]);
-        x3[59] = _mm256_add_epi32(x2[59], x2[52]);
-        x3[53] = _mm256_sub_epi32(x2[58], x2[53]);
-        x3[58] = _mm256_add_epi32(x2[58], x2[53]);
-        x3[54] = _mm256_sub_epi32(x2[57], x2[54]);
-        x3[57] = _mm256_add_epi32(x2[57], x2[54]);
-        x3[55] = _mm256_sub_epi32(x2[56], x2[55]);
-        x3[56] = _mm256_add_epi32(x2[56], x2[55]);
+            cospi_m32, cospi_p32, x2[23], x2[24], x3[19], x3[20], __rounding, cos_bit);
+        x3[32] = _mm256_add_epi32(x1[32], x2[39]);
+        x3[47] = _mm256_sub_epi32(x1[32], x2[39]);
+        x3[33] = _mm256_add_epi32(x1[33], x2[38]);
+        x3[46] = _mm256_sub_epi32(x1[33], x2[38]);
+        x3[34] = _mm256_add_epi32(x1[34], x2[37]);
+        x3[45] = _mm256_sub_epi32(x1[34], x2[37]);
+        x3[35] = _mm256_add_epi32(x1[35], x2[36]);
+        x3[44] = _mm256_sub_epi32(x1[35], x2[36]);
+        x3[36] = _mm256_add_epi32(x1[36], x2[35]);
+        x3[43] = _mm256_sub_epi32(x1[36], x2[35]);
+        x3[37] = _mm256_add_epi32(x1[37], x2[34]);
+        x3[42] = _mm256_sub_epi32(x1[37], x2[34]);
+        x3[38] = _mm256_add_epi32(x1[38], x2[33]);
+        x3[41] = _mm256_sub_epi32(x1[38], x2[33]);
+        x3[39] = _mm256_add_epi32(x1[39], x2[32]);
+        x3[40] = _mm256_sub_epi32(x1[39], x2[32]);
+        x3[48] = _mm256_sub_epi32(x1[63], x2[40]);
+        x3[24] = _mm256_add_epi32(x1[63], x2[40]);
+        x3[49] = _mm256_sub_epi32(x1[62], x2[41]);
+        x3[25] = _mm256_add_epi32(x1[62], x2[41]);
+        x3[50] = _mm256_sub_epi32(x1[61], x2[42]);
+        x3[26] = _mm256_add_epi32(x1[61], x2[42]);
+        x3[51] = _mm256_sub_epi32(x1[60], x2[43]);
+        x3[27] = _mm256_add_epi32(x1[60], x2[43]);
+        x3[52] = _mm256_sub_epi32(x1[59], x2[44]);
+        x3[28] = _mm256_add_epi32(x1[59], x2[44]);
+        x3[53] = _mm256_sub_epi32(x1[58], x2[45]);
+        x3[29] = _mm256_add_epi32(x1[58], x2[45]);
+        x3[54] = _mm256_sub_epi32(x1[57], x2[46]);
+        x3[30] = _mm256_add_epi32(x1[57], x2[46]);
+        x3[55] = _mm256_sub_epi32(x1[56], x2[47]);
+        x3[31] = _mm256_add_epi32(x1[56], x2[47]);
 
         // stage 4
-        __m256i x4[64];
+        __m256i x4[44];
         x4[0] = _mm256_add_epi32(x3[0], x3[7]);
         x4[7] = _mm256_sub_epi32(x3[0], x3[7]);
         x4[1] = _mm256_add_epi32(x3[1], x3[6]);
@@ -3354,499 +3187,329 @@ static void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t co
         x4[5] = _mm256_sub_epi32(x3[2], x3[5]);
         x4[3] = _mm256_add_epi32(x3[3], x3[4]);
         x4[4] = _mm256_sub_epi32(x3[3], x3[4]);
-        x4[8] = x3[8];
-        x4[9] = x3[9];
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x3[10], x3[13], x4[10], x4[13], __rounding, cos_bit);
+            cospi_m32, cospi_p32, x3[10], x3[13], x4[8], x4[11], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x3[11], x3[12], x4[11], x4[12], __rounding, cos_bit);
-        x4[14] = x3[14];
-        x4[15] = x3[15];
-        x4[16] = _mm256_add_epi32(x3[16], x3[23]);
-        x4[23] = _mm256_sub_epi32(x3[16], x3[23]);
-        x4[17] = _mm256_add_epi32(x3[17], x3[22]);
-        x4[22] = _mm256_sub_epi32(x3[17], x3[22]);
-        x4[18] = _mm256_add_epi32(x3[18], x3[21]);
-        x4[21] = _mm256_sub_epi32(x3[18], x3[21]);
-        x4[19] = _mm256_add_epi32(x3[19], x3[20]);
-        x4[20] = _mm256_sub_epi32(x3[19], x3[20]);
-        x4[24] = _mm256_sub_epi32(x3[31], x3[24]);
-        x4[31] = _mm256_add_epi32(x3[31], x3[24]);
-        x4[25] = _mm256_sub_epi32(x3[30], x3[25]);
-        x4[30] = _mm256_add_epi32(x3[30], x3[25]);
-        x4[26] = _mm256_sub_epi32(x3[29], x3[26]);
-        x4[29] = _mm256_add_epi32(x3[29], x3[26]);
-        x4[27] = _mm256_sub_epi32(x3[28], x3[27]);
-        x4[28] = _mm256_add_epi32(x3[28], x3[27]);
-        x4[32] = x3[32];
-        x4[33] = x3[33];
-        x4[34] = x3[34];
-        x4[35] = x3[35];
+            cospi_m32, cospi_p32, x3[11], x3[12], x4[9], x4[10], __rounding, cos_bit);
+        x4[12] = _mm256_add_epi32(x2[16], x3[19]);
+        x4[19] = _mm256_sub_epi32(x2[16], x3[19]);
+        x4[13] = _mm256_add_epi32(x2[17], x3[18]);
+        x4[18] = _mm256_sub_epi32(x2[17], x3[18]);
+        x4[14] = _mm256_add_epi32(x2[18], x3[17]);
+        x4[17] = _mm256_sub_epi32(x2[18], x3[17]);
+        x4[15] = _mm256_add_epi32(x2[19], x3[16]);
+        x4[16] = _mm256_sub_epi32(x2[19], x3[16]);
+        x4[20] = _mm256_sub_epi32(x2[31], x3[20]);
+        x4[27] = _mm256_add_epi32(x2[31], x3[20]);
+        x4[21] = _mm256_sub_epi32(x2[30], x3[21]);
+        x4[26] = _mm256_add_epi32(x2[30], x3[21]);
+        x4[22] = _mm256_sub_epi32(x2[29], x3[22]);
+        x4[25] = _mm256_add_epi32(x2[29], x3[22]);
+        x4[23] = _mm256_sub_epi32(x2[28], x3[23]);
+        x4[24] = _mm256_add_epi32(x2[28], x3[23]);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x3[36], x3[59], x4[36], x4[59], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x3[36], x3[28], x4[28], x4[43], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x3[37], x3[58], x4[37], x4[58], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x3[37], x3[29], x4[29], x4[42], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x3[38], x3[57], x4[38], x4[57], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x3[38], x3[30], x4[30], x4[41], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x3[39], x3[56], x4[39], x4[56], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x3[39], x3[31], x4[31], x4[40], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x3[40], x3[55], x4[40], x4[55], __rounding, cos_bit);
+            cospi_m48, cospi_m16, x3[40], x3[55], x4[32], x4[39], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x3[41], x3[54], x4[41], x4[54], __rounding, cos_bit);
+            cospi_m48, cospi_m16, x3[41], x3[54], x4[33], x4[38], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x3[42], x3[53], x4[42], x4[53], __rounding, cos_bit);
+            cospi_m48, cospi_m16, x3[42], x3[53], x4[34], x4[37], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x3[43], x3[52], x4[43], x4[52], __rounding, cos_bit);
-        x4[44] = x3[44];
-        x4[45] = x3[45];
-        x4[46] = x3[46];
-        x4[47] = x3[47];
-        x4[48] = x3[48];
-        x4[49] = x3[49];
-        x4[50] = x3[50];
-        x4[51] = x3[51];
-        x4[60] = x3[60];
-        x4[61] = x3[61];
-        x4[62] = x3[62];
-        x4[63] = x3[63];
+            cospi_m48, cospi_m16, x3[43], x3[52], x4[35], x4[36], __rounding, cos_bit);
 
         // stage 5
-        __m256i x5[64];
+        __m256i x5[54];
         x5[0] = _mm256_add_epi32(x4[0], x4[3]);
         x5[3] = _mm256_sub_epi32(x4[0], x4[3]);
         x5[1] = _mm256_add_epi32(x4[1], x4[2]);
         x5[2] = _mm256_sub_epi32(x4[1], x4[2]);
-        x5[4] = x4[4];
         btf_32_type0_avx2_new(
-            cospi_m32, cospi_p32, x4[5], x4[6], x5[5], x5[6], __rounding, cos_bit);
-        x5[7]  = x4[7];
-        x5[8]  = _mm256_add_epi32(x4[8], x4[11]);
-        x5[11] = _mm256_sub_epi32(x4[8], x4[11]);
-        x5[9]  = _mm256_add_epi32(x4[9], x4[10]);
-        x5[10] = _mm256_sub_epi32(x4[9], x4[10]);
-        x5[12] = _mm256_sub_epi32(x4[15], x4[12]);
-        x5[15] = _mm256_add_epi32(x4[15], x4[12]);
-        x5[13] = _mm256_sub_epi32(x4[14], x4[13]);
-        x5[14] = _mm256_add_epi32(x4[14], x4[13]);
-        x5[16] = x4[16];
-        x5[17] = x4[17];
+            cospi_m32, cospi_p32, x4[5], x4[6], x5[4], x5[5], __rounding, cos_bit);
+        x5[6]  = _mm256_add_epi32(x3[8], x4[9]);
+        x5[9]  = _mm256_sub_epi32(x3[8], x4[9]);
+        x5[7]  = _mm256_add_epi32(x3[9], x4[8]);
+        x5[8]  = _mm256_sub_epi32(x3[9], x4[8]);
+        x5[10] = _mm256_sub_epi32(x3[15], x4[10]);
+        x5[13] = _mm256_add_epi32(x3[15], x4[10]);
+        x5[11] = _mm256_sub_epi32(x3[14], x4[11]);
+        x5[12] = _mm256_add_epi32(x3[14], x4[11]);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x4[18], x4[29], x5[18], x5[29], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x4[14], x4[25], x5[14], x5[21], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x4[19], x4[28], x5[19], x5[28], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x4[15], x4[24], x5[15], x5[20], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x4[20], x4[27], x5[20], x5[27], __rounding, cos_bit);
+            cospi_m48, cospi_m16, x4[16], x4[23], x5[16], x5[19], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x4[21], x4[26], x5[21], x5[26], __rounding, cos_bit);
-        x5[22] = x4[22];
-        x5[23] = x4[23];
-        x5[24] = x4[24];
-        x5[25] = x4[25];
-        x5[30] = x4[30];
-        x5[31] = x4[31];
-        x5[32] = _mm256_add_epi32(x4[32], x4[39]);
-        x5[39] = _mm256_sub_epi32(x4[32], x4[39]);
-        x5[33] = _mm256_add_epi32(x4[33], x4[38]);
-        x5[38] = _mm256_sub_epi32(x4[33], x4[38]);
-        x5[34] = _mm256_add_epi32(x4[34], x4[37]);
-        x5[37] = _mm256_sub_epi32(x4[34], x4[37]);
-        x5[35] = _mm256_add_epi32(x4[35], x4[36]);
-        x5[36] = _mm256_sub_epi32(x4[35], x4[36]);
-        x5[40] = _mm256_sub_epi32(x4[47], x4[40]);
-        x5[47] = _mm256_add_epi32(x4[47], x4[40]);
-        x5[41] = _mm256_sub_epi32(x4[46], x4[41]);
-        x5[46] = _mm256_add_epi32(x4[46], x4[41]);
-        x5[42] = _mm256_sub_epi32(x4[45], x4[42]);
-        x5[45] = _mm256_add_epi32(x4[45], x4[42]);
-        x5[43] = _mm256_sub_epi32(x4[44], x4[43]);
-        x5[44] = _mm256_add_epi32(x4[44], x4[43]);
-        x5[48] = _mm256_add_epi32(x4[48], x4[55]);
-        x5[55] = _mm256_sub_epi32(x4[48], x4[55]);
-        x5[49] = _mm256_add_epi32(x4[49], x4[54]);
-        x5[54] = _mm256_sub_epi32(x4[49], x4[54]);
-        x5[50] = _mm256_add_epi32(x4[50], x4[53]);
-        x5[53] = _mm256_sub_epi32(x4[50], x4[53]);
-        x5[51] = _mm256_add_epi32(x4[51], x4[52]);
-        x5[52] = _mm256_sub_epi32(x4[51], x4[52]);
-        x5[56] = _mm256_sub_epi32(x4[63], x4[56]);
-        x5[63] = _mm256_add_epi32(x4[63], x4[56]);
-        x5[57] = _mm256_sub_epi32(x4[62], x4[57]);
-        x5[62] = _mm256_add_epi32(x4[62], x4[57]);
-        x5[58] = _mm256_sub_epi32(x4[61], x4[58]);
-        x5[61] = _mm256_add_epi32(x4[61], x4[58]);
-        x5[59] = _mm256_sub_epi32(x4[60], x4[59]);
-        x5[60] = _mm256_add_epi32(x4[60], x4[59]);
+            cospi_m48, cospi_m16, x4[17], x4[22], x5[17], x5[18], __rounding, cos_bit);
+        x5[22] = _mm256_add_epi32(x3[32], x4[31]);
+        x5[29] = _mm256_sub_epi32(x3[32], x4[31]);
+        x5[23] = _mm256_add_epi32(x3[33], x4[30]);
+        x5[28] = _mm256_sub_epi32(x3[33], x4[30]);
+        x5[24] = _mm256_add_epi32(x3[34], x4[29]);
+        x5[27] = _mm256_sub_epi32(x3[34], x4[29]);
+        x5[25] = _mm256_add_epi32(x3[35], x4[28]);
+        x5[26] = _mm256_sub_epi32(x3[35], x4[28]);
+        x5[30] = _mm256_sub_epi32(x3[47], x4[32]);
+        x5[37] = _mm256_add_epi32(x3[47], x4[32]);
+        x5[31] = _mm256_sub_epi32(x3[46], x4[33]);
+        x5[36] = _mm256_add_epi32(x3[46], x4[33]);
+        x5[32] = _mm256_sub_epi32(x3[45], x4[34]);
+        x5[35] = _mm256_add_epi32(x3[45], x4[34]);
+        x5[33] = _mm256_sub_epi32(x3[44], x4[35]);
+        x5[34] = _mm256_add_epi32(x3[44], x4[35]);
+        x5[38] = _mm256_add_epi32(x3[48], x4[39]);
+        x5[45] = _mm256_sub_epi32(x3[48], x4[39]);
+        x5[39] = _mm256_add_epi32(x3[49], x4[38]);
+        x5[44] = _mm256_sub_epi32(x3[49], x4[38]);
+        x5[40] = _mm256_add_epi32(x3[50], x4[37]);
+        x5[43] = _mm256_sub_epi32(x3[50], x4[37]);
+        x5[41] = _mm256_add_epi32(x3[51], x4[36]);
+        x5[42] = _mm256_sub_epi32(x3[51], x4[36]);
+        x5[46] = _mm256_sub_epi32(x3[24], x4[40]);
+        x5[53] = _mm256_add_epi32(x3[24], x4[40]);
+        x5[47] = _mm256_sub_epi32(x3[25], x4[41]);
+        x5[52] = _mm256_add_epi32(x3[25], x4[41]);
+        x5[48] = _mm256_sub_epi32(x3[26], x4[42]);
+        x5[51] = _mm256_add_epi32(x3[26], x4[42]);
+        x5[49] = _mm256_sub_epi32(x3[27], x4[43]);
+        x5[50] = _mm256_add_epi32(x3[27], x4[43]);
 
         // stage 6
-        __m256i x6[64];
+        __m256i x6[40];
         btf_32_type0_avx2_new(
-            cospi_p32, cospi_p32, x5[0], x5[1], x6[0], x6[1], __rounding, cos_bit);
+            cospi_p32, cospi_p32, x5[0], x5[1], out[0 * stride], out[32 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p48, cospi_p16, x5[2], x5[3], x6[2], x6[3], __rounding, cos_bit);
-        x6[4] = _mm256_add_epi32(x5[4], x5[5]);
-        x6[5] = _mm256_sub_epi32(x5[4], x5[5]);
-        x6[6] = _mm256_sub_epi32(x5[7], x5[6]);
-        x6[7] = _mm256_add_epi32(x5[7], x5[6]);
-        x6[8] = x5[8];
+            cospi_p48, cospi_p16, x5[2], x5[3], out[16 * stride], out[48 * stride], __rounding, cos_bit);
+        x6[0] = _mm256_add_epi32(x4[4], x5[4]);
+        x6[1] = _mm256_sub_epi32(x4[4], x5[4]);
+        x6[2] = _mm256_sub_epi32(x4[7], x5[5]);
+        x6[3] = _mm256_add_epi32(x4[7], x5[5]);
         btf_32_type0_avx2_new(
-            cospi_m16, cospi_p48, x5[9], x5[14], x6[9], x6[14], __rounding, cos_bit);
+            cospi_m16, cospi_p48, x5[7], x5[12], x6[4], x6[7], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m48, cospi_m16, x5[10], x5[13], x6[10], x6[13], __rounding, cos_bit);
-        x6[11] = x5[11];
-        x6[12] = x5[12];
-        x6[15] = x5[15];
-        x6[16] = _mm256_add_epi32(x5[16], x5[19]);
-        x6[19] = _mm256_sub_epi32(x5[16], x5[19]);
-        x6[17] = _mm256_add_epi32(x5[17], x5[18]);
-        x6[18] = _mm256_sub_epi32(x5[17], x5[18]);
-        x6[20] = _mm256_sub_epi32(x5[23], x5[20]);
-        x6[23] = _mm256_add_epi32(x5[23], x5[20]);
-        x6[21] = _mm256_sub_epi32(x5[22], x5[21]);
-        x6[22] = _mm256_add_epi32(x5[22], x5[21]);
-        x6[24] = _mm256_add_epi32(x5[24], x5[27]);
-        x6[27] = _mm256_sub_epi32(x5[24], x5[27]);
-        x6[25] = _mm256_add_epi32(x5[25], x5[26]);
-        x6[26] = _mm256_sub_epi32(x5[25], x5[26]);
-        x6[28] = _mm256_sub_epi32(x5[31], x5[28]);
-        x6[31] = _mm256_add_epi32(x5[31], x5[28]);
-        x6[29] = _mm256_sub_epi32(x5[30], x5[29]);
-        x6[30] = _mm256_add_epi32(x5[30], x5[29]);
-        x6[32] = x5[32];
-        x6[33] = x5[33];
+            cospi_m48, cospi_m16, x5[8], x5[11], x6[5], x6[6], __rounding, cos_bit);
+        x6[8]  = _mm256_add_epi32(x4[12], x5[15]);
+        x6[11] = _mm256_sub_epi32(x4[12], x5[15]);
+        x6[9]  = _mm256_add_epi32(x4[13], x5[14]);
+        x6[10] = _mm256_sub_epi32(x4[13], x5[14]);
+        x6[12] = _mm256_sub_epi32(x4[19], x5[16]);
+        x6[15] = _mm256_add_epi32(x4[19], x5[16]);
+        x6[13] = _mm256_sub_epi32(x4[18], x5[17]);
+        x6[14] = _mm256_add_epi32(x4[18], x5[17]);
+        x6[16] = _mm256_add_epi32(x4[20], x5[19]);
+        x6[19] = _mm256_sub_epi32(x4[20], x5[19]);
+        x6[17] = _mm256_add_epi32(x4[21], x5[18]);
+        x6[18] = _mm256_sub_epi32(x4[21], x5[18]);
+        x6[20] = _mm256_sub_epi32(x4[27], x5[20]);
+        x6[23] = _mm256_add_epi32(x4[27], x5[20]);
+        x6[21] = _mm256_sub_epi32(x4[26], x5[21]);
+        x6[22] = _mm256_add_epi32(x4[26], x5[21]);
         btf_32_type0_avx2_new(
-            cospi_m08, cospi_p56, x5[34], x5[61], x6[34], x6[61], __rounding, cos_bit);
+            cospi_m08, cospi_p56, x5[24], x5[51], x6[24], x6[39], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m08, cospi_p56, x5[35], x5[60], x6[35], x6[60], __rounding, cos_bit);
+            cospi_m08, cospi_p56, x5[25], x5[50], x6[25], x6[38], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m56, cospi_m08, x5[36], x5[59], x6[36], x6[59], __rounding, cos_bit);
+            cospi_m56, cospi_m08, x5[26], x5[49], x6[26], x6[37], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m56, cospi_m08, x5[37], x5[58], x6[37], x6[58], __rounding, cos_bit);
-        x6[38] = x5[38];
-        x6[39] = x5[39];
-        x6[40] = x5[40];
-        x6[41] = x5[41];
+            cospi_m56, cospi_m08, x5[27], x5[48], x6[27], x6[36], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m40, cospi_p24, x5[42], x5[53], x6[42], x6[53], __rounding, cos_bit);
+            cospi_m40, cospi_p24, x5[32], x5[43], x6[28], x6[35], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m40, cospi_p24, x5[43], x5[52], x6[43], x6[52], __rounding, cos_bit);
+            cospi_m40, cospi_p24, x5[33], x5[42], x6[29], x6[34], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m24, cospi_m40, x5[44], x5[51], x6[44], x6[51], __rounding, cos_bit);
+            cospi_m24, cospi_m40, x5[34], x5[41], x6[30], x6[33], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m24, cospi_m40, x5[45], x5[50], x6[45], x6[50], __rounding, cos_bit);
-        x6[46] = x5[46];
-        x6[47] = x5[47];
-        x6[48] = x5[48];
-        x6[49] = x5[49];
-        x6[54] = x5[54];
-        x6[55] = x5[55];
-        x6[56] = x5[56];
-        x6[57] = x5[57];
-        x6[62] = x5[62];
-        x6[63] = x5[63];
+            cospi_m24, cospi_m40, x5[35], x5[40], x6[31], x6[32], __rounding, cos_bit);
 
         // stage 7
-        __m256i x7[64];
-        x7[0] = x6[0];
-        x7[1] = x6[1];
-        x7[2] = x6[2];
-        x7[3] = x6[3];
+        __m256i x7[48];
         btf_32_type1_avx2_new(
-            cospi_p56, cospi_p08, x6[4], x6[7], x7[4], x7[7], __rounding, cos_bit);
+            cospi_p56, cospi_p08, x6[0], x6[3], out[8 * stride], out[56 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p24, cospi_p40, x6[5], x6[6], x7[5], x7[6], __rounding, cos_bit);
-        x7[8]  = _mm256_add_epi32(x6[8], x6[9]);
-        x7[9]  = _mm256_sub_epi32(x6[8], x6[9]);
-        x7[10] = _mm256_sub_epi32(x6[11], x6[10]);
-        x7[11] = _mm256_add_epi32(x6[11], x6[10]);
-        x7[12] = _mm256_add_epi32(x6[12], x6[13]);
-        x7[13] = _mm256_sub_epi32(x6[12], x6[13]);
-        x7[14] = _mm256_sub_epi32(x6[15], x6[14]);
-        x7[15] = _mm256_add_epi32(x6[15], x6[14]);
-        x7[16] = x6[16];
+            cospi_p24, cospi_p40, x6[1], x6[2], out[40 * stride], out[24 * stride], __rounding, cos_bit);
+        x7[0] = _mm256_add_epi32(x5[6], x6[4]);
+        x7[1] = _mm256_sub_epi32(x5[6], x6[4]);
+        x7[2] = _mm256_sub_epi32(x5[9], x6[5]);
+        x7[3] = _mm256_add_epi32(x5[9], x6[5]);
+        x7[4] = _mm256_add_epi32(x5[10], x6[6]);
+        x7[5] = _mm256_sub_epi32(x5[10], x6[6]);
+        x7[6] = _mm256_sub_epi32(x5[13], x6[7]);
+        x7[7] = _mm256_add_epi32(x5[13], x6[7]);
         btf_32_type0_avx2_new(
-            cospi_m08, cospi_p56, x6[17], x6[30], x7[17], x7[30], __rounding, cos_bit);
+            cospi_m08, cospi_p56, x6[9], x6[22], x7[8], x7[15], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m56, cospi_m08, x6[18], x6[29], x7[18], x7[29], __rounding, cos_bit);
-        x7[19] = x6[19];
-        x7[20] = x6[20];
+            cospi_m56, cospi_m08, x6[10], x6[21], x7[9], x7[14], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m40, cospi_p24, x6[21], x6[26], x7[21], x7[26], __rounding, cos_bit);
+            cospi_m40, cospi_p24, x6[13], x6[18], x7[10], x7[13], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m24, cospi_m40, x6[22], x6[25], x7[22], x7[25], __rounding, cos_bit);
-        x7[23] = x6[23];
-        x7[24] = x6[24];
-        x7[27] = x6[27];
-        x7[28] = x6[28];
-        x7[31] = x6[31];
-        x7[32] = _mm256_add_epi32(x6[32], x6[35]);
-        x7[35] = _mm256_sub_epi32(x6[32], x6[35]);
-        x7[33] = _mm256_add_epi32(x6[33], x6[34]);
-        x7[34] = _mm256_sub_epi32(x6[33], x6[34]);
-        x7[36] = _mm256_sub_epi32(x6[39], x6[36]);
-        x7[39] = _mm256_add_epi32(x6[39], x6[36]);
-        x7[37] = _mm256_sub_epi32(x6[38], x6[37]);
-        x7[38] = _mm256_add_epi32(x6[38], x6[37]);
-        x7[40] = _mm256_add_epi32(x6[40], x6[43]);
-        x7[43] = _mm256_sub_epi32(x6[40], x6[43]);
-        x7[41] = _mm256_add_epi32(x6[41], x6[42]);
-        x7[42] = _mm256_sub_epi32(x6[41], x6[42]);
-        x7[44] = _mm256_sub_epi32(x6[47], x6[44]);
-        x7[47] = _mm256_add_epi32(x6[47], x6[44]);
-        x7[45] = _mm256_sub_epi32(x6[46], x6[45]);
-        x7[46] = _mm256_add_epi32(x6[46], x6[45]);
-        x7[48] = _mm256_add_epi32(x6[48], x6[51]);
-        x7[51] = _mm256_sub_epi32(x6[48], x6[51]);
-        x7[49] = _mm256_add_epi32(x6[49], x6[50]);
-        x7[50] = _mm256_sub_epi32(x6[49], x6[50]);
-        x7[52] = _mm256_sub_epi32(x6[55], x6[52]);
-        x7[55] = _mm256_add_epi32(x6[55], x6[52]);
-        x7[53] = _mm256_sub_epi32(x6[54], x6[53]);
-        x7[54] = _mm256_add_epi32(x6[54], x6[53]);
-        x7[56] = _mm256_add_epi32(x6[56], x6[59]);
-        x7[59] = _mm256_sub_epi32(x6[56], x6[59]);
-        x7[57] = _mm256_add_epi32(x6[57], x6[58]);
-        x7[58] = _mm256_sub_epi32(x6[57], x6[58]);
-        x7[60] = _mm256_sub_epi32(x6[63], x6[60]);
-        x7[63] = _mm256_add_epi32(x6[63], x6[60]);
-        x7[61] = _mm256_sub_epi32(x6[62], x6[61]);
-        x7[62] = _mm256_add_epi32(x6[62], x6[61]);
+            cospi_m24, cospi_m40, x6[14], x6[17], x7[11], x7[12], __rounding, cos_bit);
+        x7[16] = _mm256_add_epi32(x5[22], x6[25]);
+        x7[17] = _mm256_sub_epi32(x5[22], x6[25]);
+        x7[19] = _mm256_add_epi32(x5[23], x6[24]);
+        x7[20] = _mm256_sub_epi32(x5[23], x6[24]);
+        x7[18] = _mm256_sub_epi32(x5[29], x6[26]);
+        x7[21] = _mm256_add_epi32(x5[29], x6[26]);
+        x7[22] = _mm256_sub_epi32(x5[28], x6[27]);
+        x7[23] = _mm256_add_epi32(x5[28], x6[27]);
+        x7[24] = _mm256_add_epi32(x5[30], x6[29]);
+        x7[25] = _mm256_sub_epi32(x5[30], x6[29]);
+        x7[26] = _mm256_add_epi32(x5[31], x6[28]);
+        x7[27] = _mm256_sub_epi32(x5[31], x6[28]);
+        x7[28] = _mm256_sub_epi32(x5[37], x6[30]);
+        x7[29] = _mm256_add_epi32(x5[37], x6[30]);
+        x7[30] = _mm256_sub_epi32(x5[36], x6[31]);
+        x7[31] = _mm256_add_epi32(x5[36], x6[31]);
+        x7[32] = _mm256_add_epi32(x5[38], x6[33]);
+        x7[33] = _mm256_sub_epi32(x5[38], x6[33]);
+        x7[34] = _mm256_add_epi32(x5[39], x6[32]);
+        x7[35] = _mm256_sub_epi32(x5[39], x6[32]);
+        x7[36] = _mm256_sub_epi32(x5[45], x6[34]);
+        x7[37] = _mm256_add_epi32(x5[45], x6[34]);
+        x7[38] = _mm256_sub_epi32(x5[44], x6[35]);
+        x7[39] = _mm256_add_epi32(x5[44], x6[35]);
+        x7[40] = _mm256_add_epi32(x5[46], x6[37]);
+        x7[41] = _mm256_sub_epi32(x5[46], x6[37]);
+        x7[42] = _mm256_add_epi32(x5[47], x6[36]);
+        x7[43] = _mm256_sub_epi32(x5[47], x6[36]);
+        x7[44] = _mm256_sub_epi32(x5[53], x6[38]);
+        x7[45] = _mm256_add_epi32(x5[53], x6[38]);
+        x7[46] = _mm256_sub_epi32(x5[52], x6[39]);
+        x7[47] = _mm256_add_epi32(x5[52], x6[39]);
 
         // stage 8
-        __m256i x8[64];
-        x8[0] = x7[0];
-        x8[1] = x7[1];
-        x8[2] = x7[2];
-        x8[3] = x7[3];
-        x8[4] = x7[4];
-        x8[5] = x7[5];
-        x8[6] = x7[6];
-        x8[7] = x7[7];
-
+        __m256i x8[32];
         btf_32_type1_avx2_new(
-            cospi_p60, cospi_p04, x7[8], x7[15], x8[8], x8[15], __rounding, cos_bit);
+            cospi_p60, cospi_p04, x7[0], x7[7], out[4 * stride], out[60 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p28, cospi_p36, x7[9], x7[14], x8[9], x8[14], __rounding, cos_bit);
+            cospi_p28, cospi_p36, x7[1], x7[6], out[36 * stride], out[28 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p44, cospi_p20, x7[10], x7[13], x8[10], x8[13], __rounding, cos_bit);
+            cospi_p44, cospi_p20, x7[2], x7[5], out[20 * stride], out[44 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p12, cospi_p52, x7[11], x7[12], x8[11], x8[12], __rounding, cos_bit);
-        x8[16] = _mm256_add_epi32(x7[16], x7[17]);
-        x8[17] = _mm256_sub_epi32(x7[16], x7[17]);
-        x8[18] = _mm256_sub_epi32(x7[19], x7[18]);
-        x8[19] = _mm256_add_epi32(x7[19], x7[18]);
-        x8[20] = _mm256_add_epi32(x7[20], x7[21]);
-        x8[21] = _mm256_sub_epi32(x7[20], x7[21]);
-        x8[22] = _mm256_sub_epi32(x7[23], x7[22]);
-        x8[23] = _mm256_add_epi32(x7[23], x7[22]);
-        x8[24] = _mm256_add_epi32(x7[24], x7[25]);
-        x8[25] = _mm256_sub_epi32(x7[24], x7[25]);
-        x8[26] = _mm256_sub_epi32(x7[27], x7[26]);
-        x8[27] = _mm256_add_epi32(x7[27], x7[26]);
-        x8[28] = _mm256_add_epi32(x7[28], x7[29]);
-        x8[29] = _mm256_sub_epi32(x7[28], x7[29]);
-        x8[30] = _mm256_sub_epi32(x7[31], x7[30]);
-        x8[31] = _mm256_add_epi32(x7[31], x7[30]);
-        x8[32] = x7[32];
+            cospi_p12, cospi_p52, x7[3], x7[4], out[52 * stride], out[12 * stride], __rounding, cos_bit);
+        x8[0]  = _mm256_add_epi32(x6[8], x7[8]);
+        x8[1]  = _mm256_sub_epi32(x6[8], x7[8]);
+        x8[2]  = _mm256_sub_epi32(x6[11], x7[9]);
+        x8[3]  = _mm256_add_epi32(x6[11], x7[9]);
+        x8[4]  = _mm256_add_epi32(x6[12], x7[10]);
+        x8[5]  = _mm256_sub_epi32(x6[12], x7[10]);
+        x8[6]  = _mm256_sub_epi32(x6[15], x7[11]);
+        x8[7]  = _mm256_add_epi32(x6[15], x7[11]);
+        x8[8]  = _mm256_add_epi32(x6[16], x7[12]);
+        x8[9]  = _mm256_sub_epi32(x6[16], x7[12]);
+        x8[10] = _mm256_sub_epi32(x6[19], x7[13]);
+        x8[11] = _mm256_add_epi32(x6[19], x7[13]);
+        x8[12] = _mm256_add_epi32(x6[20], x7[14]);
+        x8[13] = _mm256_sub_epi32(x6[20], x7[14]);
+        x8[14] = _mm256_sub_epi32(x6[23], x7[15]);
+        x8[15] = _mm256_add_epi32(x6[23], x7[15]);
         btf_32_type0_avx2_new(
-            cospi_m04, cospi_p60, x7[33], x7[62], x8[33], x8[62], __rounding, cos_bit);
+            cospi_m04, cospi_p60, x7[19], x7[47], x8[16], x8[31], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m60, cospi_m04, x7[34], x7[61], x8[34], x8[61], __rounding, cos_bit);
-        x8[35] = x7[35];
-        x8[36] = x7[36];
+            cospi_m60, cospi_m04, x7[20], x7[46], x8[17], x8[30], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m36, cospi_p28, x7[37], x7[58], x8[37], x8[58], __rounding, cos_bit);
+            cospi_m36, cospi_p28, x7[22], x7[43], x8[18], x8[29], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m28, cospi_m36, x7[38], x7[57], x8[38], x8[57], __rounding, cos_bit);
-        x8[39] = x7[39];
-        x8[40] = x7[40];
+            cospi_m28, cospi_m36, x7[23], x7[42], x8[19], x8[28], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m20, cospi_p44, x7[41], x7[54], x8[41], x8[54], __rounding, cos_bit);
+            cospi_m20, cospi_p44, x7[26], x7[39], x8[20], x8[27], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m44, cospi_m20, x7[42], x7[53], x8[42], x8[53], __rounding, cos_bit);
-        x8[43] = x7[43];
-        x8[44] = x7[44];
+            cospi_m44, cospi_m20, x7[27], x7[38], x8[21], x8[26], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m52, cospi_p12, x7[45], x7[50], x8[45], x8[50], __rounding, cos_bit);
+            cospi_m52, cospi_p12, x7[30], x7[35], x8[22], x8[25], __rounding, cos_bit);
         btf_32_type0_avx2_new(
-            cospi_m12, cospi_m52, x7[46], x7[49], x8[46], x8[49], __rounding, cos_bit);
-        x8[47] = x7[47];
-        x8[48] = x7[48];
-        x8[51] = x7[51];
-        x8[52] = x7[52];
-        x8[55] = x7[55];
-        x8[56] = x7[56];
-        x8[59] = x7[59];
-        x8[60] = x7[60];
-        x8[63] = x7[63];
+            cospi_m12, cospi_m52, x7[31], x7[34], x8[23], x8[24], __rounding, cos_bit);
 
         // stage 9
-        __m256i x9[64];
-        x9[0]  = x8[0];
-        x9[1]  = x8[1];
-        x9[2]  = x8[2];
-        x9[3]  = x8[3];
-        x9[4]  = x8[4];
-        x9[5]  = x8[5];
-        x9[6]  = x8[6];
-        x9[7]  = x8[7];
-        x9[8]  = x8[8];
-        x9[9]  = x8[9];
-        x9[10] = x8[10];
-        x9[11] = x8[11];
-        x9[12] = x8[12];
-        x9[13] = x8[13];
-        x9[14] = x8[14];
-        x9[15] = x8[15];
+        __m256i x9[32];
         btf_32_type1_avx2_new(
-            cospi_p62, cospi_p02, x8[16], x8[31], x9[16], x9[31], __rounding, cos_bit);
+            cospi_p62, cospi_p02, x8[0], x8[15], out[2 * stride], out[62 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p30, cospi_p34, x8[17], x8[30], x9[17], x9[30], __rounding, cos_bit);
+            cospi_p30, cospi_p34, x8[1], x8[14], out[34 * stride], out[30 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p46, cospi_p18, x8[18], x8[29], x9[18], x9[29], __rounding, cos_bit);
+            cospi_p46, cospi_p18, x8[2], x8[13], out[18 * stride], out[46 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p14, cospi_p50, x8[19], x8[28], x9[19], x9[28], __rounding, cos_bit);
+            cospi_p14, cospi_p50, x8[3], x8[12], out[50 * stride], out[14 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p54, cospi_p10, x8[20], x8[27], x9[20], x9[27], __rounding, cos_bit);
+            cospi_p54, cospi_p10, x8[4], x8[11], out[10 * stride], out[54 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p22, cospi_p42, x8[21], x8[26], x9[21], x9[26], __rounding, cos_bit);
+            cospi_p22, cospi_p42, x8[5], x8[10], out[42 * stride], out[22 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p38, cospi_p26, x8[22], x8[25], x9[22], x9[25], __rounding, cos_bit);
+            cospi_p38, cospi_p26, x8[6], x8[9], out[26 * stride], out[38 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p06, cospi_p58, x8[23], x8[24], x9[23], x9[24], __rounding, cos_bit);
-        x9[32] = _mm256_add_epi32(x8[32], x8[33]);
-        x9[33] = _mm256_sub_epi32(x8[32], x8[33]);
-        x9[34] = _mm256_sub_epi32(x8[35], x8[34]);
-        x9[35] = _mm256_add_epi32(x8[35], x8[34]);
-        x9[36] = _mm256_add_epi32(x8[36], x8[37]);
-        x9[37] = _mm256_sub_epi32(x8[36], x8[37]);
-        x9[38] = _mm256_sub_epi32(x8[39], x8[38]);
-        x9[39] = _mm256_add_epi32(x8[39], x8[38]);
-        x9[40] = _mm256_add_epi32(x8[40], x8[41]);
-        x9[41] = _mm256_sub_epi32(x8[40], x8[41]);
-        x9[42] = _mm256_sub_epi32(x8[43], x8[42]);
-        x9[43] = _mm256_add_epi32(x8[43], x8[42]);
-        x9[44] = _mm256_add_epi32(x8[44], x8[45]);
-        x9[45] = _mm256_sub_epi32(x8[44], x8[45]);
-        x9[46] = _mm256_sub_epi32(x8[47], x8[46]);
-        x9[47] = _mm256_add_epi32(x8[47], x8[46]);
-        x9[48] = _mm256_add_epi32(x8[48], x8[49]);
-        x9[49] = _mm256_sub_epi32(x8[48], x8[49]);
-        x9[50] = _mm256_sub_epi32(x8[51], x8[50]);
-        x9[51] = _mm256_add_epi32(x8[51], x8[50]);
-        x9[52] = _mm256_add_epi32(x8[52], x8[53]);
-        x9[53] = _mm256_sub_epi32(x8[52], x8[53]);
-        x9[54] = _mm256_sub_epi32(x8[55], x8[54]);
-        x9[55] = _mm256_add_epi32(x8[55], x8[54]);
-        x9[56] = _mm256_add_epi32(x8[56], x8[57]);
-        x9[57] = _mm256_sub_epi32(x8[56], x8[57]);
-        x9[58] = _mm256_sub_epi32(x8[59], x8[58]);
-        x9[59] = _mm256_add_epi32(x8[59], x8[58]);
-        x9[60] = _mm256_add_epi32(x8[60], x8[61]);
-        x9[61] = _mm256_sub_epi32(x8[60], x8[61]);
-        x9[62] = _mm256_sub_epi32(x8[63], x8[62]);
-        x9[63] = _mm256_add_epi32(x8[63], x8[62]);
+            cospi_p06, cospi_p58, x8[7], x8[8], out[58 * stride], out[6 * stride], __rounding, cos_bit);
+        x9[0]  = _mm256_add_epi32(x7[16], x8[16]);
+        x9[1]  = _mm256_sub_epi32(x7[16], x8[16]);
+        x9[2]  = _mm256_sub_epi32(x7[17], x8[17]);
+        x9[3]  = _mm256_add_epi32(x7[17], x8[17]);
+        x9[4]  = _mm256_add_epi32(x7[18], x8[18]);
+        x9[5]  = _mm256_sub_epi32(x7[18], x8[18]);
+        x9[6]  = _mm256_sub_epi32(x7[21], x8[19]);
+        x9[7]  = _mm256_add_epi32(x7[21], x8[19]);
+        x9[8]  = _mm256_add_epi32(x7[24], x8[20]);
+        x9[9]  = _mm256_sub_epi32(x7[24], x8[20]);
+        x9[10] = _mm256_sub_epi32(x7[25], x8[21]);
+        x9[11] = _mm256_add_epi32(x7[25], x8[21]);
+        x9[12] = _mm256_add_epi32(x7[28], x8[22]);
+        x9[13] = _mm256_sub_epi32(x7[28], x8[22]);
+        x9[14] = _mm256_sub_epi32(x7[29], x8[23]);
+        x9[15] = _mm256_add_epi32(x7[29], x8[23]);
+        x9[16] = _mm256_add_epi32(x7[32], x8[24]);
+        x9[17] = _mm256_sub_epi32(x7[32], x8[24]);
+        x9[18] = _mm256_sub_epi32(x7[33], x8[25]);
+        x9[19] = _mm256_add_epi32(x7[33], x8[25]);
+        x9[20] = _mm256_add_epi32(x7[36], x8[26]);
+        x9[21] = _mm256_sub_epi32(x7[36], x8[26]);
+        x9[22] = _mm256_sub_epi32(x7[37], x8[27]);
+        x9[23] = _mm256_add_epi32(x7[37], x8[27]);
+        x9[24] = _mm256_add_epi32(x7[40], x8[28]);
+        x9[25] = _mm256_sub_epi32(x7[40], x8[28]);
+        x9[26] = _mm256_sub_epi32(x7[41], x8[29]);
+        x9[27] = _mm256_add_epi32(x7[41], x8[29]);
+        x9[28] = _mm256_add_epi32(x7[44], x8[30]);
+        x9[29] = _mm256_sub_epi32(x7[44], x8[30]);
+        x9[30] = _mm256_sub_epi32(x7[45], x8[31]);
+        x9[31] = _mm256_add_epi32(x7[45], x8[31]);
 
         // stage 10
-        __m256i x10[64];
-        out[0 * stride]  = x9[0];
-        out[32 * stride] = x9[1];
-        out[16 * stride] = x9[2];
-        out[48 * stride] = x9[3];
-        out[8 * stride]  = x9[4];
-        out[40 * stride] = x9[5];
-        out[24 * stride] = x9[6];
-        out[56 * stride] = x9[7];
-        out[4 * stride]  = x9[8];
-        out[36 * stride] = x9[9];
-        out[20 * stride] = x9[10];
-        out[52 * stride] = x9[11];
-        out[12 * stride] = x9[12];
-        out[44 * stride] = x9[13];
-        out[28 * stride] = x9[14];
-        out[60 * stride] = x9[15];
-        out[2 * stride]  = x9[16];
-        out[34 * stride] = x9[17];
-        out[18 * stride] = x9[18];
-        out[50 * stride] = x9[19];
-        out[10 * stride] = x9[20];
-        out[42 * stride] = x9[21];
-        out[26 * stride] = x9[22];
-        out[58 * stride] = x9[23];
-        out[6 * stride]  = x9[24];
-        out[38 * stride] = x9[25];
-        out[22 * stride] = x9[26];
-        out[54 * stride] = x9[27];
-        out[14 * stride] = x9[28];
-        out[46 * stride] = x9[29];
-        out[30 * stride] = x9[30];
-        out[62 * stride] = x9[31];
         btf_32_type1_avx2_new(
-            cospi_p63, cospi_p01, x9[32], x9[63], x10[32], x10[63], __rounding, cos_bit);
+            cospi_p63, cospi_p01, x9[0], x9[31], out[1 * stride], out[63 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p31, cospi_p33, x9[33], x9[62], x10[33], x10[62], __rounding, cos_bit);
+            cospi_p31, cospi_p33, x9[1], x9[30], out[33 * stride], out[31 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p47, cospi_p17, x9[34], x9[61], x10[34], x10[61], __rounding, cos_bit);
+            cospi_p47, cospi_p17, x9[2], x9[29], out[17 * stride], out[47 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p15, cospi_p49, x9[35], x9[60], x10[35], x10[60], __rounding, cos_bit);
+            cospi_p15, cospi_p49, x9[3], x9[28], out[49 * stride], out[15 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p55, cospi_p09, x9[36], x9[59], x10[36], x10[59], __rounding, cos_bit);
+            cospi_p55, cospi_p09, x9[4], x9[27], out[9 * stride], out[55 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p23, cospi_p41, x9[37], x9[58], x10[37], x10[58], __rounding, cos_bit);
+            cospi_p23, cospi_p41, x9[5], x9[26], out[41 * stride], out[23 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p39, cospi_p25, x9[38], x9[57], x10[38], x10[57], __rounding, cos_bit);
+            cospi_p39, cospi_p25, x9[6], x9[25], out[25 * stride], out[39 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p07, cospi_p57, x9[39], x9[56], x10[39], x10[56], __rounding, cos_bit);
+            cospi_p07, cospi_p57, x9[7], x9[24], out[57 * stride], out[7 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p59, cospi_p05, x9[40], x9[55], x10[40], x10[55], __rounding, cos_bit);
+            cospi_p59, cospi_p05, x9[8], x9[23], out[5 * stride], out[59 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p27, cospi_p37, x9[41], x9[54], x10[41], x10[54], __rounding, cos_bit);
+            cospi_p27, cospi_p37, x9[9], x9[22], out[37 * stride], out[27 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p43, cospi_p21, x9[42], x9[53], x10[42], x10[53], __rounding, cos_bit);
+            cospi_p43, cospi_p21, x9[10], x9[21], out[21 * stride], out[43 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p11, cospi_p53, x9[43], x9[52], x10[43], x10[52], __rounding, cos_bit);
+            cospi_p11, cospi_p53, x9[11], x9[20], out[53 * stride], out[11 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p51, cospi_p13, x9[44], x9[51], x10[44], x10[51], __rounding, cos_bit);
+            cospi_p51, cospi_p13, x9[12], x9[19], out[13 * stride], out[51 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p19, cospi_p45, x9[45], x9[50], x10[45], x10[50], __rounding, cos_bit);
+            cospi_p19, cospi_p45, x9[13], x9[18], out[45 * stride], out[19 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p35, cospi_p29, x9[46], x9[49], x10[46], x10[49], __rounding, cos_bit);
+            cospi_p35, cospi_p29, x9[14], x9[17], out[29 * stride], out[35 * stride], __rounding, cos_bit);
         btf_32_type1_avx2_new(
-            cospi_p03, cospi_p61, x9[47], x9[48], x10[47], x10[48], __rounding, cos_bit);
-
-        // stage 11
-        out[1 * stride]  = x10[32];
-        out[3 * stride]  = x10[48];
-        out[5 * stride]  = x10[40];
-        out[7 * stride]  = x10[56];
-        out[9 * stride]  = x10[36];
-        out[11 * stride] = x10[52];
-        out[13 * stride] = x10[44];
-        out[15 * stride] = x10[60];
-        out[17 * stride] = x10[34];
-        out[19 * stride] = x10[50];
-        out[21 * stride] = x10[42];
-        out[23 * stride] = x10[58];
-        out[25 * stride] = x10[38];
-        out[27 * stride] = x10[54];
-        out[29 * stride] = x10[46];
-        out[31 * stride] = x10[62];
-        out[33 * stride] = x10[33];
-        out[35 * stride] = x10[49];
-        out[37 * stride] = x10[41];
-        out[39 * stride] = x10[57];
-        out[41 * stride] = x10[37];
-        out[43 * stride] = x10[53];
-        out[45 * stride] = x10[45];
-        out[47 * stride] = x10[61];
-        out[49 * stride] = x10[35];
-        out[51 * stride] = x10[51];
-        out[53 * stride] = x10[43];
-        out[55 * stride] = x10[59];
-        out[57 * stride] = x10[39];
-        out[59 * stride] = x10[55];
-        out[61 * stride] = x10[47];
-        out[63 * stride] = x10[63];
+            cospi_p03, cospi_p61, x9[15], x9[16], out[61 * stride], out[3 * stride], __rounding, cos_bit);
     }
 }
 

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -107,7 +107,7 @@ static const InvSqrTxfmFuncPair inv_txfm_c_avx2_func_pairs[TX_64X64 + 1] = {
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_8x8, avx2, all_txtype_imp),
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_16x16, avx2, all_txtype_imp),
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_32x32, avx2, is_tx_type_imp_32x32_avx2),
-    EMPTY_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64, avx2, is_tx_type_imp_64x64_sse4),
 };
 
 static const InvSqrTxfmFuncPair inv_txfm_c_sse4_1_func_pairs[TX_64X64 + 1] = {

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -107,7 +107,7 @@ static const InvSqrTxfmFuncPair inv_txfm_c_avx2_func_pairs[TX_64X64 + 1] = {
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_8x8, avx2, all_txtype_imp),
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_16x16, avx2, all_txtype_imp),
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_32x32, avx2, is_tx_type_imp_32x32_avx2),
-    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64, avx2, is_tx_type_imp_64x64_sse4),
+    SQR_FUNC_PAIRS(svt_av1_inv_txfm2d_add_64x64, avx2, is_tx_type_imp_64x64_sse4),
 };
 
 static const InvSqrTxfmFuncPair inv_txfm_c_sse4_1_func_pairs[TX_64X64 + 1] = {
@@ -115,7 +115,7 @@ static const InvSqrTxfmFuncPair inv_txfm_c_sse4_1_func_pairs[TX_64X64 + 1] = {
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_8x8, sse4_1, dct_adst_combine_imp),
     SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_16x16, sse4_1, dct_adst_combine_imp),
     EMPTY_FUNC_PAIRS(eb_av1_inv_txfm2d_add_32x32),
-    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64, sse4_1, is_tx_type_imp_64x64_sse4),
+    SQR_FUNC_PAIRS(svt_av1_inv_txfm2d_add_64x64, sse4_1, is_tx_type_imp_64x64_sse4),
 };
 
 // from TX_4X8 to TX_SIZES_ALL
@@ -394,7 +394,7 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
             eb_av1_inv_txfm2d_add_8x8_c,
             eb_av1_inv_txfm2d_add_16x16_c,
             eb_av1_inv_txfm2d_add_32x32_c,
-            eb_av1_inv_txfm2d_add_64x64_c};
+            svt_av1_inv_txfm2d_add_64x64_c};
         const LowbdInvRectTxfmRefFunc lowbd_rect_ref_funcs[TX_SIZES_ALL] = {
             nullptr,
             nullptr,

--- a/test/InversetransformTests.cc
+++ b/test/InversetransformTests.cc
@@ -19,8 +19,8 @@
 
 typedef void (*av1_inv_txfm_highbd_func)(const int32_t *coeff, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, int32_t bd);
 typedef void (*av1_inv_txfm2d_highbd_rect_func)(const int32_t *input, uint16_t *output_r, int32_t stride_r, uint16_t *output_w, int32_t stride_w, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-av1_inv_txfm_highbd_func av1_inv_txfm_highbd_func_ptr_array_base[3] = { eb_av1_inv_txfm2d_add_16x16_avx2 , eb_av1_inv_txfm2d_add_32x32_avx2 , eb_av1_inv_txfm2d_add_64x64_sse4_1 };
-av1_inv_txfm_highbd_func av1_inv_txfm_highbd_func_ptr_array_opt[3] = { eb_av1_inv_txfm2d_add_16x16_avx512, eb_av1_inv_txfm2d_add_32x32_avx512 , eb_av1_inv_txfm2d_add_64x64_avx512 };
+av1_inv_txfm_highbd_func av1_inv_txfm_highbd_func_ptr_array_base[3] = { eb_av1_inv_txfm2d_add_16x16_avx2 , eb_av1_inv_txfm2d_add_32x32_avx2 , svt_av1_inv_txfm2d_add_64x64_sse4_1 };
+av1_inv_txfm_highbd_func av1_inv_txfm_highbd_func_ptr_array_opt[3] = { eb_av1_inv_txfm2d_add_16x16_avx512, eb_av1_inv_txfm2d_add_32x32_avx512 , svt_av1_inv_txfm2d_add_64x64_avx512 };
 av1_inv_txfm2d_highbd_rect_func av1_inv_txfm_highbd_rect_func_ptr_array_base[6] = { eb_av1_inv_txfm2d_add_32x16_c , eb_av1_inv_txfm2d_add_16x32_c , eb_av1_inv_txfm2d_add_16x64_c , eb_av1_inv_txfm2d_add_32x64_c , eb_av1_inv_txfm2d_add_64x32_c , eb_av1_inv_txfm2d_add_64x16_c };
 av1_inv_txfm2d_highbd_rect_func av1_inv_txfm_highbd_rect_func_ptr_array_opt[6] = { eb_av1_inv_txfm2d_add_32x16_avx512 , eb_av1_inv_txfm2d_add_16x32_avx512 , eb_av1_inv_txfm2d_add_16x64_avx512 , eb_av1_inv_txfm2d_add_32x64_avx512 , eb_av1_inv_txfm2d_add_64x32_avx512 , eb_av1_inv_txfm2d_add_64x16_avx512 };
 int txsize_16[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 11, 12, 13, 14, 15};

--- a/test/ResidualTest.cc
+++ b/test/ResidualTest.cc
@@ -278,7 +278,7 @@ class ResidualKernelTest
         }
     }
 
-    void run_16bit_test() {
+    void run_16bit_test_sse2() {
         prepare_16bit_data();
 
         svt_residual_kernel16bit_sse2_intrin(input16bit_,
@@ -289,6 +289,31 @@ class ResidualKernelTest
                                              residual_stride_,
                                              area_width_,
                                              area_height_);
+        svt_residual_kernel16bit_c(input16bit_,
+                                   input_stride_,
+                                   pred16bit_,
+                                   pred_stride_,
+                                   residual2_,
+                                   residual_stride_,
+                                   area_width_,
+                                   area_height_);
+
+        check_residuals(area_width_, area_height_);
+
+
+    }
+
+    void run_16bit_test_avx2() {
+        prepare_16bit_data();
+
+        svt_residual_kernel16bit_avx2(input16bit_,
+                                      input_stride_,
+                                      pred16bit_,
+                                      pred_stride_,
+                                      residual1_,
+                                      residual_stride_,
+                                      area_width_,
+                                      area_height_);
         svt_residual_kernel16bit_c(input16bit_,
                                    input_stride_,
                                    pred16bit_,
@@ -313,7 +338,8 @@ TEST_P(ResidualKernelTest, DISABLED_SpeedTest) {
 };
 
 TEST_P(ResidualKernelTest, 16bitMatchTest) {
-    run_16bit_test();
+    run_16bit_test_sse2();
+    run_16bit_test_avx2();
 };
 
 INSTANTIATE_TEST_CASE_P(ResidualUtil, ResidualKernelTest,


### PR DESCRIPTION
# Description

1. Reduce number of memcopy in fdct8x8_avx2, fdct16x16_avx2, fdct32_new_avx2, fdct64_new_avx2
2. Implementation of missing cases for some invers transformation avx2 
    dct_dct/dct_adst/adst_dct/adst_adst in inv_txfm2d_add_{8x8/16x16}_avx2
3. Add eb_av1_inv_txfm2d_add_64x64_avx2()
4. Implementation of svt_residual_kernel16bit_avx2()

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
