### PR TITLE
Change --irefresh-type from 1 (open gop) to 2 (closed gop)

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -54,7 +54,7 @@ VBVBufSize                      : 0                         # VBV buffer size
 
 #=============================== Keyframe Placement Options ===============================
 IntraPeriod                     : -2                        # Intra period interval(frames) (-2: default intra period, -1: No intra update or an integer >=0; if RateControlMode >= 1 intra-period limited to [-2-255])
-IntraRefreshType                : 1                         # intra refresh type (1: CRA (Open GOP)2: IDR (Closed GOP))
+IntraRefreshType                : 2                         # intra refresh type (1: CRA (Open GOP), 2: IDR (Closed GOP)[default])
 
 #=============================== AV1 Specific Options ===============================
 BaseLayerSwitchMode             : 0                         # BaseLayerSwitchMode

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -191,7 +191,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |
 | --- | --- | --- | --- | --- |
 | **IntraPeriod** | --keyint | [-2 - 2^31-2] | -2 | Intra period interval(frames) -2: default intra period , -1: No intra update or an integer >= 0. if RateControlMode >= 1 intra-period limited to [-2, 255] |
-| **IntraRefreshType** | --irefresh-type | [1 - 2] | 2 | 1: CRA (Open GOP), 2: IDR (Closed GOP)][default] |
+| **IntraRefreshType** | --irefresh-type | [1 - 2] | 2 | 1: CRA (Open GOP), 2: IDR (Closed GOP)[default] |
 
 #### AV1 Specific Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -191,7 +191,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |
 | --- | --- | --- | --- | --- |
 | **IntraPeriod** | --keyint | [-2 - 2^31-2] | -2 | Intra period interval(frames) -2: default intra period , -1: No intra update or an integer >= 0. if RateControlMode >= 1 intra-period limited to [-2, 255] |
-| **IntraRefreshType** | --irefresh-type | [1 - 2] | 1 | 1: CRA (Open GOP)2: IDR (Closed GOP) |
+| **IntraRefreshType** | --irefresh-type | [1 - 2] | 2 | 1: CRA (Open GOP), 2: IDR (Closed GOP)][default] |
 
 #### AV1 Specific Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -863,7 +863,7 @@ ConfigEntry config_entry_intra_refresh[] = {
      set_cfg_intra_period},
     {SINGLE_INPUT,
      INTRA_REFRESH_TYPE_TOKEN,
-     "Intra refresh type (1: CRA (Open GOP)2: IDR (Closed GOP))",
+     "Intra refresh type (1: CRA (Open GOP), 2: IDR (Closed GOP)[default])",
      set_tile_row},
     // Termination
     {SINGLE_INPUT, NULL, NULL, NULL}};

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2913,7 +2913,7 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->enable_adaptive_quantization = 2;
     config_ptr->enc_mode = MAX_ENC_PRESET;
     config_ptr->intra_period_length = -2;
-    config_ptr->intra_refresh_type = 1;
+    config_ptr->intra_refresh_type = 2;
     config_ptr->hierarchical_levels = 4;
     config_ptr->pred_structure = EB_PRED_RANDOM_ACCESS;
     config_ptr->disable_dlf_flag = EB_FALSE;


### PR DESCRIPTION
# Description
Change --irefresh-type from 1 (open gop) to 2 (closed gop) to improve seekability in all major web browsers and various media players.

The default --irefresh-type of 1 (open gop) results in videos being difficult to seek in all of the major web browsers (Firefox, Google Chrome, Edge Chromium, etc) and various media players (MPV, MPC, VLC, etc)

Until these media players are updated to have better compatibility with --irefresh-type 1 (open gop), I suggest changing the default to --irefresh-type 2 (closed gop) in order to encourage better default settings, and greater chance of videos being encoded without seekability issues.

This new default setting will help increase the likelihood of AV1 being adopted because seekability issues will not be as much of a concern for people getting into AV1 encoding/decoding.

# Issue
Closes #1548

# Author(s)
Neltulz

# Performance impact
- [x] speed

# Test set
- [x] y4m test file can be found [here](https://github.com/AOMediaCodec/SVT-AV1/issues/1548)

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
