### PR TITLE
Actions: Use the same brew commands for ga macOS and always run cmake for macos-vectors

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,9 +36,10 @@ jobs:
         run: |
           set -x
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          brew update
-          brew upgrade -f
-          brew install -f yasm ccache cmake
+          {
+            brew update || brew update-reset
+            brew upgrade yasm ccache cmake ninja || brew install -q yasm ccache cmake ninja
+          } || brew update-reset
           printf '%s\n' \
             "PATH=/usr/local/opt/ccache/libexec:$PATH" \
             "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
@@ -113,9 +114,8 @@ jobs:
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
           {
-            brew update &&
-            brew upgrade &&
-            brew install -q yasm ccache cmake ninja
+            brew update || brew update-reset
+            brew upgrade yasm ccache cmake ninja || brew install -q yasm ccache cmake ninja
           } || brew update-reset
           printf '%s\n' \
             "PATH=/usr/local/opt/ccache/libexec:$PATH" \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -149,7 +149,7 @@ jobs:
           path: Bin/Release
       - name: Run unit tests
         run: |
-          [ -d  macos-vectors ] || cmake -S "$GITHUB_WORKSPACE" -B macos-vectors -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON -DBUILD_APPS=OFF
+          cmake -S "$GITHUB_WORKSPACE" -B macos-vectors -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON -DBUILD_APPS=OFF
           cmake --build macos-vectors --config Release --target TestVectors
           chmod +x ./Bin/Release/SvtAv1UnitTests
           parallel -u -j 4 GTEST_SHARD_INDEX={} ./Bin/Release/SvtAv1UnitTests ::: $(seq 0 $((GTEST_TOTAL_SHARDS - 1)))


### PR DESCRIPTION
# Description

I am hoping that the first commit will solve the issue whenever cmake updates, however, it is hard to reproduce and test since I have only seen macOS store cmake in variable location

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
