### PR TITLE
Fix valgrind v2

### DIFF
--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -131,6 +131,9 @@ void svt_av1_twopass_zero_stats(FIRSTPASS_STATS *section) {
     section->new_mv_count             = 0.0;
     section->count                    = 0.0;
     section->duration                 = 1.0;
+    section->raw_error_stdev          = 0.0;
+    section->pcnt_third_ref           = 0.0;
+    section->tr_coded_error           = 0.0;
 }
 void svt_av1_accumulate_stats(FIRSTPASS_STATS *section, const FIRSTPASS_STATS *frame) {
     section->frame += frame->frame;


### PR DESCRIPTION
 Initialize with 0 variables that are used by "--pass 1"

Fixes valgrind issue:
```
==56469== Syscall param write(buf) points to uninitialised byte(s)
==56469==    at 0x66C7297: write (write.c:27)
==56469==    by 0x664222C: _IO_file_write@@GLIBC_2.2.5 (fileops.c:1203)
==56469==    by 0x6643FC0: new_do_write (fileops.c:457)
==56469==    by 0x6643FC0: _IO_do_write@@GLIBC_2.2.5 (fileops.c:433)
==56469==    by 0x6646271: _IO_flush_all_lockp (genops.c:769)
==56469==    by 0x6646474: _IO_cleanup (genops.c:921)
==56469==    by 0x65FA1B1: __run_exit_handlers (exit.c:130)
==56469==    by 0x65FA1E9: exit (exit.c:139)
==56469==    by 0x65D8B9D: (below main) (libc-start.c:344)
==56469==  Address 0xf7c2640 is 464 bytes inside a block of size 4,096 alloc'd
==56469==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==56469==    by 0x66351FB: _IO_file_doallocate (filedoalloc.c:101)
==56469==    by 0x66453E8: _IO_doallocbuf (genops.c:365)
==56469==    by 0x6644507: _IO_file_overflow@@GLIBC_2.2.5 (fileops.c:759)
==56469==    by 0x6642A5C: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1266)
==56469==    by 0x66369E6: fwrite (iofwrite.c:39)
==56469==    by 0x116FFA: process_output_stream_buffer (in /home/ubuntu/Paul/Issue1543_20201027/SvtAv1EncApp)
==56469==    by 0x10E80C: main (in /home/ubuntu/Paul/Issue1543_20201027/SvtAv1EncApp)
```
@ttrigui FYI

# Description


# Issue
#1543 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
