### PR TITLE
Delete unused svt_combine_prior_with_tpl_boost()

### DIFF
--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -4473,16 +4473,6 @@ static int get_gfu_boost_from_r0_lap(double min_factor, double max_factor,
   return boost;
 }
 
-int svt_combine_prior_with_tpl_boost(int prior_boost, int tpl_boost,
-    int frames_to_key) {
-    double factor = sqrt((double)frames_to_key);
-    factor = AOMMIN(factor, 12.0);
-    factor = AOMMAX(factor, 4.0);
-    factor -= 4.0;
-    int boost = (int)((factor * prior_boost + (8.0 - factor) * tpl_boost) / 8.0);
-    return boost;
-}
-
 int svt_av1_get_deltaq_offset(AomBitDepth bit_depth, int qindex, double beta) {
     assert(beta > 0.0);
     int q = eb_av1_dc_quant_qtx(qindex, 0, bit_depth);


### PR DESCRIPTION
Delete the unused function svt_combine_prior_with_tpl_boost().

Originally named combine_prior_with_tpl_boost, it was just renamed in
commit e5d07c3b3cf73c6c9053a7c1ac3356867c732152. I found that it is not
used and can be deleted.

# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
