### PR TITLE
remove restricting the maximum number of ME segments to 64

### DIFF
--- a/Source/Lib/Common/Codec/Av1Common.h
+++ b/Source/Lib/Common/Codec/Av1Common.h
@@ -20,12 +20,6 @@ extern "C" {
 #endif
 
 // Segment Macros
-#define SEGMENT_MAX_COUNT 64
-#define SEGMENT_COMPLETION_MASK_SET(mask, index)                \
-    MULTI_LINE_MACRO_BEGIN(mask) |= (((uint64_t)1) << (index)); \
-    MULTI_LINE_MACRO_END
-#define SEGMENT_COMPLETION_MASK_TEST(mask, total_count) \
-    (mask) == ((((uint64_t)1) << (total_count)) - 1)
 #define SEGMENT_ROW_COMPLETION_TEST(mask, row_index, width) \
     ((((mask) >> ((row_index) * (width))) & ((1ull << (width)) - 1)) == ((1ull << (width)) - 1))
 #define SEGMENT_CONVERT_IDX_TO_XY(index, x, y, pic_width_in_sb)    \

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1360,14 +1360,11 @@ void *initial_rate_control_kernel(void *input_ptr) {
         PictureParentControlSet *pcs_ptr = (PictureParentControlSet *)
                                                in_results_ptr->pcs_wrapper_ptr->object_ptr;
 
-        uint32_t segment_index = in_results_ptr->segment_index;
-
-        // Set the segment mask
-        SEGMENT_COMPLETION_MASK_SET(pcs_ptr->me_segments_completion_mask, segment_index);
+        // Set the segment counter
+        pcs_ptr->me_segments_completion_count++;
 
         // If the picture is complete, proceed
-        if (SEGMENT_COMPLETION_MASK_TEST(pcs_ptr->me_segments_completion_mask,
-                                         pcs_ptr->me_segments_total_count)) {
+        if (pcs_ptr->me_segments_completion_count == pcs_ptr->me_segments_total_count) {
             SequenceControlSet *scs_ptr = (SequenceControlSet *)
                                               pcs_ptr->scs_wrapper_ptr->object_ptr;
             EncodeContext *encode_context_ptr = (EncodeContext *)scs_ptr->encode_context_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -655,7 +655,7 @@ typedef struct PictureParentControlSet {
     uint16_t inloop_me_segments_total_count;
     uint8_t  inloop_me_segments_column_count;
     uint8_t  inloop_me_segments_row_count;
-    uint64_t inloop_me_segments_completion_mask;
+    uint16_t inloop_me_segments_completion_count;
 #endif
 
     // Motion Estimation Results

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -649,7 +649,7 @@ typedef struct PictureParentControlSet {
     uint16_t me_segments_total_count;
     uint8_t  me_segments_column_count;
     uint8_t  me_segments_row_count;
-    uint64_t me_segments_completion_mask;
+    uint16_t me_segments_completion_count;
 
 #if FEATURE_INL_ME
     uint16_t inloop_me_segments_total_count;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -5587,8 +5587,8 @@ void* picture_decision_kernel(void *input_ptr)
                             pcs_ptr->me_segments_total_count = (uint16_t)(pcs_ptr->me_segments_column_count  * pcs_ptr->me_segments_row_count);
                             pcs_ptr->me_segments_completion_count = 0;
 #else
-                            pcs_ptr->me_segments_completion_mask = 0;
-                            pcs_ptr->inloop_me_segments_completion_mask = 0;
+                            pcs_ptr->me_segments_completion_count = 0;
+                            pcs_ptr->inloop_me_segments_completion_count = 0;
 
                             pcs_ptr->inloop_me_segments_column_count = 1;
                             pcs_ptr->inloop_me_segments_row_count = 1;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -5585,7 +5585,7 @@ void* picture_decision_kernel(void *input_ptr)
                             pcs_ptr->me_segments_column_count = (uint8_t)(scs_ptr->me_segment_column_count_array[pcs_ptr->temporal_layer_index]);
                             pcs_ptr->me_segments_row_count = (uint8_t)(scs_ptr->me_segment_row_count_array[pcs_ptr->temporal_layer_index]);
                             pcs_ptr->me_segments_total_count = (uint16_t)(pcs_ptr->me_segments_column_count  * pcs_ptr->me_segments_row_count);
-                            pcs_ptr->me_segments_completion_mask = 0;
+                            pcs_ptr->me_segments_completion_count = 0;
 #else
                             pcs_ptr->me_segments_completion_mask = 0;
                             pcs_ptr->inloop_me_segments_completion_mask = 0;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -7385,13 +7385,11 @@ void *rate_control_kernel(void *input_ptr) {
         case RC_INPUT:
             pcs_ptr = (PictureControlSet *)rate_control_tasks_ptr->pcs_wrapper_ptr->object_ptr;
 
-            // Set the segment mask
-            SEGMENT_COMPLETION_MASK_SET(pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_mask,
-                    rate_control_tasks_ptr->segment_index);
+            // Set the segment counter
+            pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_count++;
 
             // If the picture is complete, proceed
-            if (!(SEGMENT_COMPLETION_MASK_TEST(pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_mask,
-                        pcs_ptr->parent_pcs_ptr->inloop_me_segments_total_count))) {
+            if (!(pcs_ptr->parent_pcs_ptr->inloop_me_segments_completion_count == pcs_ptr->parent_pcs_ptr->inloop_me_segments_total_count)) {
                 svt_release_object(rate_control_tasks_wrapper_ptr);
                 continue;
             }


### PR DESCRIPTION
# Description
replace the ME segments completion mask (64 bit) by a counter to avoid restricting the number of ME segments to 64


# Author(s)
@ttrigui 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
