### PR TITLE
CI: Migrate GitHub Actions to Xcode 12.2 for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         include:
           - generator: Xcode
-            DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
           - generator: Unix Makefiles
     steps:
       - uses: actions/checkout@v2
@@ -44,6 +43,7 @@ jobs:
           printf '%s\n' \
             "PATH=/usr/local/opt/ccache/libexec:$PATH" \
             "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+          sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
           clang -v
       - name: Run CMake
         run: cmake -S "$GITHUB_WORKSPACE" -B Build -G"${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         include:
           - generator: Xcode
+            DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
           - generator: Unix Makefiles
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -59,6 +59,7 @@ jobs:
             brew update || brew update-reset
             brew upgrade yasm nasm ccache pkg-config ninja || brew install -q yasm nasm ccache pkg-config ninja
           } || brew update-reset
+          sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
       - name: Check dependencies
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache


### PR DESCRIPTION
# Description
Specifies Xcode 12.2 as compiler in the GitHub Actions workflows, as currently 12.0.1 is used by default. This allows the compilation of universal binaries for Apple Silicon in the future.

# Issue
#1569 part 1

# Author(s)
@EwoutH 

# Performance impact
- [x] N/A

# Test set
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section