### PR TITLE
Fix some valgrind issues

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -3832,6 +3832,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
                     results_ptr->leaf_data_array[results_ptr->leaf_count].mds_idx = blk_index;
                     results_ptr->leaf_data_array[results_ptr->leaf_count].tot_d1_blocks = tot_d1_blocks;
 
+                    results_ptr->leaf_data_array[results_ptr->leaf_count].final_pred_depth_refinement = 0;
                     if (use_output_stat(scs_ptr)) {
                         if (blk_geom->sq_size == force_blk_size)
                             results_ptr->leaf_data_array[results_ptr->leaf_count++].split_flag = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -565,6 +565,8 @@ extern void first_pass_loop_core(PictureControlSet *pcs_ptr,
             ? EB_TRUE
             : EB_FALSE;
 
+    candidate_ptr->count_non_zero_coeffs = 0;
+
     //ALL PLANE
     *(candidate_buffer->full_cost_ptr) = 0;
 }
@@ -753,6 +755,12 @@ static int firstpass_inter_prediction(
         candidate_buffer->candidate_ptr->interp_filters   = 0;
         svt_product_prediction_fun_table[candidate_ptr->type](
             context_ptr->hbd_mode_decision, context_ptr, pcs_ptr, candidate_buffer);
+        candidate_ptr->y_has_coeff = 0;
+        candidate_ptr->u_has_coeff = 0;
+        candidate_ptr->v_has_coeff = 0;
+        candidate_ptr->count_non_zero_coeffs = 0;
+        candidate_ptr->chroma_distortion = 0;
+        candidate_ptr->chroma_distortion_inter_depth = 0;
         *(candidate_buffer->full_cost_ptr) = 0;
         // To convert full-pel MV
         mv.col = candidate_buffer->candidate_ptr->motion_vector_xl0 >> 3;


### PR DESCRIPTION
# Description
Fix most of the valgrind errors from issue #1543 
After this PR is applied, only 3 errors left:
```
Syscall param write(buf) points to uninitialised byte(s)
   at 0xEC4EA1D: ??? (in /usr/lib64/libc-2.17.so)
   by 0xEBD9262: _IO_file_write@@GLIBC_2.2.5 (in /usr/lib64/libc-2.17.so)
   by 0xEBDAA7D: _IO_do_write@@GLIBC_2.2.5 (in /usr/lib64/libc-2.17.so)
   by 0xEBDCB24: _IO_flush_all_lockp (in /usr/lib64/libc-2.17.so)
   by 0xEBDCC84: _IO_cleanup (in /usr/lib64/libc-2.17.so)
   by 0xEB98C9A: __run_exit_handlers (in /usr/lib64/libc-2.17.so)
   by 0xEB98D36: exit (in /usr/lib64/libc-2.17.so)
   by 0xEB8155B: (below main) (in /usr/lib64/libc-2.17.so)
 Address 0x40241d0 is in a rw- anonymous segment

Conditional jump or move depends on uninitialised value(s)
   at 0x535376C: coding_loop_context_generation (EbRateDistortionCost.c:2264)
   by 0x5319829: product_coding_loop_init_fast_loop (EbProductCodingLoop.c:925)
   by 0x53AD2C0: first_pass_md_encode_block (firstpass.c:1336)
   by 0x5336394: mode_decision_sb (EbProductCodingLoop.c:8735)
   by 0x52568D1: mode_decision_kernel (EbEncDecProcess.c:4221)
   by 0xE648EA4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0xEC5D8DC: clone (in /usr/lib64/libc-2.17.so)

Conditional jump or move depends on uninitialised value(s)
   at 0x5353708: coding_loop_context_generation (EbRateDistortionCost.c:2259)
   by 0x5319829: product_coding_loop_init_fast_loop (EbProductCodingLoop.c:925)
   by 0x53AD2C0: first_pass_md_encode_block (firstpass.c:1336)
   by 0x5336394: mode_decision_sb (EbProductCodingLoop.c:8735)
   by 0x52568D1: mode_decision_kernel (EbEncDecProcess.c:4221)
   by 0xE648EA4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0xEC5D8DC: clone (in /usr/lib64/libc-2.17.so)
```

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
