### PR TITLE
Add task to CI Sanitizer thread with skip known issues.

### DIFF
--- a/.github/workflows/sanitizers-known-warnings.txt
+++ b/.github/workflows/sanitizers-known-warnings.txt
@@ -1,0 +1,18 @@
+#List of known warnings for CI task Sanitizer(thread-skip-known-warnings)
+#CI runs sanitizer with skip known warnings to detect regression of new potential issues.
+#Known warnings are tracked in issue: #1308
+
+#Race warnings (data races and use-after-free reports):
+race:svt_memcpy_small
+race:svt_memcpy_sse
+race:mode_decision_kernel
+race:picture_decision_kernel
+race:calculate_input_average_intensity
+race:compute_luma_sad_between_center_and_target_frame
+race:compute_block_mean_compute_variance
+race:picture_manager_kernel
+race:packetization_kernel
+race:signal_derivation_pre_analysis_oq
+race:compute_chroma_block_mean
+
+#End of file

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -27,21 +27,30 @@ jobs:
       matrix:
         include:
           - sanitizer: address
+            sanitizer-type: address
             allows-failure: false
             ASAN_OPTIONS: detect_leaks=1
 
           - sanitizer: memory
+            sanitizer-type: memory
             allows-failure: false
             CFLAGS: -fno-omit-frame-pointer
             CXXFLAGS: -fno-omit-frame-pointer
             svt-args: --asm 0
 
           - sanitizer: thread
+            sanitizer-type: thread
             allows-failure: true
+
+          - sanitizer: thread-skip-known-warnings
+            sanitizer-type: thread
+            allows-failure: false
+            run-prefix: TSAN_OPTIONS="suppressions=./.github/workflows/sanitizers-known-warnings.txt"
+
     env:
-      CFLAGS: -fsanitize=${{ matrix.sanitizer }} ${{ matrix.CFLAGS }}
-      CXXFLAGS: -fsanitize=${{ matrix.sanitizer }} ${{ matrix.CXXFLAGS }}
-      LDFLAGS: -fsanitize=${{ matrix.sanitizer }} ${{ matrix.LDFLAGS }}
+      CFLAGS: -fsanitize=${{ matrix.sanitizer-type }} ${{ matrix.CFLAGS }}
+      CXXFLAGS: -fsanitize=${{ matrix.sanitizer-type }} ${{ matrix.CXXFLAGS }}
+      LDFLAGS: -fsanitize=${{ matrix.sanitizer-type }} ${{ matrix.LDFLAGS }}
       ASAN_OPTIONS: ${{ matrix.ASAN_OPTIONS }}
 
     steps:
@@ -73,5 +82,5 @@ jobs:
           tar xzf video.tar.gz
 
       - name: Run Encoder
-        run: ./Bin/Debug/SvtAv1EncApp -i Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m ${{ matrix.svt-args }} -n 120 --preset 8 -b output.ivf
+        run: ${{ matrix.run-prefix }} ./Bin/Debug/SvtAv1EncApp -i Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m ${{ matrix.svt-args }} -n 120 --preset 8 -b output.ivf
         continue-on-error: ${{ matrix.allows-failure }}


### PR DESCRIPTION
# Description
Add task to CI: Sanitizer(thread-skip-known-warnings) with skip known issues.
Task is not allowed to fail, and will detect regression of new potential issues.
Known warnings are keep in file: /.github/workflows/sanitizers-known-warnings.txt"
Task Sanitizer thread (with allow to fail) raport to much issues to eliminate all in one fix.
Known warnings from Issue  #1308 should be removed in small steps.


# Issue
#1308 - only support to fix

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@spawlows 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
