### PR TITLE
run_cpuid: Use int instead of uint32_t since that's what it actualy uses

### DIFF
--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -66,11 +66,11 @@ int64_t svt_av1_block_error_c(const TranLow *coeff, const TranLow *dqcoeff,
  **************************************/
 #ifdef ARCH_X86_64
 // Helper Functions
-static INLINE void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd) {
+static INLINE void run_cpuid(int eax, int ecx, int* abcd) {
 #ifdef _WIN32
     __cpuidex(abcd, eax, ecx);
 #else
-    uint32_t ebx = 0, edx = 0;
+    int ebx = 0, edx = 0;
 #if defined(__i386__) && defined(__PIC__)
     /* in case of PIC under 32-bit EBX cannot be clobbered */
     __asm__("movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi"
@@ -100,9 +100,9 @@ static INLINE int32_t check_xcr0_ymm() {
 }
 
 static int32_t check_4thgen_intel_core_features() {
-    uint32_t abcd[4];
-    uint32_t fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
-    uint32_t avx2_bmi12_mask        = (1 << 5) | (1 << 3) | (1 << 8);
+    int       abcd[4];
+    const int fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+    const int avx2_bmi12_mask        = (1 << 5) | (1 << 3) | (1 << 8);
 
     /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
     CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
@@ -136,7 +136,7 @@ static INLINE int check_xcr0_zmm() {
 }
 
 static int32_t can_use_intel_avx512() {
-    uint32_t abcd[4];
+    int abcd[4];
 
     /*  CPUID.(EAX=07H, ECX=0):EBX[bit 16]==1 AVX512F
     CPUID.(EAX=07H, ECX=0):EBX[bit 17] AVX512DQ
@@ -144,11 +144,11 @@ static int32_t can_use_intel_avx512() {
     CPUID.(EAX=07H, ECX=0):EBX[bit 30] AVX512BW
     CPUID.(EAX=07H, ECX=0):EBX[bit 31] AVX512VL */
 
-    uint32_t avx512_ebx_mask = (1u << 16) // AVX-512F
-                             | (1u << 17) // AVX-512DQ
-                             | (1u << 28) // AVX-512CD
-                             | (1u << 30) // AVX-512BW
-                             | (1u << 31); // AVX-512VL
+    const int avx512_ebx_mask = (1u << 16) // AVX-512F
+        | (1u << 17) // AVX-512DQ
+        | (1u << 28) // AVX-512CD
+        | (1u << 30) // AVX-512BW
+        | (1u << 31); // AVX-512VL
 
     if (!check_4thgen_intel_core_features()) return 0;
 


### PR DESCRIPTION

# Description

Solves a warning when using a mingw-w64 gcc compiler since `__cpuidex` is
```c
void __cpuidex(
   int cpuInfo[4],
   int function_id,
   int subfunction_id
);
```
and takes an array of ints instead of unsigned.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
