### PR TITLE
Add svt_ prefix to functions borrowed from libaom to avoid issues whe…

### DIFF
--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -4455,7 +4455,7 @@ static int get_cqp_kf_boost_from_r0(double r0, int frames_to_key, EbInputResolut
     return boost;
 }
 
-double av1_get_gfu_boost_projection_factor(double min_factor, double max_factor,
+double svt_av1_get_gfu_boost_projection_factor(double min_factor, double max_factor,
                                            int frame_count) {
   double factor = sqrt((double)frame_count);
   factor = AOMMIN(factor, max_factor);
@@ -4468,12 +4468,12 @@ double av1_get_gfu_boost_projection_factor(double min_factor, double max_factor,
 //#define MIN_GFUBOOST_FACTOR 4.0
 static int get_gfu_boost_from_r0_lap(double min_factor, double max_factor,
                                      double r0, int frames_to_key) {
-  double factor = av1_get_gfu_boost_projection_factor(min_factor, max_factor, frames_to_key);
+  double factor = svt_av1_get_gfu_boost_projection_factor(min_factor, max_factor, frames_to_key);
   const int boost = (int)rint(factor / r0);
   return boost;
 }
 
-int combine_prior_with_tpl_boost(int prior_boost, int tpl_boost,
+int svt_combine_prior_with_tpl_boost(int prior_boost, int tpl_boost,
     int frames_to_key) {
     double factor = sqrt((double)frames_to_key);
     factor = AOMMIN(factor, 12.0);

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.h
@@ -284,7 +284,7 @@ typedef struct RateControlLayerContext {
 double eb_av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
 int svt_av1_rc_get_default_min_gf_interval(int width, int height, double framerate);
 int svt_av1_rc_get_default_max_gf_interval(double framerate, int min_gf_interval);
-double av1_get_gfu_boost_projection_factor(double min_factor, double max_factor, int frame_count);
+double svt_av1_get_gfu_boost_projection_factor(double min_factor, double max_factor, int frame_count);
 
 EbErrorType rate_control_context_ctor(EbThreadContext *  thread_context_ptr,
                                       const EbEncHandle *enc_handle_ptr);

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -522,10 +522,10 @@ static int get_projected_gfu_boost(const RATE_CONTROL *rc, int gfu_boost,
 
   double min_boost_factor = sqrt(rc->baseline_gf_interval);
   // Get the current tpl factor (number of frames = frames_to_project).
-  double tpl_factor = av1_get_gfu_boost_projection_factor(
+  double tpl_factor = svt_av1_get_gfu_boost_projection_factor(
       min_boost_factor, MAX_GFUBOOST_FACTOR, frames_to_project);
   // Get the tpl factor when number of frames = num_stats_used_for_prior_boost.
-  double tpl_factor_num_stats = av1_get_gfu_boost_projection_factor(
+  double tpl_factor_num_stats = svt_av1_get_gfu_boost_projection_factor(
       min_boost_factor, MAX_GFUBOOST_FACTOR, num_stats_used_for_gfu_boost);
   int projected_gfu_boost =
       (int)rint((tpl_factor * gfu_boost) / tpl_factor_num_stats);


### PR DESCRIPTION
…n statically linking SVT alongside libaom

# Description

When attempting to statically link libaom alongside SVT (such as with a static build of libavif), these symbols are multiply defined. This is simply adding to the pattern hinted at in EbRateControlProcess.h where another function was prefixed in a similar way. 

This discovery is a side-effect of my (ongoing) review of adding SVT-AV1 support to libavif:

https://github.com/AOMediaCodec/libavif/pull/369