### PR TITLE
Fix wrong size of memory allocation when Film Grain is used

### DIFF
--- a/Source/Lib/Encoder/Codec/noise_model.c
+++ b/Source/Lib/Encoder/Codec/noise_model.c
@@ -1471,7 +1471,7 @@ static void denoise_and_model_dctor(EbPtr p) {
 EbErrorType denoise_and_model_ctor(AomDenoiseAndModel *object_ptr, EbPtr object_init_data_ptr) {
     DenoiseAndModelInitData *init_data_ptr = (DenoiseAndModelInitData *)object_init_data_ptr;
     EbErrorType              return_error  = EB_ErrorNone;
-    uint32_t                 use_highbd    = init_data_ptr->encoder_bit_depth > EB_8BIT ? 10 : 8;
+    uint32_t                 use_highbd    = init_data_ptr->encoder_bit_depth > EB_8BIT ? 1 : 0;
 
     int32_t chroma_sub_log2[2] = {1, 1}; //todo: send chroma subsampling
     chroma_sub_log2[0]         = (init_data_ptr->encoder_color_format == EB_YUV444 ? 1 : 2) - 1;


### PR DESCRIPTION
# Description
Fix wrong size of memory allocation when Film Grain is used

Fixes 2 out of 3 points in issue #1444 
1 - for the film grain unit test : "SvtMalloc[fatal]: allocate memory failed, at D:\a\SVT-AV1\SVT-
AV1\Source\Lib\Encoder\Codec\noise_model.c, L1499"
3- Memory increase : Up to 20% in some cases

# Issue
#1444
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [x] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
