### PR TITLE
Travis CI: Update to Ubuntu 20.04 and remove IBM Z allow_failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: c
 cache: ccache
 os: linux
-dist: bionic
+dist: focal
 git:
   depth: false
   quiet: true
@@ -44,8 +44,6 @@ before_cache:
 
 # Build matrix
 jobs:
-  allow_failures:
-    - arch: s390x
   fast_finish: true
   include:
     # Multiple CPU Architectures


### PR DESCRIPTION
 - Updates the build environment to Ubuntu 20.04 Focal Fossa
 - Removes the allow_failure flag for IBM Z, since it was temporary (see #1395)

### Author(s)
@EwoutH 

### Performance impact
- [x] N/A

### Test set
- [x] other

### Merge method
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
