### PR TITLE
safestrlib: only declare the safestrlib functions if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,19 +233,15 @@ macro(ASM_COMPILE_TO_TARGET target)
     endif()
 endmacro()
 
-file(WRITE ${CMAKE_BINARY_DIR}/conftest.c "
-#include <string.h>
-#include <stdint.h>
-int main() {
-    return (uintptr_t)strnlen_s;
-}
-")
-
-try_compile(HAVE_STRNLEN_S ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/conftest.c)
-
-add_definitions(-DHAVE_STRNLEN_S=1)
-
 add_subdirectory(third_party/safestringlib)
+
+set_property(DIRECTORY .
+    APPEND
+    PROPERTY COMPILE_DEFINITIONS
+        $<$<BOOL:${HAVE_STRCPY_S}>:HAVE_STRCPY_S=1>
+        $<$<BOOL:${HAVE_STRNCPY_S}>:HAVE_STRNCPY_S=1>
+        $<$<BOOL:${HAVE_STRNLEN_S}>:HAVE_STRNLEN_S=1>
+        $<$<BOOL:${WIN32}>:_WIN32_WINNT=0x0601>)
 
 # Add Subdirectories
 add_subdirectory(Source/Lib/Common)

--- a/third_party/safestringlib/CMakeLists.txt
+++ b/third_party/safestringlib/CMakeLists.txt
@@ -1,32 +1,54 @@
-if(WIN32)
-    if(HAVE_STRNLEN_S)
-        file(WRITE dummy.c "")
-        add_library(safestringlib OBJECT dummy.c)
-    else()
-        add_library(safestringlib OBJECT
-            safeclib_private.h
-            safe_lib.h
-            safe_types.h
-            safe_lib_errno.h
-            safe_str_lib.h
-            safe_str_constraint.h
-            strnlen_s.c
-            safe_str_constraint.c
-            ignore_handler_s.c)
-    endif()
-else()
-    add_library(safestringlib OBJECT
-        safe_lib_errno.h
-        safe_str_lib.h
+file(WRITE ${CMAKE_BINARY_DIR}/conftest.c [=[
+#include <string.h>
+#include <stdint.h>
+int main() {
+    return (uintptr_t)strnlen_s;
+}
+]=])
+try_compile(HAVE_STRNLEN_S ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/conftest.c)
+
+file(WRITE ${CMAKE_BINARY_DIR}/conftest.c [=[
+#include <string.h>
+#include <stdint.h>
+int main() {
+    return (uintptr_t)strcpy_s;
+}
+]=])
+try_compile(HAVE_STRNCPY_S ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/conftest.c)
+
+file(WRITE ${CMAKE_BINARY_DIR}/conftest.c [=[
+#include <string.h>
+#include <stdint.h>
+int main() {
+    return (uintptr_t)strcpy_s;
+}
+]=])
+try_compile(HAVE_STRCPY_S ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/conftest.c)
+
+file(WRITE ${CMAKE_BINARY_DIR}/dummy.c "")
+add_library(safestringlib OBJECT ${CMAKE_BINARY_DIR}/dummy.c)
+if(NOT HAVE_STRCPY_S OR NOT HAVE_STRNCPY_S OR NOT HAVE_STRNLEN_S)
+    target_sources(safestringlib PRIVATE
+        safeclib_private.h
         safe_lib.h
         safe_types.h
-        safeclib_private.h
-        strcpy_s.c
+        safe_lib_errno.h
+        safe_str_lib.h
         safe_str_constraint.h
         safe_str_constraint.c
         ignore_handler_s.c
-        strncpy_s.c
-        strnlen_s.c)
+        $<$<NOT:$<BOOL:${HAVE_STRCPY_S}>>:strcpy_s.c>
+        $<$<NOT:$<BOOL:${HAVE_STRNCPY_S}>>:strncpy_s.c>
+        $<$<NOT:$<BOOL:${HAVE_STRNLEN_S}>>:strnlen_s.c>)
 endif()
 
-target_compile_definitions(safestringlib PUBLIC SAFECLIB_STR_NULL_SLACK=1)
+target_compile_definitions(safestringlib PUBLIC
+    SAFECLIB_STR_NULL_SLACK=1
+    $<$<BOOL:${HAVE_STRCPY_S}>:HAVE_STRCPY_S=1>
+    $<$<BOOL:${HAVE_STRNCPY_S}>:HAVE_STRNCPY_S=1>
+    $<$<BOOL:${HAVE_STRNLEN_S}>:HAVE_STRNLEN_S=1>
+    $<$<BOOL:${WIN32}>:_WIN32_WINNT=0x0601>)
+
+set(HAVE_STRCPY_S PARENT_SCOPE)
+set(HAVE_STRNCPY_S PARENT_SCOPE)
+set(HAVE_STRNLEN_S PARENT_SCOPE)

--- a/third_party/safestringlib/safe_str_lib.h
+++ b/third_party/safestringlib/safe_str_lib.h
@@ -55,6 +55,8 @@
 /* set string constraint handler */
 extern constraint_handler_t set_str_constraint_handler_s(constraint_handler_t handler);
 
+#if 0
+
 /* string compare */
 extern errno_t strcasecmp_s(const char *dest, rsize_t dmax, const char *src, int *indicator);
 
@@ -71,8 +73,14 @@ extern errno_t strcmp_s(const char *dest, rsize_t dmax, const char *src, int *in
 /* fixed field string compare */
 extern errno_t strcmpfld_s(const char *dest, rsize_t dmax, const char *src, int *indicator);
 
+#endif
+
+#ifndef HAVE_STRCPY_S
 /* string copy */
 extern errno_t strcpy_s(char *dest, rsize_t dmax, const char *src);
+#endif
+
+#if 0
 
 /* string copy */
 extern char *stpcpy_s(char *dest, rsize_t dmax, const char *src, errno_t *err);
@@ -135,11 +143,19 @@ extern errno_t strljustify_s(char *dest, rsize_t dmax);
 /* fitted string concatenate */
 extern errno_t strncat_s(char *dest, rsize_t dmax, const char *src, rsize_t slen);
 
+#endif
+
+#ifndef HAVE_STRNCPY_S
 /* fitted string copy */
 extern errno_t strncpy_s(char *dest, rsize_t dmax, const char *src, rsize_t slen);
+#endif
 
+#ifndef HAVE_STRNLEN_S
 /* string length */
 extern rsize_t strnlen_s(const char *s, rsize_t smax);
+#endif
+
+#if 0
 
 /* string terminate */
 extern rsize_t strnterminate_s(char *s, rsize_t smax);
@@ -193,5 +209,6 @@ extern errno_t wcsncpy_s(wchar_t *dest, rsize_t dmax, const wchar_t *src, rsize_
 
 /* wide string length */
 extern rsize_t wcsnlen_s(const wchar_t *dest, rsize_t dmax);
+#endif
 
 #endif /* __SAFE_STR_LIB_H__ */


### PR DESCRIPTION
# Description

didn't realize I was missing some code

The rest is for making sure that the unused functions are not declared at all so they do not conflict with the regular functions that already exist

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
