### PR TITLE
add re-encode support for 2PASS and 2PASS VBR improvement

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -186,7 +186,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **MaxSectionPct** | --maxsection-pct | [0 - ] | 2000 | 2pass VBR GOP max bitrate (percent of target) |
 | **UnderShortPct** | --undershoot-pct | [0 - 100] | 25 | Datarate undershoot (min) target (percent) |
 | **OverShortPct** | --overshoot-pct | [0 - 100] | 25 | Datarate overshoot (max) target (percent) |
-| **RecodeLoop** | --recode-loop | [0 - 3] | 2 | Recode loop levels (0=disable reencode, 1=reencode key frames, 2=reencode base layer frames, 3=reencode all frames) |
+| **RecodeLoop** | --recode-loop | [0 - 3] | 2 | Recode loop levels for 2pass VBR (0=disable reencode, 1=reencode key frames, 2=reencode base layer frames, 3=reencode all frames) |
 
 #### Keyframe Placement Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -186,6 +186,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **MaxSectionPct** | --maxsection-pct | [0 - ] | 2000 | 2pass VBR GOP max bitrate (percent of target) |
 | **UnderShortPct** | --undershoot-pct | [0 - 100] | 25 | Datarate undershoot (min) target (percent) |
 | **OverShortPct** | --overshoot-pct | [0 - 100] | 25 | Datarate overshoot (max) target (percent) |
+| **RecodeLoop** | --recode-loop | [0 - 3] | 2 | Recode loop levels (0=disable reencode, 1=reencode key frames, 2=reencode base layer frames, 3=reencode all frames) |
 
 #### Keyframe Placement Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -116,7 +116,6 @@ extern "C" {
 #define FIX_ONE_MIN_QP_ALLOWED    1 // Set default min_qp_allowed=1 for VBR good quality
 #define FIX_ALLOW_SB128_2PASS_VBR 1 // To allow SB128x128 for 2pass VBR
 #define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
-#define FIX_FIRST_PASS_GM         1 // Fix the GM setting for the first pass
 #define FIX_FIRST_PASS_HME        1 // Fix the hme/me based reference pruning level for the first pass
 
 //FOR DEBUGGING - Do not remove

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -117,6 +117,7 @@ extern "C" {
 #define FIX_ALLOW_SB128_2PASS_VBR 1 // To allow SB128x128 for 2pass VBR
 #define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
 #define FIX_FIRST_PASS_GM         1 // Fix the GM setting for the first pass
+#define FIX_FIRST_PASS_HME        1 // Fix the hme/me based reference pruning level for the first pass
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -111,6 +111,12 @@ extern "C" {
 #define TUNE_TPL_TOWARD_CHROMA                       1 //Tune TPL for better chroma. Only for 240P
 #define TUNE_LOW_DELAY                               1 // Tuning the 0B, 1B and 3B settings to support mingop 1, 2 and 4
 
+#define FEATURE_RE_ENCODE         1 // Add re-encode support
+#define FIX_VBR_LAST_GOP_BITS     1 // Fix 2nd pass last small group too big frame size error
+#define FIX_ONE_MIN_QP_ALLOWED    1 // Set default min_qp_allowed=1 for VBR good quality
+#define FIX_ALLOW_SB128_2PASS_VBR 1 // To allow SB128x128 for 2pass VBR
+#define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
+#define FIX_FIRST_PASS_GM         1 // Fix the GM setting for the first pass
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -527,6 +527,16 @@ typedef struct EbSvtAv1EncConfiguration {
      * value can range from 0-1000. */
     uint32_t over_shoot_pct;
 
+#if FEATURE_RE_ENCODE
+    /* recode_loop indicates the recode levels,
+     * DISALLOW_RECODE = 0, No recode.
+     * ALLOW_RECODE_KFMAXBW = 1, Allow recode for KF and exceeding maximum frame bandwidth.
+     * ALLOW_RECODE_KFARFGF = 2, Allow recode only for KF/ARF/GF frames.
+     * ALLOW_RECODE = 3, Allow recode for all frames based on bitrate constraints.
+     * default is 2 */
+    uint32_t recode_loop;
+#endif
+
     /* Flag to signal the content being a screen sharing content type
     *
     * Default is 0. */

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1895,7 +1895,11 @@ static EbErrorType verify_settings(EbConfig *config, uint32_t channel_number) {
     }
     if (pass != DEFAULT || config->input_stat_file || config->output_stat_file) {
 #if FIX_2PASS_VBR_4L_SUPPORT
+#if TUNE_LOW_DELAY
+        if (config->config.hierarchical_levels > 4)
+#else
         if (config->config.hierarchical_levels != 3 && config->config.hierarchical_levels != 4)
+#endif
 #else
         if (config->config.hierarchical_levels != 4)
 #endif

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -140,6 +140,9 @@
 #define VBR_MAX_SECTION_PCT_TOKEN "-maxsection-pct"
 #define UNDER_SHOOT_PCT_TOKEN "-undershoot-pct"
 #define OVER_SHOOT_PCT_TOKEN "-overshoot-pct"
+#if FEATURE_RE_ENCODE
+#define RECODE_LOOP_TOKEN "-recode-loop"
+#endif
 #define ADAPTIVE_QP_ENABLE_TOKEN "-adaptive-quantization"
 #define LOOK_AHEAD_DIST_TOKEN "-lad"
 #define ENABLE_TPL_LA_TOKEN "-enable-tpl-la"
@@ -549,6 +552,11 @@ static void set_under_shoot_pct(const char *value, EbConfig *cfg) {
 static void set_over_shoot_pct(const char *value, EbConfig *cfg) {
     cfg->config.over_shoot_pct = strtoul(value, NULL, 0);
 };
+#if FEATURE_RE_ENCODE
+static void set_recode_loop(const char *value, EbConfig *cfg) {
+    cfg->config.recode_loop = strtoul(value, NULL, 0);
+};
+#endif
 static void set_adaptive_quantization(const char *value, EbConfig *cfg) {
     cfg->config.enable_adaptive_quantization = (EbBool)strtol(value, NULL, 0);
 };
@@ -844,6 +852,9 @@ ConfigEntry config_entry_rc[] = {
     {SINGLE_INPUT, VBV_BUFSIZE_TOKEN, "VBV buffer size", set_vbv_buf_size},
     {SINGLE_INPUT, UNDER_SHOOT_PCT_TOKEN, "Datarate undershoot (min) target (%)", set_under_shoot_pct},
     {SINGLE_INPUT, OVER_SHOOT_PCT_TOKEN, "Datarate overshoot (max) target (%)", set_over_shoot_pct},
+#if FEATURE_RE_ENCODE
+    {SINGLE_INPUT, RECODE_LOOP_TOKEN, "Recode loop levels ", set_recode_loop},
+#endif
     // Termination
     {SINGLE_INPUT, NULL, NULL, NULL}};
 ConfigEntry config_entry_2p[] = {
@@ -1194,6 +1205,9 @@ ConfigEntry config_entry[] = {
     {SINGLE_INPUT, VBR_MAX_SECTION_PCT_TOKEN, "GOP max bitrate (% of target)", set_vbr_max_section_pct},
     {SINGLE_INPUT, UNDER_SHOOT_PCT_TOKEN, "Datarate undershoot (min) target (%)", set_under_shoot_pct},
     {SINGLE_INPUT, OVER_SHOOT_PCT_TOKEN, "Datarate overshoot (max) target (%)", set_over_shoot_pct},
+#if FEATURE_RE_ENCODE
+    {SINGLE_INPUT, RECODE_LOOP_TOKEN, "Recode loop levels ", set_recode_loop},
+#endif
 
     // DLF
     {SINGLE_INPUT, LOOP_FILTER_DISABLE_TOKEN, "LoopFilterDisable", set_disable_dlf_flag},
@@ -1880,7 +1894,12 @@ static EbErrorType verify_settings(EbConfig *config, uint32_t channel_number) {
         return EB_ErrorBadParameter;
     }
     if (pass != DEFAULT || config->input_stat_file || config->output_stat_file) {
-        if (config->config.hierarchical_levels != 4) {
+#if FIX_2PASS_VBR_4L_SUPPORT
+        if (config->config.hierarchical_levels != 3 && config->config.hierarchical_levels != 4)
+#else
+        if (config->config.hierarchical_levels != 4)
+#endif
+        {
             fprintf(config->error_log_file,
                 "Error instance %u: 2 pass encode for hierarchical_levels %u is not supported\n",
                 channel_number + 1, config->config.hierarchical_levels);

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -103,6 +103,19 @@ enum {
     FAST_DIAMOND = 6
 } UENUM1BYTE(SEARCH_METHODS);
 
+#if FEATURE_RE_ENCODE
+enum {
+    // No recode.
+    DISALLOW_RECODE = 0,
+    // Allow recode for KF and exceeding maximum frame bandwidth.
+    ALLOW_RECODE_KFMAXBW = 1,
+    // Allow recode only for KF/ARF/GF frames.
+    ALLOW_RECODE_KFARFGF = 2,
+    // Allow recode for all frames based on bitrate constraints.
+    ALLOW_RECODE = 3,
+} UENUM1BYTE(RecodeLoopType);
+#endif
+
 /********************************************************/
 /****************** Pre-defined Values ******************/
 /********************************************************/

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2317,6 +2317,12 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                               (sb_origin_y + blk_geom->origin_y) >> MI_SIZE_LOG2,
                               (sb_origin_x + blk_geom->origin_x) >> MI_SIZE_LOG2);
         }
+#if FEATURE_RE_ENCODE
+        if (use_input_stat(scs_ptr) &&
+            blk_it == 0 && sb_origin_x == 0 && blk_geom->origin_x == 0 && sb_origin_y == 0 && blk_geom->origin_y == 0) {
+            pcs_ptr->parent_pcs_ptr->pcs_total_rate = 0;
+        }
+#endif
         if (part != PARTITION_SPLIT && pcs_ptr->parent_pcs_ptr->sb_geom[sb_addr].block_is_allowed[blk_it]) {
             int32_t offset_d1 = ns_blk_offset[(int32_t)part]; //blk_ptr->best_d1_blk; // TOCKECK
             int32_t num_d1_block =
@@ -2360,6 +2366,9 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                     blk_ptr->qindex = sb_ptr->qindex;
                 }
 
+#if FEATURE_RE_ENCODE
+                pcs_ptr->parent_pcs_ptr->pcs_total_rate += blk_ptr->total_rate;
+#endif
                 if (blk_ptr->prediction_mode_flag == INTRA_MODE) {
                     context_ptr->is_inter = blk_ptr->use_intrabc;
                     context_ptr->tot_intra_coded_area += blk_geom->bwidth * blk_geom->bheight;

--- a/Source/Lib/Encoder/Codec/EbCodingUnit.h
+++ b/Source/Lib/Encoder/Codec/EbCodingUnit.h
@@ -417,6 +417,9 @@ typedef struct BlkStruct {
     uint8_t        filter_intra_mode;// ec
     uint8_t        do_not_process_block;
     uint8_t                  use_intrabc;
+#if FEATURE_RE_ENCODE
+    uint64_t       total_rate;
+#endif
 } BlkStruct;
 
 typedef struct TplStats {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -4899,8 +4899,6 @@ static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
     *do_recode = loop == 1;
 
     if (*do_recode) {
-        //int32_t prev_pic_qp = ppcs_ptr->picture_qp;
-        //int32_t prev_qindex = frm_hdr->quantization_params.base_q_idx;
         ppcs_ptr->loop_count++;
 
         frm_hdr->quantization_params.base_q_idx = (uint8_t)CLIP3(
@@ -4912,12 +4910,6 @@ static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
             (uint8_t)CLIP3((int32_t)scs_ptr->static_config.min_qp_allowed,
                     (int32_t)scs_ptr->static_config.max_qp_allowed,
                     (frm_hdr->quantization_params.base_q_idx + 2) >> 2);
-        //printf("do_recode POC%ld Changing QP from %d(%d) to %d(%d), projected_frame_size=%d\n",
-        //        ppcs_ptr->picture_number,
-        //        prev_pic_qp, prev_qindex,
-        //        ppcs_ptr->picture_qp,
-        //        frm_hdr->quantization_params.base_q_idx,
-        //        rc->projected_frame_size);
         pcs_ptr->picture_qp = ppcs_ptr->picture_qp;
 
         // 2pass QPM with tpl_la

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -311,6 +311,13 @@ EbBool assign_enc_dec_segments(EncDecSegments *segmentPtr, uint16_t *segmentInOu
 
         // The entire picture is provided by the MDC process, so
         //   no logic is necessary to clear input dependencies.
+#if FEATURE_RE_ENCODE
+        // Reset enc_dec segments
+        for (uint32_t row_index = 0; row_index < segmentPtr->segment_row_count; ++row_index) {
+            segmentPtr->row_array[row_index].current_seg_index =
+                segmentPtr->row_array[row_index].starting_seg_index;
+        }
+#endif
 
         // Start on Segment 0 immediately
         *segmentInOutIndex  = segmentPtr->row_array[0].current_seg_index;
@@ -4853,6 +4860,92 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
     }
 }
 
+#if FEATURE_RE_ENCODE
+void recode_loop_update_q(
+    PictureParentControlSet *ppcs_ptr,
+    int *const loop, int *const q, int *const q_low,
+    int *const q_high, const int top_index, const int bottom_index,
+    int *const undershoot_seen, int *const overshoot_seen,
+    int *const low_cr_seen, const int loop_count);
+void sb_qp_derivation_tpl_la(PictureControlSet *pcs_ptr);
+void mode_decision_configuration_init_qp_update(PictureControlSet *pcs_ptr);
+void init_enc_dec_segement(PictureParentControlSet *parentpicture_control_set_ptr);
+
+static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
+            SequenceControlSet *scs_ptr, EbBool *do_recode) {
+    PictureParentControlSet *ppcs_ptr = pcs_ptr->parent_pcs_ptr;
+    EncodeContext *const encode_context_ptr = ppcs_ptr->scs_ptr->encode_context_ptr;
+    RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+    int32_t loop = 0;
+    FrameHeader *frm_hdr = &ppcs_ptr->frm_hdr;
+    int32_t q = frm_hdr->quantization_params.base_q_idx;
+    if (ppcs_ptr->loop_count == 0) {
+        ppcs_ptr->q_low  = rc->bottom_index;
+        ppcs_ptr->q_high = rc->top_index;
+    }
+
+    // Update q and decide whether to do a recode loop
+    recode_loop_update_q(ppcs_ptr, &loop, &q,
+            &ppcs_ptr->q_low, &ppcs_ptr->q_high,
+            rc->top_index, rc->bottom_index,
+            &ppcs_ptr->undershoot_seen, &ppcs_ptr->overshoot_seen,
+            &ppcs_ptr->low_cr_seen, ppcs_ptr->loop_count);
+
+    // Special case for overlay frame.
+    if (loop && rc->is_src_frame_alt_ref &&
+        rc->projected_frame_size < rc->max_frame_bandwidth) {
+        loop = 0;
+    }
+    *do_recode = loop == 1;
+
+    if (*do_recode) {
+        int32_t prev_pic_qp = ppcs_ptr->picture_qp;
+        int32_t prev_qindex = frm_hdr->quantization_params.base_q_idx;
+        ppcs_ptr->loop_count++;
+
+        frm_hdr->quantization_params.base_q_idx = (uint8_t)CLIP3(
+                (int32_t)quantizer_to_qindex[scs_ptr->static_config.min_qp_allowed],
+                (int32_t)quantizer_to_qindex[scs_ptr->static_config.max_qp_allowed],
+                q);
+
+        ppcs_ptr->picture_qp =
+            (uint8_t)CLIP3((int32_t)scs_ptr->static_config.min_qp_allowed,
+                    (int32_t)scs_ptr->static_config.max_qp_allowed,
+                    (frm_hdr->quantization_params.base_q_idx + 2) >> 2);
+        printf("do_recode POC%ld Changing QP from %d(%d) to %d(%d), projected_frame_size=%d\n",
+                ppcs_ptr->picture_number,
+                prev_pic_qp, prev_qindex,
+                ppcs_ptr->picture_qp,
+                frm_hdr->quantization_params.base_q_idx,
+                rc->projected_frame_size);
+        pcs_ptr->picture_qp = ppcs_ptr->picture_qp;
+
+        // 2pass QPM with tpl_la
+        if (scs_ptr->static_config.enable_adaptive_quantization == 2 &&
+            !use_output_stat(scs_ptr) &&
+            use_input_stat(scs_ptr) &&
+#if !ENABLE_TPL_ZERO_LAD
+            scs_ptr->static_config.look_ahead_distance != 0 &&
+#endif
+            scs_ptr->static_config.enable_tpl_la &&
+            ppcs_ptr->r0 != 0)
+            sb_qp_derivation_tpl_la(pcs_ptr);
+        else
+        {
+            ppcs_ptr->frm_hdr.delta_q_params.delta_q_present = 0;
+            ppcs_ptr->average_qp = 0;
+            for (int sb_addr = 0; sb_addr < pcs_ptr->sb_total_count_pix; ++sb_addr) {
+                SuperBlock * sb_ptr = pcs_ptr->sb_ptr_array[sb_addr];
+                sb_ptr->qindex   = quantizer_to_qindex[pcs_ptr->picture_qp];
+                ppcs_ptr->average_qp += pcs_ptr->picture_qp;
+            }
+        }
+    } else {
+        ppcs_ptr->loop_count = 0;
+    }
+}
+#endif
+
 /* EncDec (Encode Decode) Kernel */
 /*********************************************************************************
 *
@@ -5312,6 +5405,47 @@ void *mode_decision_kernel(void *input_ptr) {
         svt_release_mutex(pcs_ptr->intra_mutex);
 
         if (last_sb_flag) {
+#if FEATURE_RE_ENCODE
+            EbBool do_recode = EB_FALSE;
+            scs_ptr->encode_context_ptr->recode_loop = scs_ptr->static_config.recode_loop;
+            if (use_input_stat(scs_ptr) &&
+                scs_ptr->encode_context_ptr->recode_loop != DISALLOW_RECODE) {
+                recode_loop_decision_maker(pcs_ptr, scs_ptr, &do_recode);
+            }
+
+            if (do_recode) {
+
+                pcs_ptr->enc_dec_coded_sb_count = 0;
+                last_sb_flag = EB_FALSE;
+                // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
+                if (context_ptr->is_md_rate_estimation_ptr_owner) {
+                    EB_FREE_ARRAY(context_ptr->md_rate_estimation_ptr);
+                    context_ptr->is_md_rate_estimation_ptr_owner = EB_FALSE;
+                }
+                context_ptr->md_rate_estimation_ptr = pcs_ptr->md_rate_estimation_array;
+                // re-init mode decision configuration for qp update for re-encode frame
+                mode_decision_configuration_init_qp_update(pcs_ptr);
+                // init segment for re-encode frame
+                init_enc_dec_segement(pcs_ptr->parent_pcs_ptr);
+                EbObjectWrapper *enc_dec_re_encode_tasks_wrapper_ptr;
+                uint16_t tg_count =
+                    pcs_ptr->parent_pcs_ptr->tile_group_cols * pcs_ptr->parent_pcs_ptr->tile_group_rows;
+                for (uint16_t tile_group_idx = 0; tile_group_idx < tg_count; tile_group_idx++) {
+                    svt_get_empty_object(context_ptr->enc_dec_feedback_fifo_ptr,
+                            &enc_dec_re_encode_tasks_wrapper_ptr);
+
+                    EncDecTasks *enc_dec_re_encode_tasks_ptr = (EncDecTasks *)enc_dec_re_encode_tasks_wrapper_ptr->object_ptr;
+                    enc_dec_re_encode_tasks_ptr->pcs_wrapper_ptr  = enc_dec_tasks_ptr->pcs_wrapper_ptr;
+                    enc_dec_re_encode_tasks_ptr->input_type       = ENCDEC_TASKS_MDC_INPUT;
+                    enc_dec_re_encode_tasks_ptr->tile_group_index = tile_group_idx;
+
+                    // Post the Full Results Object
+                    svt_post_full_object(enc_dec_re_encode_tasks_wrapper_ptr);
+                }
+
+            }
+            else {
+#endif
             // Copy film grain data from parent picture set to the reference object for further reference
             if (scs_ptr->seq_header.film_grain_params_present) {
                 if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
@@ -5357,6 +5491,9 @@ void *mode_decision_kernel(void *input_ptr) {
                 ((pcs_ptr->parent_pcs_ptr->aligned_height + scs_ptr->sb_size_pix - 1) >> sb_size_log2);
             // Post EncDec Results
             svt_post_full_object(enc_dec_results_wrapper_ptr);
+#if FEATURE_RE_ENCODE
+            }
+#endif
         }
         // Release Mode Decision Results
         svt_release_object(enc_dec_tasks_wrapper_ptr);

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -4899,8 +4899,8 @@ static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
     *do_recode = loop == 1;
 
     if (*do_recode) {
-        int32_t prev_pic_qp = ppcs_ptr->picture_qp;
-        int32_t prev_qindex = frm_hdr->quantization_params.base_q_idx;
+        //int32_t prev_pic_qp = ppcs_ptr->picture_qp;
+        //int32_t prev_qindex = frm_hdr->quantization_params.base_q_idx;
         ppcs_ptr->loop_count++;
 
         frm_hdr->quantization_params.base_q_idx = (uint8_t)CLIP3(
@@ -4912,12 +4912,12 @@ static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
             (uint8_t)CLIP3((int32_t)scs_ptr->static_config.min_qp_allowed,
                     (int32_t)scs_ptr->static_config.max_qp_allowed,
                     (frm_hdr->quantization_params.base_q_idx + 2) >> 2);
-        printf("do_recode POC%ld Changing QP from %d(%d) to %d(%d), projected_frame_size=%d\n",
-                ppcs_ptr->picture_number,
-                prev_pic_qp, prev_qindex,
-                ppcs_ptr->picture_qp,
-                frm_hdr->quantization_params.base_q_idx,
-                rc->projected_frame_size);
+        //printf("do_recode POC%ld Changing QP from %d(%d) to %d(%d), projected_frame_size=%d\n",
+        //        ppcs_ptr->picture_number,
+        //        prev_pic_qp, prev_qindex,
+        //        ppcs_ptr->picture_qp,
+        //        frm_hdr->quantization_params.base_q_idx,
+        //        rc->projected_frame_size);
         pcs_ptr->picture_qp = ppcs_ptr->picture_qp;
 
         // 2pass QPM with tpl_la

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.c
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.c
@@ -179,6 +179,10 @@ EbErrorType encode_context_ctor(EncodeContext* encode_context_ptr, EbPtr object_
     encode_context_ptr->enc_mode                      = SPEED_CONTROL_INIT_MOD;
     encode_context_ptr->previous_selected_ref_qp      = 32;
     encode_context_ptr->max_coded_poc_selected_ref_qp = 32;
+#if FEATURE_RE_ENCODE
+    encode_context_ptr->recode_tolerance              = 25;
+    encode_context_ptr->rc_cfg.min_cr                 = 0;
+#endif
     EB_CREATE_MUTEX(encode_context_ptr->shared_reference_mutex);
     EB_CREATE_MUTEX(encode_context_ptr->stat_file_mutex);
     encode_context_ptr->num_lap_buffers = 0; //lap not supported for now

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -209,6 +209,12 @@ typedef struct EncodeContext {
     STATS_BUFFER_CTX stats_buf_context;
     SvtAv1FixedBuf rc_twopass_stats_in; // replaced oxcf->two_pass_cfg.stats_in in aom
     FirstPassStatsOut stats_out;
+#if FEATURE_RE_ENCODE
+    RecodeLoopType recode_loop;
+    // This feature controls the tolerence vs target used in deciding whether to
+    // recode a frame. It has no meaning if recode is disabled.
+    int recode_tolerance;
+#endif
 } EncodeContext;
 
 typedef struct EncodeContextInitData {

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5607,7 +5607,7 @@ uint32_t product_full_mode_decision(
         }
     }
 #if FEATURE_RE_ENCODE
-    if (/*use_input_stat(scs_ptr) && */(context_ptr->pd_pass == PD_PASS_2)) {
+    if (/*use_input_stat(scs_ptr) && */context_ptr->pd_pass == PD_PASS_2) {
         blk_ptr->total_rate = buffer_ptr_array[lowest_cost_index]->candidate_ptr->total_rate;
     }
 #endif

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5607,7 +5607,7 @@ uint32_t product_full_mode_decision(
         }
     }
 #if FEATURE_RE_ENCODE
-    if (/*use_input_stat(scs_ptr) && */context_ptr->pd_pass == PD_PASS_2) {
+    if (context_ptr->pd_pass == PD_PASS_2) {
         blk_ptr->total_rate = buffer_ptr_array[lowest_cost_index]->candidate_ptr->total_rate;
     }
 #endif

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5606,6 +5606,11 @@ uint32_t product_full_mode_decision(
             lowest_cost = *(buffer_ptr_array[cand_index]->full_cost_ptr);
         }
     }
+#if FEATURE_RE_ENCODE
+    if (/*use_input_stat(scs_ptr) && */(context_ptr->pd_pass == PD_PASS_2)) {
+        blk_ptr->total_rate = buffer_ptr_array[lowest_cost_index]->candidate_ptr->total_rate;
+    }
+#endif
 
     candidate_ptr = buffer_ptr_array[lowest_cost_index]->candidate_ptr;
     if (context_ptr->blk_lambda_tuning){

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -448,10 +448,6 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
     } else
         context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
 #endif
-#if FIX_FIRST_PASS_GM
-    if (use_output_stat(scs_ptr))
-        context_ptr->me_context_ptr->compute_global_motion = EB_FALSE; //gm_level = 0;
-#endif
 
     // Set hme/me based reference pruning level (0-4)
     if (enc_mode <= ENC_MR)

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -448,6 +448,10 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
     } else
         context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
 #endif
+#if FIX_FIRST_PASS_GM
+    if (use_output_stat(scs_ptr))
+        context_ptr->me_context_ptr->compute_global_motion = EB_FALSE; //gm_level = 0;
+#endif
 
     // Set hme/me based reference pruning level (0-4)
     if (enc_mode <= ENC_MR)

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1418,6 +1418,13 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     object_ptr->frame_height = init_data_ptr->picture_height;
 
     object_ptr->superres_denom = SCALE_NUMERATOR;
+#if FEATURE_RE_ENCODE
+     // Loop variables
+    object_ptr->loop_count = 0;
+    object_ptr->overshoot_seen = 0;
+    object_ptr->undershoot_seen = 0;
+    object_ptr->low_cr_seen = 0;
+#endif
 
     return return_error;
 }

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -968,6 +968,16 @@ typedef struct PictureParentControlSet {
 #if FEATURE_GM_OPT
     GmControls gm_ctrls;
 #endif
+#if FEATURE_RE_ENCODE
+    // Loop variables
+    int q_low;
+    int q_high;
+    int loop_count;
+    int overshoot_seen;
+    int undershoot_seen;
+    int low_cr_seen;
+    uint64_t pcs_total_rate;
+#endif
 } PictureParentControlSet;
 
 typedef struct PictureControlSetInitData {

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -576,6 +576,135 @@ static EbErrorType tpl_init_pcs_tpl_data(
     return 0;
 }
 #endif
+
+#if FEATURE_RE_ENCODE
+void init_enc_dec_segement(PictureParentControlSet *parentpicture_control_set_ptr) {
+    SequenceControlSet *scs_ptr = (SequenceControlSet *)parentpicture_control_set_ptr->scs_wrapper_ptr->object_ptr;
+    uint8_t pic_width_in_sb = (uint8_t)((parentpicture_control_set_ptr->aligned_width +
+                scs_ptr->sb_size_pix - 1) /
+            scs_ptr->sb_size_pix);
+    uint8_t picture_height_in_sb = (uint8_t)((parentpicture_control_set_ptr->aligned_height +
+                scs_ptr->sb_size_pix - 1) /
+            scs_ptr->sb_size_pix);
+    set_tile_info(parentpicture_control_set_ptr);
+    int sb_size_log2 = scs_ptr->seq_header.sb_size_log2;
+    uint32_t enc_dec_seg_col_cnt = scs_ptr->enc_dec_segment_col_count_array[parentpicture_control_set_ptr->temporal_layer_index];
+    uint32_t enc_dec_seg_row_cnt = scs_ptr->enc_dec_segment_row_count_array[parentpicture_control_set_ptr->temporal_layer_index];
+    Av1Common *const cm = parentpicture_control_set_ptr->av1_cm;
+    const int tile_cols = parentpicture_control_set_ptr->av1_cm->tiles_info.tile_cols;
+    const int tile_rows = parentpicture_control_set_ptr->av1_cm->tiles_info.tile_rows;
+    uint8_t tile_group_cols = MIN(
+            tile_cols,
+            scs_ptr
+            ->tile_group_col_count_array[parentpicture_control_set_ptr->temporal_layer_index]);
+    uint8_t tile_group_rows = MIN(
+            tile_rows,
+            scs_ptr
+            ->tile_group_row_count_array[parentpicture_control_set_ptr->temporal_layer_index]);
+
+    if (tile_group_cols * tile_group_rows > 1) {
+        enc_dec_seg_col_cnt = MIN(enc_dec_seg_col_cnt,
+                (uint8_t)(pic_width_in_sb / tile_group_cols));
+        enc_dec_seg_row_cnt = MIN(
+                enc_dec_seg_row_cnt,
+                (uint8_t)(picture_height_in_sb / tile_group_rows));
+    }
+    parentpicture_control_set_ptr->tile_group_cols = tile_group_cols;
+    parentpicture_control_set_ptr->tile_group_rows = tile_group_rows;
+
+    uint8_t tile_group_col_start_tile_idx[1024];
+    uint8_t tile_group_row_start_tile_idx[1024];
+
+    // Get the tile start index for tile group
+    for (uint8_t c = 0; c <= tile_group_cols; c++) {
+        tile_group_col_start_tile_idx[c] = c * tile_cols / tile_group_cols;
+    }
+    for (uint8_t r = 0; r <= tile_group_rows; r++) {
+        tile_group_row_start_tile_idx[r] = r * tile_rows / tile_group_rows;
+    }
+    for (uint8_t r = 0; r < tile_group_rows; r++) {
+        for (uint8_t c = 0; c < tile_group_cols; c++) {
+            uint16_t tile_group_idx        = r * tile_group_cols + c;
+            uint16_t top_left_tile_col_idx = tile_group_col_start_tile_idx[c];
+            uint16_t top_left_tile_row_idx = tile_group_row_start_tile_idx[r];
+            uint16_t bottom_right_tile_col_idx =
+                tile_group_col_start_tile_idx[c + 1];
+            uint16_t bottom_right_tile_row_idx =
+                tile_group_row_start_tile_idx[r + 1];
+
+            TileGroupInfo *tg_info_ptr =
+                &parentpicture_control_set_ptr->tile_group_info[tile_group_idx];
+
+            tg_info_ptr->tile_group_tile_start_x = top_left_tile_col_idx;
+            tg_info_ptr->tile_group_tile_end_x   = bottom_right_tile_col_idx;
+
+            tg_info_ptr->tile_group_tile_start_y = top_left_tile_row_idx;
+            tg_info_ptr->tile_group_tile_end_y   = bottom_right_tile_row_idx;
+
+            tg_info_ptr->tile_group_sb_start_x =
+                cm->tiles_info.tile_col_start_mi[top_left_tile_col_idx] >>
+                sb_size_log2;
+            tg_info_ptr->tile_group_sb_start_y =
+                cm->tiles_info.tile_row_start_mi[top_left_tile_row_idx] >>
+                sb_size_log2;
+
+            // Get the SB end of the bottom right tile
+            tg_info_ptr->tile_group_sb_end_x =
+                (cm->tiles_info.tile_col_start_mi[bottom_right_tile_col_idx] >>
+                 sb_size_log2);
+            tg_info_ptr->tile_group_sb_end_y =
+                (cm->tiles_info.tile_row_start_mi[bottom_right_tile_row_idx] >>
+                 sb_size_log2);
+
+            // Get the width/height of tile group in SB
+            tg_info_ptr->tile_group_height_in_sb =
+                tg_info_ptr->tile_group_sb_end_y -
+                tg_info_ptr->tile_group_sb_start_y;
+            tg_info_ptr->tile_group_width_in_sb =
+                tg_info_ptr->tile_group_sb_end_x -
+                tg_info_ptr->tile_group_sb_start_x;
+
+            // Init segments within the tile group
+            enc_dec_segments_init(
+                    parentpicture_control_set_ptr->child_pcs->enc_dec_segment_ctrl[tile_group_idx],
+                    enc_dec_seg_col_cnt,
+                    enc_dec_seg_row_cnt,
+                    tg_info_ptr->tile_group_width_in_sb,
+                    tg_info_ptr->tile_group_height_in_sb);
+            // Enable tile parallelism in Entropy Coding stage
+            for (uint16_t r = top_left_tile_row_idx;
+                    r < bottom_right_tile_row_idx;
+                    r++) {
+                for (uint16_t c = top_left_tile_col_idx;
+                        c < bottom_right_tile_col_idx;
+                        c++) {
+                    uint16_t tileIdx = r * tile_cols + c;
+                    parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                        ->entropy_coding_current_row = 0;
+                    parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                        ->entropy_coding_current_available_row = 0;
+                    parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                        ->entropy_coding_row_count =
+                        (cm->tiles_info.tile_row_start_mi[r + 1] -
+                         cm->tiles_info.tile_row_start_mi[r]) >>
+                        sb_size_log2;
+                    parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                        ->entropy_coding_in_progress = EB_FALSE;
+                    parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                        ->entropy_coding_tile_done = EB_FALSE;
+
+                    for (unsigned rowIndex = 0; rowIndex < MAX_SB_ROWS;
+                            ++rowIndex) {
+                        parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
+                            ->entropy_coding_row_array[rowIndex] = EB_FALSE;
+                    }
+                }
+            }
+            parentpicture_control_set_ptr->child_pcs->entropy_coding_pic_reset_flag = EB_TRUE;
+        }
+    }
+}
+#endif
 /* Picture Manager Kernel */
 
 /***************************************************************************************************
@@ -1040,6 +1169,18 @@ void *picture_manager_kernel(void *input_ptr) {
                                        entry_scs_ptr->sb_size_pix - 1) /
                                       entry_scs_ptr->sb_size_pix);
 
+#if FEATURE_RE_ENCODE
+                        init_enc_dec_segement(entry_pcs_ptr);
+
+                        int      sb_size_log2    = entry_scs_ptr->seq_header.sb_size_log2;
+                        struct PictureParentControlSet *ppcs_ptr = child_pcs_ptr->parent_pcs_ptr;
+                        const int tile_cols = ppcs_ptr->av1_cm->tiles_info.tile_cols;
+                        const int tile_rows = ppcs_ptr->av1_cm->tiles_info.tile_rows;
+                        Av1Common *const                cm       = ppcs_ptr->av1_cm;
+                        uint16_t                        tile_row, tile_col;
+                        uint32_t                        x_sb_index, y_sb_index;
+                        TileInfo  tile_info;
+#else
                         set_tile_info(entry_pcs_ptr);
 
                         int      sb_size_log2    = entry_scs_ptr->seq_header.sb_size_log2;
@@ -1169,6 +1310,7 @@ void *picture_manager_kernel(void *input_ptr) {
                                 child_pcs_ptr->entropy_coding_pic_reset_flag = EB_TRUE;
                             }
                         }
+#endif
 
                         child_pcs_ptr->sb_total_count_pix = pic_width_in_sb * picture_height_in_sb;
 

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -672,21 +672,21 @@ void init_enc_dec_segement(PictureParentControlSet *parentpicture_control_set_pt
                     tg_info_ptr->tile_group_width_in_sb,
                     tg_info_ptr->tile_group_height_in_sb);
             // Enable tile parallelism in Entropy Coding stage
-            for (uint16_t r = top_left_tile_row_idx;
-                    r < bottom_right_tile_row_idx;
-                    r++) {
-                for (uint16_t c = top_left_tile_col_idx;
-                        c < bottom_right_tile_col_idx;
-                        c++) {
-                    uint16_t tileIdx = r * tile_cols + c;
+            for (uint16_t s = top_left_tile_row_idx;
+                    s < bottom_right_tile_row_idx;
+                    s++) {
+                for (uint16_t d = top_left_tile_col_idx;
+                        d < bottom_right_tile_col_idx;
+                        d++) {
+                    uint16_t tileIdx = s * tile_cols + d;
                     parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
                         ->entropy_coding_current_row = 0;
                     parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
                         ->entropy_coding_current_available_row = 0;
                     parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
                         ->entropy_coding_row_count =
-                        (cm->tiles_info.tile_row_start_mi[r + 1] -
-                         cm->tiles_info.tile_row_start_mi[r]) >>
+                        (cm->tiles_info.tile_row_start_mi[s + 1] -
+                         cm->tiles_info.tile_row_start_mi[s]) >>
                         sb_size_log2;
                     parentpicture_control_set_ptr->child_pcs->entropy_coding_info[tileIdx]
                         ->entropy_coding_in_progress = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -6396,7 +6396,11 @@ static void sb_setup_lambda(PictureControlSet *pcs_ptr,
  * Calculates the QP per SB based on the tpl statistics
  * used in one pass and second pass of two pass encoding
  ******************************************************/
+#if FEATURE_RE_ENCODE
+void sb_qp_derivation_tpl_la(
+#else
 static void sb_qp_derivation_tpl_la(
+#endif
     PictureControlSet         *pcs_ptr) {
 
     PictureParentControlSet   *ppcs_ptr = pcs_ptr->parent_pcs_ptr;
@@ -6873,11 +6877,28 @@ static void set_rate_correction_factor(PictureParentControlSet *ppcs_ptr, double
 }
 
 // Calculate rate for the given 'q'.
+#if FEATURE_RE_ENCODE
+static int get_bits_per_mb(PictureParentControlSet *ppcs_ptr, int use_cyclic_refresh,
+#else
 static int get_bits_per_mb(PictureControlSet *pcs_ptr, int use_cyclic_refresh,
+#endif
                            double correction_factor, int q) {
+#if FEATURE_RE_ENCODE
+  SequenceControlSet *scs_ptr = ppcs_ptr->scs_ptr;
+#else
   SequenceControlSet *scs_ptr = pcs_ptr->parent_pcs_ptr->scs_ptr;
+#endif
   return use_cyclic_refresh
              ? 0/*av1_cyclic_refresh_rc_bits_per_mb(cpi, q, correction_factor)*/
+#if FEATURE_RE_ENCODE
+             : svt_av1_rc_bits_per_mb(ppcs_ptr->frm_hdr.frame_type, q,
+#if TUNE_SC_QPS_IMP
+                correction_factor, scs_ptr->static_config.encoder_bit_depth,
+                 pcs_ptr->parent_pcs_ptr->sc_content_detected);
+#else
+                 correction_factor, scs_ptr->static_config.encoder_bit_depth);
+#endif
+#else
              : svt_av1_rc_bits_per_mb(pcs_ptr->parent_pcs_ptr->frm_hdr.frame_type, q,
 #if TUNE_SC_QPS_IMP
                 correction_factor, scs_ptr->static_config.encoder_bit_depth,
@@ -6892,7 +6913,11 @@ static int get_bits_per_mb(PictureControlSet *pcs_ptr, int use_cyclic_refresh,
 // the two rates is closer to the desired rate.
 // Also, respects the selected aq_mode when computing the rate.
 static int find_closest_qindex_by_rate(int desired_bits_per_mb,
+#if FEATURE_RE_ENCODE
+                                       PictureParentControlSet *ppcs_ptr,
+#else
                                        PictureControlSet *pcs_ptr,
+#endif
                                        double correction_factor,
                                        int best_qindex, int worst_qindex) {
   const int use_cyclic_refresh = 0/*cpi->oxcf.q_cfg.aq_mode == CYCLIC_REFRESH_AQ &&
@@ -6905,7 +6930,11 @@ static int find_closest_qindex_by_rate(int desired_bits_per_mb,
   while (low < high) {
     const int mid = (low + high) >> 1;
     const int mid_bits_per_mb =
+#if FEATURE_RE_ENCODE
+        get_bits_per_mb(ppcs_ptr, use_cyclic_refresh, correction_factor, mid);
+#else
         get_bits_per_mb(pcs_ptr, use_cyclic_refresh, correction_factor, mid);
+#endif
     if (mid_bits_per_mb > desired_bits_per_mb) {
       low = mid + 1;
     } else {
@@ -6917,7 +6946,11 @@ static int find_closest_qindex_by_rate(int desired_bits_per_mb,
   // Calculate rate difference of this q index from the desired rate.
   const int curr_q = low;
   const int curr_bits_per_mb =
+#if FEATURE_RE_ENCODE
+      get_bits_per_mb(ppcs_ptr, use_cyclic_refresh, correction_factor, curr_q);
+#else
       get_bits_per_mb(pcs_ptr, use_cyclic_refresh, correction_factor, curr_q);
+#endif
   const int curr_bit_diff = (curr_bits_per_mb <= desired_bits_per_mb)
                                 ? desired_bits_per_mb - curr_bits_per_mb
                                 : INT_MAX;
@@ -6931,7 +6964,11 @@ static int find_closest_qindex_by_rate(int desired_bits_per_mb,
     prev_bit_diff = INT_MAX;
   } else {
     const int prev_bits_per_mb =
+#if FEATURE_RE_ENCODE
+        get_bits_per_mb(ppcs_ptr, use_cyclic_refresh, correction_factor, prev_q);
+#else
         get_bits_per_mb(pcs_ptr, use_cyclic_refresh, correction_factor, prev_q);
+#endif
     assert(prev_bits_per_mb > desired_bits_per_mb);
     prev_bit_diff = prev_bits_per_mb - desired_bits_per_mb;
   }
@@ -6941,17 +6978,29 @@ static int find_closest_qindex_by_rate(int desired_bits_per_mb,
   return (curr_bit_diff <= prev_bit_diff) ? curr_q : prev_q;
 }
 
+#if FEATURE_RE_ENCODE
+static int av1_rc_regulate_q(PictureParentControlSet *ppcs_ptr, int target_bits_per_frame,
+#else
 static int av1_rc_regulate_q(PictureControlSet *pcs_ptr, int target_bits_per_frame,
+#endif
                       int active_best_quality, int active_worst_quality,
                       int width, int height) {
   const int MBs = ((width + 15) / 16) * ((height + 15) / 16);//av1_get_MBs(width, height);
   const double correction_factor =
+#if FEATURE_RE_ENCODE
+      get_rate_correction_factor(ppcs_ptr/*, width, height*/);
+#else
       get_rate_correction_factor(pcs_ptr->parent_pcs_ptr/*, width, height*/);
+#endif
   const int target_bits_per_mb =
       (int)(((uint64_t)target_bits_per_frame << BPER_MB_NORMBITS) / MBs);
 
   int q =
+#if FEATURE_RE_ENCODE
+      find_closest_qindex_by_rate(target_bits_per_mb, ppcs_ptr, correction_factor,
+#else
       find_closest_qindex_by_rate(target_bits_per_mb, pcs_ptr, correction_factor,
+#endif
                                   active_best_quality, active_worst_quality);
 
   return q;
@@ -6985,8 +7034,13 @@ static int get_q(PictureControlSet *pcs_ptr,
     }
     q = clamp(q, active_best_quality, active_worst_quality);
   } else {
+#if FEATURE_RE_ENCODE
+    q = av1_rc_regulate_q(pcs_ptr->parent_pcs_ptr, rc->this_frame_target, active_best_quality,
+                          active_worst_quality, width, height);
+#else
     q = av1_rc_regulate_q(pcs_ptr, rc->this_frame_target, active_best_quality,
                           active_worst_quality, width, height);
+#endif
     if (q > active_worst_quality) {
       // Special case when we are targeting the max allowed rate.
       if (rc->this_frame_target < rc->max_frame_bandwidth) {
@@ -7050,6 +7104,13 @@ static int rc_pick_q_and_bounds(PictureControlSet *pcs_ptr) {
         active_worst_quality = q;
     }
 
+#if FEATURE_RE_ENCODE
+    rc->top_index = active_worst_quality;
+    rc->bottom_index = active_best_quality;
+
+    assert(rc->top_index <= rc->worst_quality && rc->top_index >= rc->best_quality);
+    assert(rc->bottom_index <= rc->worst_quality && rc->bottom_index >= rc->best_quality);
+#endif
     assert(q <= rc->worst_quality && q >= rc->best_quality);
 
     if (gf_group->update_type[pcs_ptr->parent_pcs_ptr->gf_group_index] == ARF_UPDATE) rc->arf_q = q;
@@ -7470,6 +7531,322 @@ static void av1_set_target_rate(PictureControlSet *pcs_ptr, int width, int heigh
         vbr_rate_correction(pcs_ptr, &target_rate);
     av1_rc_set_frame_target(pcs_ptr, target_rate, width, height);
 }
+
+#if FEATURE_RE_ENCODE
+static double av1_get_compression_ratio(PictureParentControlSet *ppcs_ptr,
+                                 size_t encoded_frame_size) {
+  const int upscaled_width = ppcs_ptr->av1_cm->frm_size.superres_upscaled_width;
+  const int height = ppcs_ptr->av1_cm->frm_size.frame_height;//cm->height;
+  const int luma_pic_size = upscaled_width * height;
+  const BITSTREAM_PROFILE profile = ppcs_ptr->scs_ptr->seq_header.seq_profile;
+  const int pic_size_profile_factor =
+      profile == PROFILE_0 ? 15 : (profile == PROFILE_1 ? 30 : 36);
+  encoded_frame_size =
+      (encoded_frame_size > 129 ? encoded_frame_size - 128 : 1);
+  const size_t uncompressed_frame_size =
+      (luma_pic_size * pic_size_profile_factor) >> 3;
+  return uncompressed_frame_size / (double)encoded_frame_size;
+}
+
+static void av1_rc_compute_frame_size_bounds(PictureParentControlSet *ppcs_ptr, int frame_target,
+                                      int *frame_under_shoot_limit,
+                                      int *frame_over_shoot_limit) {
+  EncodeContext *const encode_context_ptr = ppcs_ptr->scs_ptr->encode_context_ptr;
+  RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+  const RateControlCfg *const rc_cfg = &encode_context_ptr->rc_cfg;
+  if (rc_cfg->mode == AOM_Q) {
+    *frame_under_shoot_limit = 0;
+    *frame_over_shoot_limit = INT_MAX;
+  } else {
+    // For very small rate targets where the fractional adjustment
+    // may be tiny make sure there is at least a minimum range.
+    assert(encode_context_ptr->recode_tolerance <= 100);
+    const int tolerance = (int)AOMMAX(
+        100, ((int64_t)encode_context_ptr->recode_tolerance * frame_target) / 100);
+    *frame_under_shoot_limit = AOMMAX(frame_target - tolerance, 0);
+    *frame_over_shoot_limit =
+        AOMMIN(frame_target + tolerance, rc->max_frame_bandwidth);
+  }
+}
+
+// Function to test for conditions that indicate we should loop
+// back and recode a frame.
+static AOM_INLINE int recode_loop_test(PictureParentControlSet *ppcs_ptr, int high_limit,
+                                       int low_limit, int q, int maxq,
+                                       int minq) {
+  EncodeContext *const encode_context_ptr = ppcs_ptr->scs_ptr->encode_context_ptr;
+  RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+  const RateControlCfg *const rc_cfg = &encode_context_ptr->rc_cfg;
+  const int frame_is_kfgfarf = frame_is_kf_gf_arf(ppcs_ptr);
+  int force_recode = 0;
+
+  if ((rc->projected_frame_size >= rc->max_frame_bandwidth) ||
+      (encode_context_ptr->recode_loop == ALLOW_RECODE) ||
+      (frame_is_kfgfarf &&
+       (encode_context_ptr->recode_loop >= ALLOW_RECODE_KFMAXBW)
+       )) {
+    // TODO(agrange) high_limit could be greater than the scale-down threshold.
+    if ((rc->projected_frame_size > high_limit && q < maxq) ||
+        (rc->projected_frame_size < low_limit && q > minq)) {
+      force_recode = 1;
+    } else if (rc_cfg->mode == AOM_CQ) {
+      // Deal with frame undershoot and whether or not we are
+      // below the automatically set cq level.
+      if (q > rc_cfg->cq_level &&
+          rc->projected_frame_size < ((rc->this_frame_target * 7) >> 3)) {
+        force_recode = 1;
+      }
+    }
+  }
+  return force_recode;
+}
+
+static int get_regulated_q_overshoot(PictureParentControlSet *ppcs_ptr, int q_low,
+                                     int q_high, int top_index,
+                                     int bottom_index) {
+  EncodeContext *const encode_context_ptr = ppcs_ptr->scs_ptr->encode_context_ptr;
+  RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+  const int width  = ppcs_ptr->av1_cm->frm_size.frame_width;
+  const int height = ppcs_ptr->av1_cm->frm_size.frame_height;
+
+  av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+
+  int q_regulated =
+      av1_rc_regulate_q(ppcs_ptr, rc->this_frame_target, bottom_index,
+                        AOMMAX(q_high, top_index), width, height);
+
+  int retries = 0;
+  while (q_regulated < q_low && retries < 10) {
+    av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+    q_regulated =
+        av1_rc_regulate_q(ppcs_ptr, rc->this_frame_target, bottom_index,
+                          AOMMAX(q_high, top_index), width, height);
+    retries++;
+  }
+  return q_regulated;
+}
+
+static AOM_INLINE int get_regulated_q_undershoot(PictureParentControlSet *ppcs_ptr,
+                                                 int q_high, int top_index,
+                                                 int bottom_index) {
+  EncodeContext *const encode_context_ptr = ppcs_ptr->scs_ptr->encode_context_ptr;
+  RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+  const int width  = ppcs_ptr->av1_cm->frm_size.frame_width;
+  const int height = ppcs_ptr->av1_cm->frm_size.frame_height;
+
+  av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+  int q_regulated = av1_rc_regulate_q(ppcs_ptr, rc->this_frame_target, bottom_index,
+                                      top_index, width, height);
+
+  int retries = 0;
+  while (q_regulated > q_high && retries < 10) {
+    av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+    q_regulated = av1_rc_regulate_q(ppcs_ptr, rc->this_frame_target, bottom_index,
+                                    top_index, width, height);
+    retries++;
+  }
+  return q_regulated;
+}
+
+void recode_loop_update_q(
+    PictureParentControlSet *ppcs_ptr,
+    int *const loop, int *const q, int *const q_low,
+    int *const q_high, const int top_index, const int bottom_index,
+    int *const undershoot_seen, int *const overshoot_seen,
+    int *const low_cr_seen, const int loop_count) {
+  SequenceControlSet *const scs_ptr = ppcs_ptr->scs_ptr;
+  EncodeContext *const encode_context_ptr = scs_ptr->encode_context_ptr;
+  RATE_CONTROL *const rc = &(encode_context_ptr->rc);
+  const RateControlCfg *const rc_cfg = &encode_context_ptr->rc_cfg;
+  const int do_dummy_pack = (
+         scs_ptr->encode_context_ptr->recode_loop >= ALLOW_RECODE_KFMAXBW &&
+         rc_cfg->mode != AOM_Q) ||
+         rc_cfg->min_cr > 0;
+  rc->projected_frame_size = do_dummy_pack ? (((ppcs_ptr->pcs_total_rate + (1 << (AV1_PROB_COST_SHIFT - 1))) >> AV1_PROB_COST_SHIFT)
+                                             + ((ppcs_ptr->frm_hdr.frame_type == KEY_FRAME) ? 13  : 0))
+                                           : 0;
+  if (ppcs_ptr->loop_count) {
+    // scale rc->projected_frame_size with *0.8 for loop_count>=1
+    rc->projected_frame_size = (rc->projected_frame_size * 8) / 10;
+  }
+  *loop = 0;
+  if (scs_ptr->encode_context_ptr->recode_loop == ALLOW_RECODE_KFMAXBW &&
+      ppcs_ptr->frm_hdr.frame_type != KEY_FRAME) {
+    // skip re-encode for inter frame when setting -recode-loop 1
+    return;
+  }
+
+  const int min_cr = rc_cfg->min_cr;
+  if (min_cr > 0) {
+    //aom_clear_system_state();
+    const double compression_ratio =
+        av1_get_compression_ratio(ppcs_ptr, rc->projected_frame_size >> 3);
+    const double target_cr = min_cr / 100.0;
+    if (compression_ratio < target_cr) {
+      *low_cr_seen = 1;
+      if (*q < rc->worst_quality) {
+        const double cr_ratio = target_cr / compression_ratio;
+        const int projected_q = AOMMAX(*q + 1, (int)(*q * cr_ratio * cr_ratio));
+        *q = AOMMIN(AOMMIN(projected_q, *q + 32), rc->worst_quality);
+        *q_low = AOMMAX(*q, *q_low);
+        *q_high = AOMMAX(*q, *q_high);
+        *loop = 1;
+      }
+    }
+    if (*low_cr_seen) return;
+  }
+
+  if (rc_cfg->mode == AOM_Q) return;
+
+  const int last_q = *q;
+  int frame_over_shoot_limit = 0, frame_under_shoot_limit = 0;
+  av1_rc_compute_frame_size_bounds(ppcs_ptr, rc->this_frame_target,
+                                   &frame_under_shoot_limit,
+                                   &frame_over_shoot_limit);
+  if (frame_over_shoot_limit == 0) frame_over_shoot_limit = 1;
+
+#if 0
+  if (ppcs_ptr->frm_hdr.frame_type == KEY_FRAME && rc->this_key_frame_forced &&
+      rc->projected_frame_size < rc->max_frame_bandwidth) {
+    AV1_COMMON *const cm = &ppcs_ptr->av1_cm;
+    int64_t kf_err;
+    const int64_t high_err_target = cpi->ambient_err;
+    const int64_t low_err_target = cpi->ambient_err >> 1;
+
+#if CONFIG_AV1_HIGHBITDEPTH
+    if (cm->seq_params.use_highbitdepth) {
+      kf_err = aom_highbd_get_y_sse(cpi->source, &cm->cur_frame->buf);
+    } else {
+      kf_err = aom_get_y_sse(cpi->source, &cm->cur_frame->buf);
+    }
+#else
+    kf_err = aom_get_y_sse(cpi->source, &cm->cur_frame->buf);
+#endif
+    // Prevent possible divide by zero error below for perfect KF
+    kf_err += !kf_err;
+
+    // The key frame is not good enough or we can afford
+    // to make it better without undue risk of popping.
+    if ((kf_err > high_err_target &&
+         rc->projected_frame_size <= frame_over_shoot_limit) ||
+        (kf_err > low_err_target &&
+         rc->projected_frame_size <= frame_under_shoot_limit)) {
+      // Lower q_high
+      *q_high = AOMMAX(*q - 1, *q_low);
+
+      // Adjust Q
+      *q = (int)((*q * high_err_target) / kf_err);
+      *q = AOMMIN(*q, (*q_high + *q_low) >> 1);
+    } else if (kf_err < low_err_target &&
+               rc->projected_frame_size >= frame_under_shoot_limit) {
+      // The key frame is much better than the previous frame
+      // Raise q_low
+      *q_low = AOMMIN(*q + 1, *q_high);
+
+      // Adjust Q
+      *q = (int)((*q * low_err_target) / kf_err);
+      *q = AOMMIN(*q, (*q_high + *q_low + 1) >> 1);
+    }
+
+    // Clamp Q to upper and lower limits:
+    *q = clamp(*q, *q_low, *q_high);
+    *loop = (*q != last_q);
+    return;
+  }
+#endif
+
+  if (recode_loop_test(ppcs_ptr, frame_over_shoot_limit, frame_under_shoot_limit, *q,
+                       AOMMAX(*q_high, top_index), bottom_index)) {
+      const int width  = ppcs_ptr->av1_cm->frm_size.frame_width;
+      const int height = ppcs_ptr->av1_cm->frm_size.frame_height;
+    // Is the projected frame size out of range and are we allowed
+    // to attempt to recode.
+
+    // Frame size out of permitted range:
+    // Update correction factor & compute new Q to try...
+    // Frame is too large
+    if (rc->projected_frame_size > rc->this_frame_target) {
+      // Special case if the projected size is > the max allowed.
+      if (*q == *q_high &&
+          rc->projected_frame_size >= rc->max_frame_bandwidth) {
+        const double q_val_high_current =
+            svt_av1_convert_qindex_to_q(*q_high, scs_ptr->static_config.encoder_bit_depth);
+        const double q_val_high_new =
+            q_val_high_current *
+            ((double)rc->projected_frame_size / rc->max_frame_bandwidth);
+        *q_high = av1_find_qindex(q_val_high_new, scs_ptr->static_config.encoder_bit_depth,
+                                  rc->best_quality, rc->worst_quality);
+      }
+
+      // Raise Qlow as to at least the current value
+      *q_low = AOMMIN(*q + 1, *q_high);
+
+      if (*undershoot_seen || loop_count > 2 ||
+          (loop_count == 2 && !frame_is_intra_only(ppcs_ptr))) {
+        av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+
+        *q = (*q_high + *q_low + 1) / 2;
+      } else if (loop_count == 2 && frame_is_intra_only(ppcs_ptr)) {
+        const int q_mid = (*q_high + *q_low + 1) / 2;
+        const int q_regulated = get_regulated_q_overshoot(
+            ppcs_ptr, *q_low, *q_high, top_index, bottom_index);
+        // Get 'q' in-between 'q_mid' and 'q_regulated' for a smooth
+        // transition between loop_count < 2 and loop_count > 2.
+        *q = (q_mid + q_regulated + 1) / 2;
+      } else {
+        *q = get_regulated_q_overshoot(ppcs_ptr, *q_low, *q_high, top_index,
+                                       bottom_index);
+      }
+
+      *overshoot_seen = 1;
+    } else {
+      // Frame is too small
+      *q_high = AOMMAX(*q - 1, *q_low);
+
+      if (*overshoot_seen || loop_count > 2 ||
+          (loop_count == 2 && !frame_is_intra_only(ppcs_ptr))) {
+        av1_rc_update_rate_correction_factors(ppcs_ptr, width, height);
+        *q = (*q_high + *q_low) / 2;
+      } else if (loop_count == 2 && frame_is_intra_only(ppcs_ptr)) {
+        const int q_mid = (*q_high + *q_low) / 2;
+        const int q_regulated =
+            get_regulated_q_undershoot(ppcs_ptr, *q_high, top_index, bottom_index);
+        // Get 'q' in-between 'q_mid' and 'q_regulated' for a smooth
+        // transition between loop_count < 2 and loop_count > 2.
+        *q = (q_mid + q_regulated) / 2;
+
+        // Special case reset for qlow for constrained quality.
+        // This should only trigger where there is very substantial
+        // undershoot on a frame and the auto cq level is above
+        // the user passsed in value.
+        if (rc_cfg->mode == AOM_CQ && q_regulated < *q_low) {
+          *q_low = *q;
+        }
+      } else {
+        *q = get_regulated_q_undershoot(ppcs_ptr, *q_high, top_index, bottom_index);
+
+        // Special case reset for qlow for constrained quality.
+        // This should only trigger where there is very substantial
+        // undershoot on a frame and the auto cq level is above
+        // the user passsed in value.
+        if (rc_cfg->mode == AOM_CQ && *q < *q_low) {
+          *q_low = *q;
+        }
+      }
+
+      *undershoot_seen = 1;
+    }
+
+    // Clamp Q to upper and lower limits:
+    *q = clamp(*q, *q_low, *q_high);
+  }
+
+  *q = (uint8_t)CLIP3((int32_t)quantizer_to_qindex[scs_ptr->static_config.min_qp_allowed],
+                      (int32_t)quantizer_to_qindex[scs_ptr->static_config.max_qp_allowed],
+                      *q);
+  *loop = (*q != last_q);
+}
+#endif
 
 void *rate_control_kernel(void *input_ptr) {
     // Context

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -7662,7 +7662,7 @@ void recode_loop_update_q(
          scs_ptr->encode_context_ptr->recode_loop >= ALLOW_RECODE_KFMAXBW &&
          rc_cfg->mode != AOM_Q) ||
          rc_cfg->min_cr > 0;
-  rc->projected_frame_size = do_dummy_pack ? (((ppcs_ptr->pcs_total_rate + (1 << (AV1_PROB_COST_SHIFT - 1))) >> AV1_PROB_COST_SHIFT)
+  rc->projected_frame_size = do_dummy_pack ? (int)(((ppcs_ptr->pcs_total_rate + (1 << (AV1_PROB_COST_SHIFT - 1))) >> AV1_PROB_COST_SHIFT)
                                              + ((ppcs_ptr->frm_hdr.frame_type == KEY_FRAME) ? 13  : 0))
                                            : 0;
   if (ppcs_ptr->loop_count) {

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -6894,7 +6894,7 @@ static int get_bits_per_mb(PictureControlSet *pcs_ptr, int use_cyclic_refresh,
              : svt_av1_rc_bits_per_mb(ppcs_ptr->frm_hdr.frame_type, q,
 #if TUNE_SC_QPS_IMP
                 correction_factor, scs_ptr->static_config.encoder_bit_depth,
-                 pcs_ptr->parent_pcs_ptr->sc_content_detected);
+                 ppcs_ptr->sc_content_detected);
 #else
                  correction_factor, scs_ptr->static_config.encoder_bit_depth);
 #endif
@@ -6905,6 +6905,7 @@ static int get_bits_per_mb(PictureControlSet *pcs_ptr, int use_cyclic_refresh,
                  pcs_ptr->parent_pcs_ptr->sc_content_detected);
 #else
                  correction_factor, scs_ptr->static_config.encoder_bit_depth);
+#endif
 #endif
 }
 
@@ -7601,6 +7602,7 @@ static AOM_INLINE int recode_loop_test(PictureParentControlSet *ppcs_ptr, int hi
   return force_recode;
 }
 
+// get overshoot regulated q based on q_low
 static int get_regulated_q_overshoot(PictureParentControlSet *ppcs_ptr, int q_low,
                                      int q_high, int top_index,
                                      int bottom_index) {
@@ -7626,6 +7628,7 @@ static int get_regulated_q_overshoot(PictureParentControlSet *ppcs_ptr, int q_lo
   return q_regulated;
 }
 
+// get undershoot regulated q based on q_high
 static AOM_INLINE int get_regulated_q_undershoot(PictureParentControlSet *ppcs_ptr,
                                                  int q_high, int top_index,
                                                  int bottom_index) {
@@ -7648,6 +7651,9 @@ static AOM_INLINE int get_regulated_q_undershoot(PictureParentControlSet *ppcs_p
   return q_regulated;
 }
 
+// This function works out whether we under- or over-shot
+// our bitrate target and adjusts q as appropriate.  Also decides whether
+// or not we should do another recode loop, indicated by *loop
 void recode_loop_update_q(
     PictureParentControlSet *ppcs_ptr,
     int *const loop, int *const q, int *const q_low,

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -7538,9 +7538,9 @@ static double av1_get_compression_ratio(PictureParentControlSet *ppcs_ptr,
   const int upscaled_width = ppcs_ptr->av1_cm->frm_size.superres_upscaled_width;
   const int height = ppcs_ptr->av1_cm->frm_size.frame_height;//cm->height;
   const int luma_pic_size = upscaled_width * height;
-  const BITSTREAM_PROFILE profile = ppcs_ptr->scs_ptr->seq_header.seq_profile;
+  const /*BITSTREAM_PROFILE*/EbAv1SeqProfile profile = ppcs_ptr->scs_ptr->seq_header.seq_profile;
   const int pic_size_profile_factor =
-      profile == PROFILE_0 ? 15 : (profile == PROFILE_1 ? 30 : 36);
+      profile == /*PROFILE_0*/MAIN_PROFILE ? 15 : (profile == /*PROFILE_1*/HIGH_PROFILE ? 30 : 36);
   encoded_frame_size =
       (encoded_frame_size > 129 ? encoded_frame_size - 128 : 1);
   const size_t uncompressed_frame_size =

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.h
@@ -200,6 +200,10 @@ typedef struct {
     int enable_scenecut_detection;
     int use_arf_in_this_kf_group;
     int next_is_fwd_key;
+#if FEATURE_RE_ENCODE
+    int top_index;
+    int bottom_index;
+#endif
 } RATE_CONTROL;
 
 /**************************************

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -2277,7 +2277,16 @@ EbErrorType first_pass_signal_derivation_me_kernel(
 #endif
 
     // Set hme/me based reference pruning level (0-4)
+#if FIX_FIRST_PASS_HME
+    if (scs_ptr->static_config.enc_mode <= ENC_MR)
+        set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
+    else if (scs_ptr->static_config.enc_mode <= ENC_M3)
+        set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 2);
+    else
+        set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 4);
+#else
     set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
+#endif
 
     // Set hme-based me sr adjustment level
     set_me_sr_adjustment_ctrls(context_ptr->me_context_ptr, 0);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2270,6 +2270,13 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
         scs_ptr->static_config.enable_tpl_la = 1;
         scs_ptr->static_config.intra_refresh_type     = 2;
     }
+#if FEATURE_RE_ENCODE
+    if (scs_ptr->static_config.recode_loop > 0 &&
+        (!use_input_stat(scs_ptr) || scs_ptr->static_config.rate_control_mode != 1)) {
+        // Only allow re-encoding for 2pass VBR, otherwise force recode_loop to DISALLOW_RECODE or 0
+        scs_ptr->static_config.recode_loop = DISALLOW_RECODE;
+    }
+#endif
 
     derive_input_resolution(
         &scs_ptr->input_resolution,
@@ -3351,8 +3358,7 @@ EbErrorType svt_svt_enc_init_parameter(
     config_ptr->under_shoot_pct = 25;
     config_ptr->over_shoot_pct = 25;
 #if FEATURE_RE_ENCODE
-    //config_ptr->recode_loop = 0;//DISALLOW_RECODE;
-    config_ptr->recode_loop = 2;//ALLOW_RECODE_KFARFGF;
+    config_ptr->recode_loop = ALLOW_RECODE_KFARFGF;
 #endif
 
     // Bitstream options

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2281,7 +2281,13 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
         scs_ptr->static_config.super_block_size = 64;
     else
         scs_ptr->static_config.super_block_size = (scs_ptr->static_config.enc_mode <= ENC_M4) ? 128 : 64;
+#if FIX_ALLOW_SB128_2PASS_VBR
+    scs_ptr->static_config.super_block_size = (scs_ptr->static_config.rate_control_mode > 0 && !use_input_stat(scs_ptr))
+                                              ? 64
+                                              : scs_ptr->static_config.super_block_size;
+#else
     scs_ptr->static_config.super_block_size = (scs_ptr->static_config.rate_control_mode > 0) ? 64 : scs_ptr->static_config.super_block_size;
+#endif
    // scs_ptr->static_config.hierarchical_levels = (scs_ptr->static_config.rate_control_mode > 1) ? 3 : scs_ptr->static_config.hierarchical_levels;
     if (use_output_stat(scs_ptr))
         scs_ptr->static_config.hierarchical_levels = 0;
@@ -2524,6 +2530,9 @@ void copy_api_from_app(
     scs_ptr->static_config.vbr_max_section_pct = ((EbSvtAv1EncConfiguration*)config_struct)->vbr_max_section_pct;
     scs_ptr->static_config.under_shoot_pct     = ((EbSvtAv1EncConfiguration*)config_struct)->under_shoot_pct;
     scs_ptr->static_config.over_shoot_pct      = ((EbSvtAv1EncConfiguration*)config_struct)->over_shoot_pct;
+#if FEATURE_RE_ENCODE
+    scs_ptr->static_config.recode_loop         = ((EbSvtAv1EncConfiguration*)config_struct)->recode_loop;
+#endif
 
     //Segmentation
     //TODO: check RC mode and set only when RC is enabled in the final version.
@@ -3265,7 +3274,11 @@ EbErrorType svt_svt_enc_init_parameter(
     config_ptr->enable_tpl_la = 1;
     config_ptr->target_bit_rate = 7000000;
     config_ptr->max_qp_allowed = 63;
+#if FIX_ONE_MIN_QP_ALLOWED
+    config_ptr->min_qp_allowed = 1;
+#else
     config_ptr->min_qp_allowed = 10;
+#endif
 
     config_ptr->enable_adaptive_quantization = 2;
     config_ptr->enc_mode = MAX_ENC_PRESET;
@@ -3337,6 +3350,10 @@ EbErrorType svt_svt_enc_init_parameter(
     config_ptr->vbr_max_section_pct = 2000;
     config_ptr->under_shoot_pct = 25;
     config_ptr->over_shoot_pct = 25;
+#if FEATURE_RE_ENCODE
+    //config_ptr->recode_loop = 0;//DISALLOW_RECODE;
+    config_ptr->recode_loop = 2;//ALLOW_RECODE_KFARFGF;
+#endif
 
     // Bitstream options
     //config_ptr->codeVpsSpsPps = 0;


### PR DESCRIPTION
# Description

- Added re-encode support for 2pass VBR
- Fixed 2nd pass last small group too big frame size error
- Set default min_qp_allowed=1 for VBR good quality
- To allow SB128x128 for 2pass VBR
- Add 2pass VBR 4L support

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@kelvinhu325 
@lijing0010 
@anaghdin 
@huijuanzh 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [x] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
