### PR TITLE
eb_config_ctor: remove reassignment of the pass variable

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1393,15 +1393,14 @@ EbConfig * eb_config_ctor(EncodePass pass) {
     if (!config_ptr)
         return NULL;
 
-    if (pass == ENCODE_FIRST_PASS)
-        config_ptr->pass = 1;
-    else if (pass == ENCODE_LAST_PASS)
-        config_ptr->pass = 2;
+    switch (pass) {
+    case ENCODE_FIRST_PASS: config_ptr->pass = 1; break;
+    case ENCODE_LAST_PASS: config_ptr->pass = 2; break;
+    default: config_ptr->pass = DEFAULT;
+    }
 
     config_ptr->error_log_file         = stderr;
     config_ptr->buffered_input         = -1;
-
-    config_ptr->pass = DEFAULT;
 
     return config_ptr;
 }


### PR DESCRIPTION
# Description

based on the conversation https://github.com/AOMediaCodec/SVT-AV1/commit/99c6693dc744732e23ea33a6cdff916e7a7131a3#r43459612

command ran
```bash
# build master
./master/SvtAv1EncApp --passes 2 -i /home/ubuntu/akiyo_cif.y4m --preset 3 --keyint -1 -b masterm3.ivf
# build pr
./pr/SvtAv1EncApp --passes 2 -i /home/ubuntu/akiyo_cif.y4m --preset 3 --keyint -1 -b prm3.ivf

diff masterm3.ivf prm3.ivf
```

The changes are expected to be lossless

/cc @xuguangxin 

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
