### PR TITLE
2pass: initial data rate control options

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2974,6 +2974,13 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->encoder_color_format = EB_YUV420;
     config_ptr->mrp_level = DEFAULT;
 
+    // Two pass data rate control options
+    config_ptr->vbr_bias_pct = 50;
+    config_ptr->vbr_min_section_pct = 0;
+    config_ptr->vbr_max_section_pct = 2000;
+    config_ptr->under_shoot_pct = 25;
+    config_ptr->over_shoot_pct = 25;
+
     // Bitstream options
     //config_ptr->codeVpsSpsPps = 0;
     //config_ptr->codeEosNal = 0;


### PR DESCRIPTION
# Description
Some initial settings are not set, realated to the 2-pass encoding.
Without these settings, the encoder creates a small (low bitrate) bitstream, not the configured one.

# Issue
Using this command line, the latest git version (after #1524) makes an 1/3 size (bitrate) output file (1657589 vs 504457 bytes)
ffmpeg -i desperado.mp4 -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp.exe -i stdin -n 500 --pass 1 -w 1920 -h 1080 --preset 8 --irefresh-type 2 --rc 1 --tbr 800 -b desp_800k.ivf
ffmpeg -i desperado.mp4 -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp.exe -i stdin -n 500 --pass 2 -w 1920 -h 1080 --preset 8 --irefresh-type 2 --rc 1 --tbr 800 -b desp_800k.ivf

And all (release and git) versions from v0.8.5 makes incorrect (small, low bitrate) bitstream using the library part only, due to those missing lines.
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
