### PR TITLE
 Tune 0B/1B/3B settings to support minigop 1, 2 and 4

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -152,7 +152,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **FrameRateDenominator** | --fps-denom | [0 - 2^64 -1] | 0 | Frame rate denominator e.g. 100 |
 | **EncoderBitDepth** | --input-depth | [8 , 10] | 8 | specifies the bit depth of the input video |
 | **Encoder16BitPipeline** | --16bit-pipeline | [0 , 1] | 0 | Bit depth for enc-dec(0: lbd[default], 1: hbd) |
-| **HierarchicalLevels** | --hierarchical-levels | [3 - 4] | 4 | 0 : Flat4: 5-Level HierarchyMinigop Size = (2^HierarchicalLevels) (e.g. 3 == > 7B pyramid, 4 == > 15B Pyramid) |
+| **HierarchicalLevels** | --hierarchical-levels | [0 - 5] | 4 | 0 : Flat4: 5-Level HierarchyMinigop Size = (2^HierarchicalLevels) (e.g. 0 == > 0B pyramid, 1 == > 1B pyramid, 2 == > 3B pyramid, 3 == > 7B pyramid, 4 == > 15B Pyramid) |
 | **PredStructure** | --pred-struct | [0-2] | 2 | Set prediction structure( 0: low delay P, 1: low delay B, 2: random access [default]) |
 | **HighDynamicRangeInput** | --enable-hdr | [0-1] | 0 | Enable high dynamic range(0: OFF[default], ON: 1) |
 | **Asm** | --asm |  [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max] | 11 or max | Limit assembly instruction set ("0" is equivalent to "c", "1" is "mmx" etc, max value is "11" or "max"), by default select highest assembly instruction that is supported by CPU |

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -109,7 +109,7 @@ extern "C" {
 #define TUNE_PALETTE_LEVEL                       1 // palette level will only be 6 for temporal layer == 0, not encode preset <=M3
 #define FEATURE_MDS0_ELIMINATE_CAND                  1 // Eliminate candidates based on the estimated cost of the distortion in mds0.
 #define TUNE_TPL_TOWARD_CHROMA                       1 //Tune TPL for better chroma. Only for 240P
-#define LOW_DELAY_TUNE          1 // Tuning the 0B, 1B and 3B settings to support mingop 1, 2 and 4
+#define TUNE_LOW_DELAY                               1 // Tuning the 0B, 1B and 3B settings to support mingop 1, 2 and 4
 
 
 //FOR DEBUGGING - Do not remove

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -109,6 +109,8 @@ extern "C" {
 #define TUNE_PALETTE_LEVEL                       1 // palette level will only be 6 for temporal layer == 0, not encode preset <=M3
 #define FEATURE_MDS0_ELIMINATE_CAND                  1 // Eliminate candidates based on the estimated cost of the distortion in mds0.
 #define TUNE_TPL_TOWARD_CHROMA                       1 //Tune TPL for better chroma. Only for 240P
+#define LOW_DELAY_TUNE          1 // Tuning the 0B, 1B and 3B settings to support mingop 1, 2 and 4
+
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -490,14 +490,25 @@ static EbErrorType generate_picture_window_split(
 *
 ***************************************************************************************************/
 EbErrorType handle_incomplete_picture_window_map(
+#if LOW_DELAY_TUNE
+    uint32_t                       hierarchical_level,
+#endif
     PictureDecisionContext        *context_ptr,
     EncodeContext                 *encode_context_ptr) {
     EbErrorType return_error = EB_ErrorNone;
     if (context_ptr->total_number_of_mini_gops == 0) {
+#if LOW_DELAY_TUNE
+        //The trailing frames of minigop16 will try to use minigop8 first
+        hierarchical_level = hierarchical_level >=3 ? 3 : hierarchical_level;
+#endif
         context_ptr->mini_gop_start_index[context_ptr->total_number_of_mini_gops] = 0;
         context_ptr->mini_gop_end_index[context_ptr->total_number_of_mini_gops] = encode_context_ptr->pre_assignment_buffer_count - 1;
         context_ptr->mini_gop_length[context_ptr->total_number_of_mini_gops] = encode_context_ptr->pre_assignment_buffer_count - context_ptr->mini_gop_start_index[context_ptr->total_number_of_mini_gops];
+#if LOW_DELAY_TUNE
+        context_ptr->mini_gop_hierarchical_levels[context_ptr->total_number_of_mini_gops] = hierarchical_level;
+#else
         context_ptr->mini_gop_hierarchical_levels[context_ptr->total_number_of_mini_gops] = 3;// MIN_HIERARCHICAL_LEVEL; // AMIR to be updated after other predictions are supported
+#endif
 
         context_ptr->total_number_of_mini_gops++;
     }
@@ -1376,6 +1387,27 @@ static void  av1_generate_rps_info(
             return;
         }
 
+#if LOW_DELAY_TUNE
+        const uint8_t  base0_idx = (context_ptr->lay0_toggle + 8 - 1) % 8;
+        const uint8_t  base1_idx = (context_ptr->lay0_toggle + 8 - 2) % 8;
+        const uint8_t  base2_idx = (context_ptr->lay0_toggle + 8 - 3) % 8;
+        const uint8_t  base3_idx = (context_ptr->lay0_toggle + 8 - 4) % 8;
+        const uint8_t  base4_idx = (context_ptr->lay0_toggle + 8 - 5) % 8;
+        const uint8_t  base5_idx = (context_ptr->lay0_toggle + 8 - 6) % 8;
+        //const uint8_t  base6_idx = (context_ptr->lay0_toggle + 8 - 7) % 8;
+        const uint8_t  base7_idx = (context_ptr->lay0_toggle + 8 - 8) % 8;
+
+       // {1, 3, 5, 7},    // GOP Index 0 - Ref List 0
+       // { 2, 4, 6, 0 }     // GOP Index 0 - Ref List 1
+        av1_rps->ref_dpb_index[LAST] = base0_idx;
+        av1_rps->ref_dpb_index[LAST2] = base2_idx;
+        av1_rps->ref_dpb_index[LAST3] = base4_idx;
+        av1_rps->ref_dpb_index[GOLD] = base7_idx;
+
+        av1_rps->ref_dpb_index[BWD] = base1_idx;
+        av1_rps->ref_dpb_index[ALT2] = base3_idx;
+        av1_rps->ref_dpb_index[ALT] = base5_idx;
+#else
         const uint8_t  base0_idx = context_ptr->lay0_toggle == 0 ? 1 : context_ptr->lay0_toggle == 1 ? 2 : 0;
         const uint8_t  base1_idx = context_ptr->lay0_toggle == 0 ? 2 : context_ptr->lay0_toggle == 1 ? 0 : 1;
 
@@ -1389,15 +1421,25 @@ static void  av1_generate_rps_info(
         av1_rps->ref_dpb_index[BWD] = av1_rps->ref_dpb_index[LAST];
         av1_rps->ref_dpb_index[ALT2] = av1_rps->ref_dpb_index[LAST2];
         av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[LAST];
+#endif
         gop_i = 0;
         av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[0]);
         av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[1]);
+#if LOW_DELAY_TUNE
+        av1_rps->ref_poc_array[LAST3] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[2]);
+        av1_rps->ref_poc_array[GOLD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[3]);
+#else
         av1_rps->ref_poc_array[LAST3] = av1_rps->ref_poc_array[LAST];
         av1_rps->ref_poc_array[GOLD] = av1_rps->ref_poc_array[LAST];
+#endif
 
         av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[0]);
         av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[1]);
+#if LOW_DELAY_TUNE
+        av1_rps->ref_poc_array[ALT] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[2]);
+#else
         av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
+#endif
 
         prune_refs(pred_position_ptr, av1_rps);
         av1_rps->refresh_frame_mask = 1 << context_ptr->lay0_toggle;
@@ -1406,7 +1448,11 @@ static void  av1_generate_rps_info(
         set_frame_display_params(pcs_ptr, context_ptr, mini_gop_index);
         frm_hdr->show_frame = EB_TRUE;
         pcs_ptr->has_show_existing = EB_FALSE;
+#if LOW_DELAY_TUNE
+        context_ptr->lay0_toggle = (1 + context_ptr->lay0_toggle) % 8;
+#else
         context_ptr->lay0_toggle = circ_inc(3, 1, context_ptr->lay0_toggle);
+#endif
     } else if (pcs_ptr->hierarchical_levels == 1) {
         uint8_t gop_i;
         if (frm_hdr->frame_type == KEY_FRAME) {
@@ -1414,13 +1460,44 @@ static void  av1_generate_rps_info(
             return;
         }
 
+#if LOW_DELAY_TUNE
+        const uint8_t  base_off0_idx = (context_ptr->lay0_toggle + 5 - 5) % 5;
+        const uint8_t  base_off2_idx = (context_ptr->lay0_toggle + 5 - 1) % 5;
+        const uint8_t  base_off4_idx = (context_ptr->lay0_toggle + 5 - 2) % 5;
+        const uint8_t  base_off6_idx = (context_ptr->lay0_toggle + 5 - 3) % 5;
+        const uint8_t  base_off8_idx = (context_ptr->lay0_toggle + 5 - 4) % 5;
+        //const uint8_t  lay1_off0_idx = (context_ptr->lay1_toggle + 3 - 3) % 3 + 5;
+        const uint8_t  lay1_off2_idx = (context_ptr->lay1_toggle + 3 - 1) % 3 + 5;
+        //const uint8_t  lay1_off4_idx = (context_ptr->lay1_toggle + 3 - 2) % 3 + 5;
+#else
         const uint8_t  base0_idx = context_ptr->lay0_toggle == 0 ? 1 : context_ptr->lay0_toggle == 1 ? 2 : 0;
         const uint8_t  base1_idx = context_ptr->lay0_toggle == 0 ? 2 : context_ptr->lay0_toggle == 1 ? 0 : 1;
         const uint8_t  base2_idx = context_ptr->lay0_toggle == 0 ? 0 : context_ptr->lay0_toggle == 1 ? 1 : 2;
+#endif
 
         switch (pcs_ptr->temporal_layer_index) {
         case 0:
+#if LOW_DELAY_TUNE
+            //{2, 6, 10, 0},     // GOP Index 0 - Ref List 0
+            //{4, 8, 0, 0}       // GOP Index 0 - Ref List 1
+            av1_rps->ref_dpb_index[LAST] = base_off2_idx;
+            av1_rps->ref_dpb_index[LAST2] = base_off6_idx;
+            av1_rps->ref_dpb_index[LAST3] = base_off0_idx;
+            av1_rps->ref_dpb_index[GOLD] = av1_rps->ref_dpb_index[LAST];
 
+            av1_rps->ref_dpb_index[BWD] = base_off4_idx;
+            av1_rps->ref_dpb_index[ALT2] = base_off8_idx;
+            av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[LAST];
+            gop_i = 0;
+            av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[0]);
+            av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[1]);
+            av1_rps->ref_poc_array[LAST3] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[2]);
+            av1_rps->ref_poc_array[GOLD] = av1_rps->ref_poc_array[LAST];
+
+            av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list1[0]);
+            av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list1[1]);
+            av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
+#else
             //{2, 4, 0, 0},     // GOP Index 0 - Ref List 0
             //{2, 4, 0, 0},     // GOP Index 0 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base1_idx;
@@ -1440,11 +1517,24 @@ static void  av1_generate_rps_info(
             av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list1[0]);
             av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list1[1]);
             av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
+#endif
 
             av1_rps->refresh_frame_mask = 1 << context_ptr->lay0_toggle;
             break;
 
         case 1:
+#if LOW_DELAY_TUNE
+            //{ 1, 2, 3, 5},    // GOP Index 1 - Ref List 0
+            //{ -1, 0, 0, 0 }     // GOP Index 1 - Ref List 1
+            av1_rps->ref_dpb_index[LAST] = base_off2_idx;
+            av1_rps->ref_dpb_index[LAST2] = lay1_off2_idx;
+            av1_rps->ref_dpb_index[LAST3] = base_off4_idx;
+            av1_rps->ref_dpb_index[GOLD] = base_off6_idx;
+
+            av1_rps->ref_dpb_index[BWD] = base_off0_idx;
+            av1_rps->ref_dpb_index[ALT2] = av1_rps->ref_dpb_index[BWD];
+            av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[BWD];
+#else
             //{ 1, 3, 0, 0}   // GOP Index 2 - Ref List 0
             //{-1, 0, 0, 0}   // GOP Index 2 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base1_idx;
@@ -1455,8 +1545,20 @@ static void  av1_generate_rps_info(
             av1_rps->ref_dpb_index[BWD] = base2_idx;
             av1_rps->ref_dpb_index[ALT2] = av1_rps->ref_dpb_index[BWD];
             av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[BWD];
+#endif
 
             gop_i = 1;
+#if LOW_DELAY_TUNE
+            av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[0]);
+            av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[1]);
+            av1_rps->ref_poc_array[LAST3] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[2]);
+            av1_rps->ref_poc_array[GOLD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[3]);;
+
+            av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list1[0]);
+            av1_rps->ref_poc_array[ALT2] = av1_rps->ref_poc_array[BWD];
+            av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
+            av1_rps->refresh_frame_mask = 1 << (context_ptr->lay1_toggle+5);
+#else
             av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[0]);
             av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[1]);
             av1_rps->ref_poc_array[LAST3] = av1_rps->ref_poc_array[LAST];
@@ -1467,6 +1569,7 @@ static void  av1_generate_rps_info(
             av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
 
             av1_rps->refresh_frame_mask = 0;
+#endif
 
             break;
 
@@ -1486,7 +1589,11 @@ static void  av1_generate_rps_info(
                 pcs_ptr->has_show_existing = EB_TRUE;
 
                 if (picture_index == 0)
+#if LOW_DELAY_TUNE
+                    frm_hdr->show_existing_frame = base_off0_idx;
+#else
                     frm_hdr->show_existing_frame = base2_idx;
+#endif
                 else
                     SVT_LOG("Error in GOP indexing for hierarchical level %d\n", pcs_ptr->hierarchical_levels);
             }
@@ -1499,10 +1606,15 @@ static void  av1_generate_rps_info(
                 ((scs_ptr->static_config.pred_structure == EB_PRED_LOW_DELAY_P ||
                   scs_ptr->static_config.pred_structure == EB_PRED_LOW_DELAY_B) &&
                  (pcs_ptr->temporal_layer_index == 0))) {
+#if LOW_DELAY_TUNE
+            context_ptr->lay0_toggle = (1 + context_ptr->lay0_toggle) % 5;
+            context_ptr->lay1_toggle = (1 + context_ptr->lay1_toggle) % 3;
+#else
             //Layer0 toggle 0->1->2
             context_ptr->lay0_toggle = circ_inc(3, 1, context_ptr->lay0_toggle);
             //Layer1 toggle 3->4
             context_ptr->lay1_toggle = 1 - context_ptr->lay1_toggle;
+#endif
         }
     } else if (pcs_ptr->hierarchical_levels == 2) {
         uint8_t gop_i;
@@ -1521,7 +1633,27 @@ static void  av1_generate_rps_info(
 
         switch (pcs_ptr->temporal_layer_index) {
         case 0:
+#if LOW_DELAY_TUNE
+            //{4, 12, 0, 0},     // GOP Index 0 - Ref List 0
+            //{ 4, 8, 0, 0 }      // GOP Index 0 - Ref List 1
+            av1_rps->ref_dpb_index[LAST] = base1_idx;
+            av1_rps->ref_dpb_index[LAST2] = base2_idx;
+            av1_rps->ref_dpb_index[LAST3] = av1_rps->ref_dpb_index[LAST];
+            av1_rps->ref_dpb_index[GOLD] = av1_rps->ref_dpb_index[LAST];
 
+            av1_rps->ref_dpb_index[BWD] = base1_idx;
+            av1_rps->ref_dpb_index[ALT2] = base0_idx;
+            av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[LAST];
+            gop_i = 0;
+            av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list0[0]);
+            av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list0[1]);
+            av1_rps->ref_poc_array[LAST3] = av1_rps->ref_poc_array[LAST];
+            av1_rps->ref_poc_array[GOLD] = av1_rps->ref_poc_array[LAST];
+
+            av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list1[0]);
+            av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list1[1]);
+            av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
+#else
             //{4, 8, 0, 0},     // GOP Index 0 - Ref List 0
             //{4, 8, 0, 0},     // GOP Index 0 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base1_idx;
@@ -1541,7 +1673,7 @@ static void  av1_generate_rps_info(
             av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list1[0]);
             av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, three_level_hierarchical_pred_struct[gop_i].ref_list1[1]);
             av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
-
+#endif
             av1_rps->refresh_frame_mask = 1 << context_ptr->lay0_toggle;
             break;
 
@@ -5040,6 +5172,9 @@ void* picture_decision_kernel(void *input_ptr)
                                         encode_context_ptr);
 
                                 handle_incomplete_picture_window_map(
+#if LOW_DELAY_TUNE
+                                        scs_ptr->static_config.hierarchical_levels,
+#endif
                                         context_ptr,
                                         encode_context_ptr);
                             }
@@ -5068,6 +5203,9 @@ void* picture_decision_kernel(void *input_ptr)
 
                         // 1st Loop over Pictures in the Pre-Assignment Buffer
                         for (out_stride_diff64 = context_ptr->mini_gop_start_index[mini_gop_index]; out_stride_diff64 <= context_ptr->mini_gop_end_index[mini_gop_index]; ++out_stride_diff64) {
+#if LOW_DELAY_TUNE
+                            EbBool is_trailing_frame = EB_FALSE;
+#endif
                             pcs_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[out_stride_diff64]->object_ptr;
                             scs_ptr = (SequenceControlSet*)pcs_ptr->scs_wrapper_ptr->object_ptr;
                             frm_hdr = &pcs_ptr->frm_hdr;
@@ -5086,6 +5224,15 @@ void* picture_decision_kernel(void *input_ptr)
                                     scs_ptr->reference_count,
                                     pcs_ptr->hierarchical_levels);
                                 picture_type = P_SLICE;
+#if LOW_DELAY_TUNE
+                                if (scs_ptr->static_config.hierarchical_levels == 1 &&
+                                    encode_context_ptr->prediction_structure_group_ptr->ref_count_used < MAX_REF_IDX) {
+                                    // Only works for 1B case
+                                    is_trailing_frame = EB_TRUE;
+                                    encode_context_ptr->pred_struct_position =
+                                        pcs_ptr->pred_struct_ptr->steady_state_index + out_stride_diff64 - context_ptr->mini_gop_start_index[mini_gop_index];
+                                }
+#endif
                             }
                             // Open GOP CRA - adjust the RPS
                             else if ((context_ptr->mini_gop_length[mini_gop_index] == pcs_ptr->pred_struct_ptr->pred_struct_period) &&
@@ -5108,6 +5255,9 @@ void* picture_decision_kernel(void *input_ptr)
                                     (encode_context_ptr->pre_assignment_buffer_eos_flag) ? P_SLICE :
                                     B_SLICE;
                             }
+#if LOW_DELAY_TUNE
+                            if (!is_trailing_frame) {
+#endif
                             // If mini GOP switch, reset position
                             encode_context_ptr->pred_struct_position = (pcs_ptr->init_pred_struct_position_flag) ?
                                 pcs_ptr->pred_struct_ptr->init_pic_index :
@@ -5135,6 +5285,9 @@ void* picture_decision_kernel(void *input_ptr)
                             // Else, Increment the position normally
                             else
                                 ++encode_context_ptr->pred_struct_position;
+#if LOW_DELAY_TUNE
+                            }
+#endif
                             // The poc number of the latest IDR picture is stored so that last_idr_picture (present in PCS) for the incoming pictures can be updated.
                             // The last_idr_picture is used in reseting the poc (in entropy coding) whenever IDR is encountered.
                             // Note IMP: This logic only works when display and decode order are the same. Currently for Random Access, IDR is inserted (similar to CRA) by using trailing P pictures (low delay fashion) and breaking prediction structure.
@@ -5143,10 +5296,16 @@ void* picture_decision_kernel(void *input_ptr)
                                 encode_context_ptr->last_idr_picture = pcs_ptr->picture_number;
                             else
                                 pcs_ptr->last_idr_picture = encode_context_ptr->last_idr_picture;
+#if LOW_DELAY_TUNE
+                            if (!is_trailing_frame) {
+#endif
                             // Cycle the PredStructPosition if its overflowed
                             encode_context_ptr->pred_struct_position = (encode_context_ptr->pred_struct_position == pcs_ptr->pred_struct_ptr->pred_struct_entry_count) ?
                                 encode_context_ptr->pred_struct_position - pcs_ptr->pred_struct_ptr->pred_struct_period :
                                 encode_context_ptr->pred_struct_position;
+#if LOW_DELAY_TUNE
+                            }
+#endif
 
                             pred_position_ptr = pcs_ptr->pred_struct_ptr->pred_struct_entry_ptr_array[encode_context_ptr->pred_struct_position];
                             if (scs_ptr->static_config.enable_overlays == EB_TRUE) {

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -490,21 +490,21 @@ static EbErrorType generate_picture_window_split(
 *
 ***************************************************************************************************/
 EbErrorType handle_incomplete_picture_window_map(
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
     uint32_t                       hierarchical_level,
 #endif
     PictureDecisionContext        *context_ptr,
     EncodeContext                 *encode_context_ptr) {
     EbErrorType return_error = EB_ErrorNone;
     if (context_ptr->total_number_of_mini_gops == 0) {
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         //The trailing frames of minigop16 will try to use minigop8 first
         hierarchical_level = hierarchical_level >=3 ? 3 : hierarchical_level;
 #endif
         context_ptr->mini_gop_start_index[context_ptr->total_number_of_mini_gops] = 0;
         context_ptr->mini_gop_end_index[context_ptr->total_number_of_mini_gops] = encode_context_ptr->pre_assignment_buffer_count - 1;
         context_ptr->mini_gop_length[context_ptr->total_number_of_mini_gops] = encode_context_ptr->pre_assignment_buffer_count - context_ptr->mini_gop_start_index[context_ptr->total_number_of_mini_gops];
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         context_ptr->mini_gop_hierarchical_levels[context_ptr->total_number_of_mini_gops] = hierarchical_level;
 #else
         context_ptr->mini_gop_hierarchical_levels[context_ptr->total_number_of_mini_gops] = 3;// MIN_HIERARCHICAL_LEVEL; // AMIR to be updated after other predictions are supported
@@ -1387,7 +1387,7 @@ static void  av1_generate_rps_info(
             return;
         }
 
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         const uint8_t  base0_idx = (context_ptr->lay0_toggle + 8 - 1) % 8;
         const uint8_t  base1_idx = (context_ptr->lay0_toggle + 8 - 2) % 8;
         const uint8_t  base2_idx = (context_ptr->lay0_toggle + 8 - 3) % 8;
@@ -1425,7 +1425,7 @@ static void  av1_generate_rps_info(
         gop_i = 0;
         av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[0]);
         av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[1]);
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         av1_rps->ref_poc_array[LAST3] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[2]);
         av1_rps->ref_poc_array[GOLD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list0[3]);
 #else
@@ -1435,7 +1435,7 @@ static void  av1_generate_rps_info(
 
         av1_rps->ref_poc_array[BWD] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[0]);
         av1_rps->ref_poc_array[ALT2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[1]);
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         av1_rps->ref_poc_array[ALT] = get_ref_poc(context_ptr, pcs_ptr->picture_number, flat_pred_struct[gop_i].ref_list1[2]);
 #else
         av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
@@ -1448,7 +1448,7 @@ static void  av1_generate_rps_info(
         set_frame_display_params(pcs_ptr, context_ptr, mini_gop_index);
         frm_hdr->show_frame = EB_TRUE;
         pcs_ptr->has_show_existing = EB_FALSE;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         context_ptr->lay0_toggle = (1 + context_ptr->lay0_toggle) % 8;
 #else
         context_ptr->lay0_toggle = circ_inc(3, 1, context_ptr->lay0_toggle);
@@ -1460,7 +1460,7 @@ static void  av1_generate_rps_info(
             return;
         }
 
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         const uint8_t  base_off0_idx = (context_ptr->lay0_toggle + 5 - 5) % 5;
         const uint8_t  base_off2_idx = (context_ptr->lay0_toggle + 5 - 1) % 5;
         const uint8_t  base_off4_idx = (context_ptr->lay0_toggle + 5 - 2) % 5;
@@ -1477,7 +1477,7 @@ static void  av1_generate_rps_info(
 
         switch (pcs_ptr->temporal_layer_index) {
         case 0:
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
             //{2, 6, 10, 0},     // GOP Index 0 - Ref List 0
             //{4, 8, 0, 0}       // GOP Index 0 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base_off2_idx;
@@ -1523,7 +1523,7 @@ static void  av1_generate_rps_info(
             break;
 
         case 1:
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
             //{ 1, 2, 3, 5},    // GOP Index 1 - Ref List 0
             //{ -1, 0, 0, 0 }     // GOP Index 1 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base_off2_idx;
@@ -1548,7 +1548,7 @@ static void  av1_generate_rps_info(
 #endif
 
             gop_i = 1;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
             av1_rps->ref_poc_array[LAST] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[0]);
             av1_rps->ref_poc_array[LAST2] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[1]);
             av1_rps->ref_poc_array[LAST3] = get_ref_poc(context_ptr, pcs_ptr->picture_number, two_level_hierarchical_pred_struct[gop_i].ref_list0[2]);
@@ -1589,7 +1589,7 @@ static void  av1_generate_rps_info(
                 pcs_ptr->has_show_existing = EB_TRUE;
 
                 if (picture_index == 0)
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                     frm_hdr->show_existing_frame = base_off0_idx;
 #else
                     frm_hdr->show_existing_frame = base2_idx;
@@ -1606,7 +1606,7 @@ static void  av1_generate_rps_info(
                 ((scs_ptr->static_config.pred_structure == EB_PRED_LOW_DELAY_P ||
                   scs_ptr->static_config.pred_structure == EB_PRED_LOW_DELAY_B) &&
                  (pcs_ptr->temporal_layer_index == 0))) {
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
             context_ptr->lay0_toggle = (1 + context_ptr->lay0_toggle) % 5;
             context_ptr->lay1_toggle = (1 + context_ptr->lay1_toggle) % 3;
 #else
@@ -1633,7 +1633,7 @@ static void  av1_generate_rps_info(
 
         switch (pcs_ptr->temporal_layer_index) {
         case 0:
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
             //{4, 12, 0, 0},     // GOP Index 0 - Ref List 0
             //{ 4, 8, 0, 0 }      // GOP Index 0 - Ref List 1
             av1_rps->ref_dpb_index[LAST] = base1_idx;
@@ -5172,7 +5172,7 @@ void* picture_decision_kernel(void *input_ptr)
                                         encode_context_ptr);
 
                                 handle_incomplete_picture_window_map(
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                                         scs_ptr->static_config.hierarchical_levels,
 #endif
                                         context_ptr,
@@ -5203,7 +5203,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                         // 1st Loop over Pictures in the Pre-Assignment Buffer
                         for (out_stride_diff64 = context_ptr->mini_gop_start_index[mini_gop_index]; out_stride_diff64 <= context_ptr->mini_gop_end_index[mini_gop_index]; ++out_stride_diff64) {
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                             EbBool is_trailing_frame = EB_FALSE;
 #endif
                             pcs_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[out_stride_diff64]->object_ptr;
@@ -5224,7 +5224,7 @@ void* picture_decision_kernel(void *input_ptr)
                                     scs_ptr->reference_count,
                                     pcs_ptr->hierarchical_levels);
                                 picture_type = P_SLICE;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                                 if (scs_ptr->static_config.hierarchical_levels == 1 &&
                                     encode_context_ptr->prediction_structure_group_ptr->ref_count_used < MAX_REF_IDX) {
                                     // Only works for 1B case
@@ -5255,7 +5255,7 @@ void* picture_decision_kernel(void *input_ptr)
                                     (encode_context_ptr->pre_assignment_buffer_eos_flag) ? P_SLICE :
                                     B_SLICE;
                             }
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                             if (!is_trailing_frame) {
 #endif
                             // If mini GOP switch, reset position
@@ -5285,7 +5285,7 @@ void* picture_decision_kernel(void *input_ptr)
                             // Else, Increment the position normally
                             else
                                 ++encode_context_ptr->pred_struct_position;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                             }
 #endif
                             // The poc number of the latest IDR picture is stored so that last_idr_picture (present in PCS) for the incoming pictures can be updated.
@@ -5296,14 +5296,14 @@ void* picture_decision_kernel(void *input_ptr)
                                 encode_context_ptr->last_idr_picture = pcs_ptr->picture_number;
                             else
                                 pcs_ptr->last_idr_picture = encode_context_ptr->last_idr_picture;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                             if (!is_trailing_frame) {
 #endif
                             // Cycle the PredStructPosition if its overflowed
                             encode_context_ptr->pred_struct_position = (encode_context_ptr->pred_struct_position == pcs_ptr->pred_struct_ptr->pred_struct_entry_count) ?
                                 encode_context_ptr->pred_struct_position - pcs_ptr->pred_struct_ptr->pred_struct_period :
                                 encode_context_ptr->pred_struct_position;
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
                             }
 #endif
 

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -81,7 +81,7 @@
 PredictionStructureConfigEntry flat_pred_struct[] = {{
     0, // GOP Index 0 - Temporal Layer
     0, // GOP Index 0 - Decode Order
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
     {1, 3, 5, 8},    // GOP Index 0 - Ref List 0
     {2, 4, 6, 0}     // GOP Index 0 - Ref List 1
 #else
@@ -107,7 +107,7 @@ PredictionStructureConfigEntry two_level_hierarchical_pred_struct[] = {
     {
         0, // GOP Index 0 - Temporal Layer
         0, // GOP Index 0 - Decode Order
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         {2, 6, 10, 0},     // GOP Index 0 - Ref List 0
         {4, 8, 0, 0}      // GOP Index 0 - Ref List 1
 #else
@@ -118,7 +118,7 @@ PredictionStructureConfigEntry two_level_hierarchical_pred_struct[] = {
     {
         1, // GOP Index 1 - Temporal Layer
         1, // GOP Index 1 - Decode Order
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         { 1, 2 ,3, 5},    // GOP Index 1 - Ref List 0
         {-1, 0, 0, 0}     // GOP Index 1 - Ref List 1
 #else
@@ -148,7 +148,7 @@ PredictionStructureConfigEntry three_level_hierarchical_pred_struct[] = {
     {
         0, // GOP Index 0 - Temporal Layer
         0, // GOP Index 0 - Decode Order
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         {4, 12, 0, 0},     // GOP Index 0 - Ref List 0
         {4, 8, 0, 0}      // GOP Index 0 - Ref List 1
 #else
@@ -2052,7 +2052,7 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     }
 
     if (ref_count_used < MAX_REF_IDX) {
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
         for (int gop_i = 0; gop_i < 1; ++gop_i) {
             for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
                 prediction_structure_config_array[0].entry_array[gop_i].ref_list0[i] = 0;

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -81,8 +81,13 @@
 PredictionStructureConfigEntry flat_pred_struct[] = {{
     0, // GOP Index 0 - Temporal Layer
     0, // GOP Index 0 - Decode Order
+#if LOW_DELAY_TUNE
+    {1, 3, 5, 8},    // GOP Index 0 - Ref List 0
+    {2, 4, 6, 0}     // GOP Index 0 - Ref List 1
+#else
     {1, 2, 0, 0}, // GOP Index 0 - Ref List 0
     {1, 2, 0, 0} // GOP Index 0 - Ref List 1
+#endif
 }};
 
 /************************************************
@@ -102,14 +107,24 @@ PredictionStructureConfigEntry two_level_hierarchical_pred_struct[] = {
     {
         0, // GOP Index 0 - Temporal Layer
         0, // GOP Index 0 - Decode Order
+#if LOW_DELAY_TUNE
+        {2, 6, 10, 0},     // GOP Index 0 - Ref List 0
+        {4, 8, 0, 0}      // GOP Index 0 - Ref List 1
+#else
         {2, 4, 0, 0}, // GOP Index 0 - Ref List 0
         {2, 4, 0, 0} // GOP Index 0 - Ref List 1
+#endif
     },
     {
         1, // GOP Index 1 - Temporal Layer
         1, // GOP Index 1 - Decode Order
+#if LOW_DELAY_TUNE
+        { 1, 2 ,3, 5},    // GOP Index 1 - Ref List 0
+        {-1, 0, 0, 0}     // GOP Index 1 - Ref List 1
+#else
         {1, 3, 0, 0}, // GOP Index 1 - Ref List 0
         {-1, 0, 0, 0} // GOP Index 1 - Ref List 1
+#endif
     }};
 
 /************************************************
@@ -133,8 +148,13 @@ PredictionStructureConfigEntry three_level_hierarchical_pred_struct[] = {
     {
         0, // GOP Index 0 - Temporal Layer
         0, // GOP Index 0 - Decode Order
+#if LOW_DELAY_TUNE
+        {4, 12, 0, 0},     // GOP Index 0 - Ref List 0
+        {4, 8, 0, 0}      // GOP Index 0 - Ref List 1
+#else
         {4, 8, 0, 0}, // GOP Index 0 - Ref List 0
         {4, 8, 0, 0} // GOP Index 0 - Ref List 1
+#endif
     },
     {
         2, // GOP Index 1 - Temporal Layer
@@ -2032,12 +2052,34 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     }
 
     if (ref_count_used < MAX_REF_IDX) {
+#if LOW_DELAY_TUNE
+        for (int gop_i = 0; gop_i < 1; ++gop_i) {
+            for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
+                prediction_structure_config_array[0].entry_array[gop_i].ref_list0[i] = 0;
+                prediction_structure_config_array[0].entry_array[gop_i].ref_list1[i] = 0;
+            }
+        }
+        for (int gop_i = 0; gop_i < 2; ++gop_i) {
+            for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
+                prediction_structure_config_array[1].entry_array[gop_i].ref_list0[i] = 0;
+                prediction_structure_config_array[1].entry_array[gop_i].ref_list1[i] = 0;
+            }
+        }
+        for (int gop_i = 0; gop_i < 4; ++gop_i) {
+            for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
+                prediction_structure_config_array[2].entry_array[gop_i].ref_list0[i] = 0;
+                prediction_structure_config_array[2].entry_array[gop_i].ref_list1[i] = 0;
+            }
+        }
+        pred_struct_group_ptr->ref_count_used = ref_count_used;
+#else
         for (int gop_i = 1; gop_i < 4; ++gop_i) {
             for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
                 prediction_structure_config_array[2].entry_array[gop_i].ref_list0[i] = 0;
                 prediction_structure_config_array[2].entry_array[gop_i].ref_list1[i] = 0;
             }
         }
+#endif
 
         for (int gop_i = 1; gop_i < 8; ++gop_i) {
             for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.h
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.h
@@ -179,7 +179,7 @@ typedef struct PredictionStructureGroup {
     PredictionStructure **prediction_structure_ptr_array;
     uint32_t              prediction_structure_count;
     void*                 priv; /* private member*/
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
     uint8_t               ref_count_used;
 #endif
 } PredictionStructureGroup;

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.h
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.h
@@ -179,6 +179,9 @@ typedef struct PredictionStructureGroup {
     PredictionStructure **prediction_structure_ptr_array;
     uint32_t              prediction_structure_count;
     void*                 priv; /* private member*/
+#if LOW_DELAY_TUNE
+    uint8_t               ref_count_used;
+#endif
 } PredictionStructureGroup;
 
 /************************************************

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2732,10 +2732,17 @@ static EbErrorType verify_settings(
         SVT_LOG("Error instance %u: QP must be [0 - %d]\n", channel_number + 1, MAX_QP_VALUE);
         return_error = EB_ErrorBadParameter;
     }
+#if LOW_DELAY_TUNE
+    if (config->hierarchical_levels > 5) {
+        SVT_LOG("Error instance %u: Hierarchical Levels supported [0-5]\n", channel_number + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+#else
     if (config->hierarchical_levels != 3 && config->hierarchical_levels != 4 && config->hierarchical_levels != 5) {
         SVT_LOG("Error instance %u: Hierarchical Levels supported [3-5]\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
+#endif
     if ((config->intra_period_length < -2 || config->intra_period_length > 2*((1 << 30) - 1)) && config->rate_control_mode == 0) {
         SVT_LOG("Error Instance %u: The intra period must be [-2, 2^31-2]  \n", channel_number + 1);
         return_error = EB_ErrorBadParameter;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2732,7 +2732,7 @@ static EbErrorType verify_settings(
         SVT_LOG("Error instance %u: QP must be [0 - %d]\n", channel_number + 1, MAX_QP_VALUE);
         return_error = EB_ErrorBadParameter;
     }
-#if LOW_DELAY_TUNE
+#if TUNE_LOW_DELAY
     if (config->hierarchical_levels > 5) {
         SVT_LOG("Error instance %u: Hierarchical Levels supported [0-5]\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;


### PR DESCRIPTION
# Description

- To support 0B/1B/3B or -hierarchical-level 0/1/2 and tune low delay

# Issue
To support -hierarchical-level 0/1/2 and tune low delay

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@kelvinhu325 
@lijing0010 
@anaghdin 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [] quality
- [ ] memory
- [ ] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
