### PR TITLE
set progress to default to 1 in EbConfig constructor

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1400,6 +1400,7 @@ EbConfig * eb_config_ctor(EncodePass pass) {
 
     config_ptr->error_log_file         = stderr;
     config_ptr->buffered_input         = -1;
+    config_ptr->progress               = 1;
 
     config_ptr->pass = DEFAULT;
 


### PR DESCRIPTION
# Description
adds back the default value for progress output.

There is no quality or speed impact expected.

Tested Objective-1-fast 8 bit
  | Speed Deviation  | BD-Rate   Deviation | Memory Deviation
-- | -- | -- | --
M4 - 8bit - 1 pass | -0.21% | 0.00 | 0.01%
M8 - 8bit - 1pass | -0.36%|  0.00| 0.01%

# Issue
fixes #1564 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@ccccheung 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
