### PR TITLE
Cleanup macros to set kernel pointers

### DIFF
--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -61,6 +61,7 @@ int64_t svt_av1_block_error_c(const TranLow *coeff, const TranLow *dqcoeff,
   *ssz = sqcoeff;
   return error;
 }
+
 /**************************************
  * Instruction Set Support
  **************************************/
@@ -191,1315 +192,601 @@ CPU_FLAGS get_cpu_flags_to_use() {
     return flags;
 }
 #endif
-#ifndef NON_AVX512_SUPPORT
-#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
-    do {                                                                                      \
-        ptr = c;                                                                              \
-        if (((uintptr_t)NULL != (uintptr_t)mmx) && (flags & HAS_MMX)) ptr = mmx;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse) && (flags & HAS_SSE)) ptr = sse;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse2) && (flags & HAS_SSE2)) ptr = sse2;           \
-        if (((uintptr_t)NULL != (uintptr_t)sse3) && (flags & HAS_SSE3)) ptr = sse3;           \
-        if (((uintptr_t)NULL != (uintptr_t)ssse3) && (flags & HAS_SSSE3)) ptr = ssse3;        \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;     \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;     \
-        if (((uintptr_t)NULL != (uintptr_t)avx) && (flags & HAS_AVX)) ptr = avx;              \
-        if (((uintptr_t)NULL != (uintptr_t)avx2) && (flags & HAS_AVX2)) ptr = avx2;           \
-        if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;    \
-    } while (0)
-#else
-#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
-    do {                                                                                      \
-        ptr = c;                                                                              \
-        if (((uintptr_t)NULL != (uintptr_t)mmx) && (flags & HAS_MMX)) ptr = mmx;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse) && (flags & HAS_SSE)) ptr = sse;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse2) && (flags & HAS_SSE2)) ptr = sse2;           \
-        if (((uintptr_t)NULL != (uintptr_t)sse3) && (flags & HAS_SSE3)) ptr = sse3;           \
-        if (((uintptr_t)NULL != (uintptr_t)ssse3) && (flags & HAS_SSSE3)) ptr = ssse3;        \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;     \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;     \
-        if (((uintptr_t)NULL != (uintptr_t)avx) && (flags & HAS_AVX)) ptr = avx;              \
-        if (((uintptr_t)NULL != (uintptr_t)avx2) && (flags & HAS_AVX2)) ptr = avx2;           \
-    } while (0)
-#endif
 
-#define SET_SSE2(ptr, c, sse2) SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
-#define SET_SSE2_AVX2(ptr, c, sse2, avx2) SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
-#define SET_SSSE3(ptr, c, ssse3) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, 0, 0)
-#define SET_SSE41(ptr, c, sse4_1) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
-#define SET_SSE41(ptr, c, sse4_1) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
-#define SET_SSE41_AVX2(ptr, c, sse4_1, avx2) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, 0)
-#define SET_SSE41_AVX2_AVX512(ptr, c, sse4_1, avx2, avx512) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, avx512)
-#define SET_AVX2(ptr, c, avx2) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, 0)
-#define SET_AVX2_AVX512(ptr, c, avx2, avx512) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, avx512)
+#ifdef ARCH_X86_64
+#ifndef NON_AVX512_SUPPORT
+#define SET_FUNCTIONS_AVX512(ptr, avx512)                                                         \
+    if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;
+#else /* NON_AVX512_SUPPORT */
+#define SET_FUNCTIONS_AVX512(ptr, avx512)
+#endif /* NON_AVX512_SUPPORT */
+
+#define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
+    if (((uintptr_t)NULL != (uintptr_t)mmx)    && (flags & HAS_MMX))    ptr = mmx;                \
+    if (((uintptr_t)NULL != (uintptr_t)sse)    && (flags & HAS_SSE))    ptr = sse;                \
+    if (((uintptr_t)NULL != (uintptr_t)sse2)   && (flags & HAS_SSE2))   ptr = sse2;               \
+    if (((uintptr_t)NULL != (uintptr_t)sse3)   && (flags & HAS_SSE3))   ptr = sse3;               \
+    if (((uintptr_t)NULL != (uintptr_t)ssse3)  && (flags & HAS_SSSE3))  ptr = ssse3;              \
+    if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;             \
+    if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;             \
+    if (((uintptr_t)NULL != (uintptr_t)avx)    && (flags & HAS_AVX))    ptr = avx;                \
+    if (((uintptr_t)NULL != (uintptr_t)avx2)   && (flags & HAS_AVX2))   ptr = avx2;               \
+    SET_FUNCTIONS_AVX512(ptr, avx512)
+#else /* ARCH_X86_64 */
+#define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)
+#endif /* ARCH_X86_64 */
+
+#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
+    do {                                                                                          \
+        if (ptr != 0) {                                                                           \
+            printf("Error: %s:%i: Pointer \"%s\" is set before!\n", __FILE__, __LINE__, #ptr);    \
+            assert(0);                                                                            \
+        }                                                                                         \
+        if ((uintptr_t)NULL == (uintptr_t)c) {                                                    \
+            printf("Error: %s:%i: Pointer \"%s\" on C is NULL!\n", __FILE__, __LINE__, #ptr);     \
+            assert(0);                                                                            \
+        }                                                                                         \
+        ptr = c;                                                                                  \
+        SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
+    } while (0)
+
+/* Macros SET_* use local variable CPU_FLAGS flags */
+#define SET_ONLY_C(ptr, c)                                  SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#define SET_SSE2(ptr, c, sse2)                              SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
+#define SET_SSE2_AVX2(ptr, c, sse2, avx2)                   SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
+#define SET_SSE2_AVX512(ptr, c, sse2, avx512)               SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, avx512)
+#define SET_SSSE3(ptr, c, ssse3)                            SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, 0, 0)
+#define SET_SSSE3_AVX2(ptr, c, ssse3, avx2)                 SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, avx2, 0)
+#define SET_SSE41(ptr, c, sse4_1)                           SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
+#define SET_SSE41_AVX2(ptr, c, sse4_1, avx2)                SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, 0)
+#define SET_SSE41_AVX2_AVX512(ptr, c, sse4_1, avx2, avx512) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, avx512)
+#define SET_AVX2(ptr, c, avx2)                              SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, 0)
+#define SET_AVX2_AVX512(ptr, c, avx2, avx512)               SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, avx512)
 
 
 void setup_common_rtcd_internal(CPU_FLAGS flags) {
+#ifdef ARCH_X86_64
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */
-
+    flags &= get_cpu_flags_to_use();
     //to use C: flags=0
+#else
     (void)flags;
-    svt_aom_blend_a64_mask = svt_aom_blend_a64_mask_c;
-    svt_aom_blend_a64_hmask = svt_aom_blend_a64_hmask_c;
-    svt_aom_blend_a64_vmask = svt_aom_blend_a64_vmask_c;
+#endif
 
-    svt_aom_highbd_blend_a64_mask = svt_aom_highbd_blend_a64_mask_c;
-    svt_aom_highbd_blend_a64_hmask_8bit = svt_aom_highbd_blend_a64_hmask_8bit_c;
-    svt_aom_highbd_blend_a64_vmask_8bit = svt_aom_highbd_blend_a64_vmask_8bit_c;
+    SET_SSE41_AVX2(svt_aom_blend_a64_mask, svt_aom_blend_a64_mask_c, svt_aom_blend_a64_mask_sse4_1, svt_aom_blend_a64_mask_avx2);
+    SET_SSE41(svt_aom_blend_a64_hmask, svt_aom_blend_a64_hmask_c, svt_aom_blend_a64_hmask_sse4_1);
+    SET_SSE41(svt_aom_blend_a64_vmask, svt_aom_blend_a64_vmask_c, svt_aom_blend_a64_vmask_sse4_1);
+    SET_AVX2(svt_aom_lowbd_blend_a64_d16_mask, svt_aom_lowbd_blend_a64_d16_mask_c, svt_aom_lowbd_blend_a64_d16_mask_avx2);
+    SET_SSE41(svt_aom_highbd_blend_a64_mask, svt_aom_highbd_blend_a64_mask_c, svt_aom_highbd_blend_a64_mask_8bit_sse4_1);
+    SET_SSE41(svt_aom_highbd_blend_a64_hmask_8bit, svt_aom_highbd_blend_a64_hmask_8bit_c, svt_aom_highbd_blend_a64_hmask_8bit_sse4_1);
+    SET_SSE41(svt_aom_highbd_blend_a64_vmask_8bit, svt_aom_highbd_blend_a64_vmask_8bit_c, svt_aom_highbd_blend_a64_vmask_8bit_sse4_1);
+    SET_SSE41(svt_aom_highbd_blend_a64_vmask_16bit, svt_aom_highbd_blend_a64_vmask_16bit_c, svt_aom_highbd_blend_a64_vmask_16bit_sse4_1);
+    SET_SSE41(svt_aom_highbd_blend_a64_hmask_16bit, svt_aom_highbd_blend_a64_hmask_16bit_c, svt_aom_highbd_blend_a64_hmask_16bit_sse4_1);
+    SET_AVX2(svt_aom_highbd_blend_a64_d16_mask, svt_aom_highbd_blend_a64_d16_mask_c, svt_aom_highbd_blend_a64_d16_mask_avx2);
+    SET_AVX2(svt_cfl_predict_lbd, svt_cfl_predict_lbd_c, svt_cfl_predict_lbd_avx2);
+    SET_AVX2(svt_cfl_predict_hbd, svt_cfl_predict_hbd_c, svt_cfl_predict_hbd_avx2);
+    SET_SSE41(svt_av1_filter_intra_predictor, svt_av1_filter_intra_predictor_c, svt_av1_filter_intra_predictor_sse4_1);
+    SET_SSE41(svt_av1_filter_intra_edge_high, svt_av1_filter_intra_edge_high_c, svt_av1_filter_intra_edge_high_sse4_1);
+    SET_SSE41(svt_av1_filter_intra_edge, svt_av1_filter_intra_edge_c, svt_av1_filter_intra_edge_sse4_1);
+    SET_SSE41(svt_av1_upsample_intra_edge, svt_av1_upsample_intra_edge_c, svt_av1_upsample_intra_edge_sse4_1);
+    SET_AVX2(svt_av1_build_compound_diffwtd_mask_d16, svt_av1_build_compound_diffwtd_mask_d16_c, svt_av1_build_compound_diffwtd_mask_d16_avx2);
+    SET_AVX2(svt_av1_highbd_wiener_convolve_add_src, svt_av1_highbd_wiener_convolve_add_src_c, svt_av1_highbd_wiener_convolve_add_src_avx2);
+    SET_AVX2(svt_apply_selfguided_restoration, svt_apply_selfguided_restoration_c, svt_apply_selfguided_restoration_avx2);
+    SET_AVX2(svt_av1_selfguided_restoration, svt_av1_selfguided_restoration_c, svt_av1_selfguided_restoration_avx2);
+    SET_AVX2(svt_av1_inv_txfm2d_add_4x4, svt_av1_inv_txfm2d_add_4x4_c, svt_av1_inv_txfm2d_add_4x4_avx2);
+    SET_SSE41(svt_av1_inv_txfm2d_add_4x8, svt_av1_inv_txfm2d_add_4x8_c, svt_av1_inv_txfm2d_add_4x8_sse4_1);
+    SET_SSE41(svt_av1_inv_txfm2d_add_4x16, svt_av1_inv_txfm2d_add_4x16_c, svt_av1_inv_txfm2d_add_4x16_sse4_1);
+    SET_SSE41(svt_av1_inv_txfm2d_add_8x4, svt_av1_inv_txfm2d_add_8x4_c, svt_av1_inv_txfm2d_add_8x4_sse4_1);
+    SET_AVX2(svt_av1_inv_txfm2d_add_8x8, svt_av1_inv_txfm2d_add_8x8_c, svt_av1_inv_txfm2d_add_8x8_avx2);
+    SET_AVX2(svt_av1_inv_txfm2d_add_8x16, svt_av1_inv_txfm2d_add_8x16_c, svt_av1_highbd_inv_txfm_add_avx2);
+    SET_AVX2(svt_av1_inv_txfm2d_add_8x32, svt_av1_inv_txfm2d_add_8x32_c, svt_av1_highbd_inv_txfm_add_avx2);
+    SET_SSE41(svt_av1_inv_txfm2d_add_16x4, svt_av1_inv_txfm2d_add_16x4_c, svt_av1_inv_txfm2d_add_16x4_sse4_1);
+    SET_AVX2(svt_av1_inv_txfm2d_add_16x8, svt_av1_inv_txfm2d_add_16x8_c, svt_av1_highbd_inv_txfm_add_avx2);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_16x16, svt_av1_inv_txfm2d_add_16x16_c, svt_av1_inv_txfm2d_add_16x16_avx2, svt_av1_inv_txfm2d_add_16x16_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_16x32, svt_av1_inv_txfm2d_add_16x32_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_16x32_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_16x64, svt_av1_inv_txfm2d_add_16x64_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_16x64_avx512);
+    SET_AVX2(svt_av1_inv_txfm2d_add_32x8, svt_av1_inv_txfm2d_add_32x8_c, svt_av1_highbd_inv_txfm_add_avx2);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_32x16, svt_av1_inv_txfm2d_add_32x16_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_32x16_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_32x32, svt_av1_inv_txfm2d_add_32x32_c, svt_av1_inv_txfm2d_add_32x32_avx2, svt_av1_inv_txfm2d_add_32x32_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_32x64, svt_av1_inv_txfm2d_add_32x64_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_32x64_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_64x16, svt_av1_inv_txfm2d_add_64x16_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_64x16_avx512);
+    SET_AVX2_AVX512(svt_av1_inv_txfm2d_add_64x32, svt_av1_inv_txfm2d_add_64x32_c, svt_av1_highbd_inv_txfm_add_avx2, svt_av1_inv_txfm2d_add_64x32_avx512);
+    SET_SSE41_AVX2_AVX512(svt_av1_inv_txfm2d_add_64x64, svt_av1_inv_txfm2d_add_64x64_c, svt_av1_inv_txfm2d_add_64x64_sse4_1, svt_av1_inv_txfm2d_add_64x64_avx2, svt_av1_inv_txfm2d_add_64x64_avx512);
+    SET_SSSE3_AVX2(svt_av1_inv_txfm_add, svt_av1_inv_txfm_add_c, svt_av1_inv_txfm_add_ssse3, svt_av1_inv_txfm_add_avx2);
+    SET_AVX2(svt_compressed_packmsb, svt_compressed_packmsb_c, svt_compressed_packmsb_avx2_intrin);
+    SET_AVX2(svt_c_pack, svt_c_pack_c, svt_c_pack_avx2_intrin);
+    SET_SSE2_AVX2(svt_unpack_avg, svt_unpack_avg_c, svt_unpack_avg_sse2_intrin, svt_unpack_avg_avx2_intrin);
+    SET_AVX2(svt_unpack_avg_safe_sub, svt_unpack_avg_safe_sub_c, svt_unpack_avg_safe_sub_avx2_intrin);
+    SET_AVX2(svt_un_pack8_bit_data, svt_un_pack8_bit_data_c, svt_enc_un_pack8_bit_data_avx2_intrin);
+    SET_AVX2(svt_cfl_luma_subsampling_420_lbd, svt_cfl_luma_subsampling_420_lbd_c, svt_cfl_luma_subsampling_420_lbd_avx2);
+    SET_AVX2(svt_cfl_luma_subsampling_420_hbd, svt_cfl_luma_subsampling_420_hbd_c, svt_cfl_luma_subsampling_420_hbd_avx2);
+    SET_AVX2(svt_convert_8bit_to_16bit, svt_convert_8bit_to_16bit_c, svt_convert_8bit_to_16bit_avx2);
+    SET_AVX2(svt_convert_16bit_to_8bit, svt_convert_16bit_to_8bit_c, svt_convert_16bit_to_8bit_avx2);
+    SET_SSE2_AVX2(svt_pack2d_16_bit_src_mul4, svt_enc_msb_pack2_d, svt_enc_msb_pack2d_sse2_intrin, svt_enc_msb_pack2d_avx2_intrin_al);
+    SET_SSE2(svt_un_pack2d_16_bit_src_mul4, svt_enc_msb_un_pack2_d, svt_enc_msb_un_pack2d_sse2_intrin);
+    SET_AVX2(svt_full_distortion_kernel_cbf_zero32_bits, svt_full_distortion_kernel_cbf_zero32_bits_c, svt_full_distortion_kernel_cbf_zero32_bits_avx2);
+    SET_AVX2(svt_full_distortion_kernel32_bits, svt_full_distortion_kernel32_bits_c, svt_full_distortion_kernel32_bits_avx2);
 
-    svt_aom_highbd_blend_a64_vmask_16bit = svt_aom_highbd_blend_a64_vmask_16bit_c;
-    svt_aom_highbd_blend_a64_hmask_16bit = svt_aom_highbd_blend_a64_hmask_16bit_c;
+    SET_AVX2_AVX512(svt_spatial_full_distortion_kernel, svt_spatial_full_distortion_kernel_c, svt_spatial_full_distortion_kernel_avx2, svt_spatial_full_distortion_kernel_avx512);
+    SET_AVX2(svt_full_distortion_kernel16_bits, svt_full_distortion_kernel16_bits_c, svt_full_distortion_kernel16_bits_avx2);
+    SET_AVX2_AVX512(svt_residual_kernel8bit, svt_residual_kernel8bit_c, svt_residual_kernel8bit_avx2, svt_residual_kernel8bit_avx512);
+    SET_SSE2_AVX2(svt_residual_kernel16bit, svt_residual_kernel16bit_c, svt_residual_kernel16bit_sse2_intrin, svt_residual_kernel16bit_avx2);
+    SET_SSE2(svt_picture_average_kernel, svt_picture_average_kernel_c, svt_picture_average_kernel_sse2_intrin);
+    SET_SSE2(svt_picture_average_kernel1_line, svt_picture_average_kernel1_line_c, svt_picture_average_kernel1_line_sse2_intrin);
+    SET_AVX2_AVX512(svt_av1_wiener_convolve_add_src, svt_av1_wiener_convolve_add_src_c, svt_av1_wiener_convolve_add_src_avx2, svt_av1_wiener_convolve_add_src_avx512);
+    SET_ONLY_C(svt_av1_convolve_2d_scale, svt_av1_convolve_2d_scale_c);
+    SET_AVX2(svt_av1_highbd_convolve_y_sr, svt_av1_highbd_convolve_y_sr_c, svt_av1_highbd_convolve_y_sr_avx2);
+    SET_AVX2(svt_av1_highbd_convolve_2d_sr, svt_av1_highbd_convolve_2d_sr_c, svt_av1_highbd_convolve_2d_sr_avx2);
+    SET_ONLY_C(svt_av1_highbd_convolve_2d_scale, svt_av1_highbd_convolve_2d_scale_c);
+    SET_AVX2(svt_av1_highbd_convolve_2d_copy_sr, svt_av1_highbd_convolve_2d_copy_sr_c, svt_av1_highbd_convolve_2d_copy_sr_avx2);
+    SET_AVX2(svt_av1_highbd_jnt_convolve_2d, svt_av1_highbd_jnt_convolve_2d_c, svt_av1_highbd_jnt_convolve_2d_avx2);
+    SET_AVX2(svt_av1_highbd_jnt_convolve_2d_copy, svt_av1_highbd_jnt_convolve_2d_copy_c, svt_av1_highbd_jnt_convolve_2d_copy_avx2);
+    SET_AVX2(svt_av1_highbd_jnt_convolve_x, svt_av1_highbd_jnt_convolve_x_c, svt_av1_highbd_jnt_convolve_x_avx2);
+    SET_AVX2(svt_av1_highbd_jnt_convolve_y, svt_av1_highbd_jnt_convolve_y_c, svt_av1_highbd_jnt_convolve_y_avx2);
+    SET_AVX2(svt_av1_highbd_convolve_x_sr, svt_av1_highbd_convolve_x_sr_c, svt_av1_highbd_convolve_x_sr_avx2);
+    SET_AVX2_AVX512(svt_av1_convolve_2d_sr, svt_av1_convolve_2d_sr_c, svt_av1_convolve_2d_sr_avx2, svt_av1_convolve_2d_sr_avx512);
+    SET_AVX2_AVX512(svt_av1_convolve_2d_copy_sr, svt_av1_convolve_2d_copy_sr_c, svt_av1_convolve_2d_copy_sr_avx2, svt_av1_convolve_2d_copy_sr_avx512);
+    SET_AVX2_AVX512(svt_av1_convolve_x_sr, svt_av1_convolve_x_sr_c, svt_av1_convolve_x_sr_avx2, svt_av1_convolve_x_sr_avx512);
+    SET_AVX2_AVX512(svt_av1_convolve_y_sr, svt_av1_convolve_y_sr_c, svt_av1_convolve_y_sr_avx2, svt_av1_convolve_y_sr_avx512);
+    SET_AVX2_AVX512(svt_av1_jnt_convolve_2d, svt_av1_jnt_convolve_2d_c, svt_av1_jnt_convolve_2d_avx2, svt_av1_jnt_convolve_2d_avx512);
+    SET_AVX2_AVX512(svt_av1_jnt_convolve_2d_copy, svt_av1_jnt_convolve_2d_copy_c, svt_av1_jnt_convolve_2d_copy_avx2, svt_av1_jnt_convolve_2d_copy_avx512);
+    SET_AVX2_AVX512(svt_av1_jnt_convolve_x, svt_av1_jnt_convolve_x_c, svt_av1_jnt_convolve_x_avx2, svt_av1_jnt_convolve_x_avx512);
+    SET_AVX2_AVX512(svt_av1_jnt_convolve_y, svt_av1_jnt_convolve_y_c, svt_av1_jnt_convolve_y_avx2, svt_av1_jnt_convolve_y_avx512);
+    SET_AVX2(svt_aom_convolve8_horiz, svt_aom_convolve8_horiz_c, svt_aom_convolve8_horiz_avx2);
+    SET_AVX2(svt_aom_convolve8_vert, svt_aom_convolve8_vert_c, svt_aom_convolve8_vert_avx2);
+    SET_AVX2(svt_av1_build_compound_diffwtd_mask, svt_av1_build_compound_diffwtd_mask_c, svt_av1_build_compound_diffwtd_mask_avx2);
+    SET_AVX2(svt_av1_build_compound_diffwtd_mask_highbd, svt_av1_build_compound_diffwtd_mask_highbd_c, svt_av1_build_compound_diffwtd_mask_highbd_avx2);
+    SET_AVX2(svt_av1_wedge_sse_from_residuals, svt_av1_wedge_sse_from_residuals_c, svt_av1_wedge_sse_from_residuals_avx2);
+    SET_AVX2(svt_aom_subtract_block, svt_aom_subtract_block_c, svt_aom_subtract_block_avx2);
+    SET_SSE2(svt_aom_highbd_subtract_block, svt_aom_highbd_subtract_block_c, svt_aom_highbd_subtract_block_sse2);
+    SET_ONLY_C(svt_aom_highbd_smooth_v_predictor_2x2, svt_aom_highbd_smooth_v_predictor_2x2_c);
+    SET_SSSE3(svt_aom_highbd_smooth_v_predictor_4x4, svt_aom_highbd_smooth_v_predictor_4x4_c, svt_aom_highbd_smooth_v_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_v_predictor_4x8, svt_aom_highbd_smooth_v_predictor_4x8_c, svt_aom_highbd_smooth_v_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_v_predictor_4x16, svt_aom_highbd_smooth_v_predictor_4x16_c, svt_aom_highbd_smooth_v_predictor_4x16_ssse3);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_8x4, svt_aom_highbd_smooth_v_predictor_8x4_c, svt_aom_highbd_smooth_v_predictor_8x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_8x8, svt_aom_highbd_smooth_v_predictor_8x8_c, svt_aom_highbd_smooth_v_predictor_8x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_8x16, svt_aom_highbd_smooth_v_predictor_8x16_c, svt_aom_highbd_smooth_v_predictor_8x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_8x32, svt_aom_highbd_smooth_v_predictor_8x32_c, svt_aom_highbd_smooth_v_predictor_8x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_16x4, svt_aom_highbd_smooth_v_predictor_16x4_c, svt_aom_highbd_smooth_v_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_16x8, svt_aom_highbd_smooth_v_predictor_16x8_c, svt_aom_highbd_smooth_v_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_16x16, svt_aom_highbd_smooth_v_predictor_16x16_c, svt_aom_highbd_smooth_v_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_16x32, svt_aom_highbd_smooth_v_predictor_16x32_c, svt_aom_highbd_smooth_v_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_v_predictor_16x64, svt_aom_highbd_smooth_v_predictor_16x64_c, svt_aom_highbd_smooth_v_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_32x8, svt_aom_highbd_smooth_v_predictor_32x8_c, svt_aom_highbd_smooth_v_predictor_32x8_avx2, aom_highbd_smooth_v_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_32x16, svt_aom_highbd_smooth_v_predictor_32x16_c, svt_aom_highbd_smooth_v_predictor_32x16_avx2, aom_highbd_smooth_v_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_32x32, svt_aom_highbd_smooth_v_predictor_32x32_c, svt_aom_highbd_smooth_v_predictor_32x32_avx2, aom_highbd_smooth_v_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_32x64, svt_aom_highbd_smooth_v_predictor_32x64_c, svt_aom_highbd_smooth_v_predictor_32x64_avx2, aom_highbd_smooth_v_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_64x16, svt_aom_highbd_smooth_v_predictor_64x16_c, svt_aom_highbd_smooth_v_predictor_64x16_avx2, aom_highbd_smooth_v_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_64x32, svt_aom_highbd_smooth_v_predictor_64x32_c, svt_aom_highbd_smooth_v_predictor_64x32_avx2, aom_highbd_smooth_v_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_v_predictor_64x64, svt_aom_highbd_smooth_v_predictor_64x64_c, svt_aom_highbd_smooth_v_predictor_64x64_avx2, aom_highbd_smooth_v_predictor_64x64_avx512);
+    SET_AVX2(svt_av1_dr_prediction_z1, svt_av1_dr_prediction_z1_c, svt_av1_dr_prediction_z1_avx2);
+    SET_AVX2(svt_av1_dr_prediction_z2, svt_av1_dr_prediction_z2_c, svt_av1_dr_prediction_z2_avx2);
+    SET_AVX2(svt_av1_dr_prediction_z3, svt_av1_dr_prediction_z3_c, svt_av1_dr_prediction_z3_avx2);
+    SET_AVX2(svt_av1_highbd_dr_prediction_z1, svt_av1_highbd_dr_prediction_z1_c, svt_av1_highbd_dr_prediction_z1_avx2);
+    SET_AVX2(svt_av1_highbd_dr_prediction_z2, svt_av1_highbd_dr_prediction_z2_c, svt_av1_highbd_dr_prediction_z2_avx2);
+    SET_AVX2(svt_av1_highbd_dr_prediction_z3, svt_av1_highbd_dr_prediction_z3_c, svt_av1_highbd_dr_prediction_z3_avx2);
+    SET_SSSE3(svt_aom_paeth_predictor_4x4, svt_aom_paeth_predictor_4x4_c, svt_aom_paeth_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_4x8, svt_aom_paeth_predictor_4x8_c, svt_aom_paeth_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_4x16, svt_aom_paeth_predictor_4x16_c, svt_aom_paeth_predictor_4x16_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_8x4, svt_aom_paeth_predictor_8x4_c, svt_aom_paeth_predictor_8x4_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_8x8, svt_aom_paeth_predictor_8x8_c, svt_aom_paeth_predictor_8x8_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_8x16, svt_aom_paeth_predictor_8x16_c, svt_aom_paeth_predictor_8x16_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_8x32, svt_aom_paeth_predictor_8x32_c, svt_aom_paeth_predictor_8x32_ssse3);
+    SET_SSSE3(svt_aom_paeth_predictor_16x4, svt_aom_paeth_predictor_16x4_c, svt_aom_paeth_predictor_16x4_ssse3);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_16x8, svt_aom_paeth_predictor_16x8_c, svt_aom_paeth_predictor_16x8_ssse3, svt_aom_paeth_predictor_16x8_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_16x16, svt_aom_paeth_predictor_16x16_c, svt_aom_paeth_predictor_16x16_ssse3, svt_aom_paeth_predictor_16x16_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_16x32, svt_aom_paeth_predictor_16x32_c, svt_aom_paeth_predictor_16x32_ssse3, svt_aom_paeth_predictor_16x32_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_16x64, svt_aom_paeth_predictor_16x64_c, svt_aom_paeth_predictor_16x64_ssse3, svt_aom_paeth_predictor_16x64_avx2);
+    SET_SSSE3(svt_aom_paeth_predictor_32x8, svt_aom_paeth_predictor_32x8_c, svt_aom_paeth_predictor_32x8_ssse3);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_32x16, svt_aom_paeth_predictor_32x16_c, svt_aom_paeth_predictor_32x16_ssse3, svt_aom_paeth_predictor_32x16_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_32x32, svt_aom_paeth_predictor_32x32_c, svt_aom_paeth_predictor_32x32_ssse3, svt_aom_paeth_predictor_32x32_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_32x64, svt_aom_paeth_predictor_32x64_c, svt_aom_paeth_predictor_32x64_ssse3, svt_aom_paeth_predictor_32x64_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_64x16, svt_aom_paeth_predictor_64x16_c, svt_aom_paeth_predictor_64x16_ssse3, svt_aom_paeth_predictor_64x16_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_64x32, svt_aom_paeth_predictor_64x32_c, svt_aom_paeth_predictor_64x32_ssse3, svt_aom_paeth_predictor_64x32_avx2);
+    SET_SSSE3_AVX2(svt_aom_paeth_predictor_64x64, svt_aom_paeth_predictor_64x64_c, svt_aom_paeth_predictor_64x64_ssse3, svt_aom_paeth_predictor_64x64_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_2x2, svt_aom_highbd_paeth_predictor_2x2_c, svt_aom_highbd_paeth_predictor_2x2_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_4x4, svt_aom_highbd_paeth_predictor_4x4_c, svt_aom_highbd_paeth_predictor_4x4_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_4x8, svt_aom_highbd_paeth_predictor_4x8_c, svt_aom_highbd_paeth_predictor_4x8_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_4x16, svt_aom_highbd_paeth_predictor_4x16_c, svt_aom_highbd_paeth_predictor_4x16_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_8x4, svt_aom_highbd_paeth_predictor_8x4_c, svt_aom_highbd_paeth_predictor_8x4_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_8x8, svt_aom_highbd_paeth_predictor_8x8_c, svt_aom_highbd_paeth_predictor_8x8_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_8x16, svt_aom_highbd_paeth_predictor_8x16_c, svt_aom_highbd_paeth_predictor_8x16_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_8x32, svt_aom_highbd_paeth_predictor_8x32_c, svt_aom_highbd_paeth_predictor_8x32_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_16x4, svt_aom_highbd_paeth_predictor_16x4_c, svt_aom_highbd_paeth_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_16x8, svt_aom_highbd_paeth_predictor_16x8_c, svt_aom_highbd_paeth_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_16x16, svt_aom_highbd_paeth_predictor_16x16_c, svt_aom_highbd_paeth_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_16x32, svt_aom_highbd_paeth_predictor_16x32_c, svt_aom_highbd_paeth_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_16x64, svt_aom_highbd_paeth_predictor_16x64_c, svt_aom_highbd_paeth_predictor_16x64_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_32x8, svt_aom_highbd_paeth_predictor_32x8_c, svt_aom_highbd_paeth_predictor_32x8_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_32x16, svt_aom_highbd_paeth_predictor_32x16_c, svt_aom_highbd_paeth_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_32x32, svt_aom_highbd_paeth_predictor_32x32_c, svt_aom_highbd_paeth_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_32x64, svt_aom_highbd_paeth_predictor_32x64_c, svt_aom_highbd_paeth_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_64x16, svt_aom_highbd_paeth_predictor_64x16_c, svt_aom_highbd_paeth_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_64x32, svt_aom_highbd_paeth_predictor_64x32_c, svt_aom_highbd_paeth_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_highbd_paeth_predictor_64x64, svt_aom_highbd_paeth_predictor_64x64_c, svt_aom_highbd_paeth_predictor_64x64_avx2);
+    SET_SSE2(aom_sum_squares_i16, svt_aom_sum_squares_i16_c, svt_aom_sum_squares_i16_sse2);
+    SET_SSE2(svt_aom_dc_predictor_4x4, svt_aom_dc_predictor_4x4_c, svt_aom_dc_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_dc_predictor_4x8, svt_aom_dc_predictor_4x8_c, svt_aom_dc_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_dc_predictor_4x16, svt_aom_dc_predictor_4x16_c, svt_aom_dc_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_dc_predictor_8x4, svt_aom_dc_predictor_8x4_c, svt_aom_dc_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_dc_predictor_8x8, svt_aom_dc_predictor_8x8_c, svt_aom_dc_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_dc_predictor_8x16, svt_aom_dc_predictor_8x16_c, svt_aom_dc_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_dc_predictor_8x32, svt_aom_dc_predictor_8x32_c, svt_aom_dc_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_dc_predictor_16x4, svt_aom_dc_predictor_16x4_c, svt_aom_dc_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_dc_predictor_16x8, svt_aom_dc_predictor_16x8_c, svt_aom_dc_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_dc_predictor_16x16, svt_aom_dc_predictor_16x16_c, svt_aom_dc_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_dc_predictor_16x32, svt_aom_dc_predictor_16x32_c, svt_aom_dc_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_dc_predictor_16x64, svt_aom_dc_predictor_16x64_c, svt_aom_dc_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_dc_predictor_32x8, svt_aom_dc_predictor_32x8_c, svt_aom_dc_predictor_32x8_sse2);
+    SET_AVX2(svt_aom_dc_predictor_32x16, svt_aom_dc_predictor_32x16_c, svt_aom_dc_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_dc_predictor_32x32, svt_aom_dc_predictor_32x32_c, svt_aom_dc_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_dc_predictor_32x64, svt_aom_dc_predictor_32x64_c, svt_aom_dc_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_dc_predictor_64x16, svt_aom_dc_predictor_64x16_c, svt_aom_dc_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_dc_predictor_64x32, svt_aom_dc_predictor_64x32_c, svt_aom_dc_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_dc_predictor_64x64, svt_aom_dc_predictor_64x64_c, svt_aom_dc_predictor_64x64_avx2);
 
-    svt_cfl_predict_lbd = svt_cfl_predict_lbd_c;
-    svt_cfl_predict_hbd = svt_cfl_predict_hbd_c;
+    SET_SSE2(svt_aom_dc_top_predictor_4x4, svt_aom_dc_top_predictor_4x4_c, svt_aom_dc_top_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_4x8, svt_aom_dc_top_predictor_4x8_c, svt_aom_dc_top_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_4x16, svt_aom_dc_top_predictor_4x16_c, svt_aom_dc_top_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_8x4, svt_aom_dc_top_predictor_8x4_c, svt_aom_dc_top_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_8x8, svt_aom_dc_top_predictor_8x8_c, svt_aom_dc_top_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_8x16, svt_aom_dc_top_predictor_8x16_c, svt_aom_dc_top_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_8x32, svt_aom_dc_top_predictor_8x32_c, svt_aom_dc_top_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_16x4, svt_aom_dc_top_predictor_16x4_c, svt_aom_dc_top_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_16x8, svt_aom_dc_top_predictor_16x8_c, svt_aom_dc_top_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_16x16, svt_aom_dc_top_predictor_16x16_c, svt_aom_dc_top_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_16x32, svt_aom_dc_top_predictor_16x32_c, svt_aom_dc_top_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_16x64, svt_aom_dc_top_predictor_16x64_c, svt_aom_dc_top_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_dc_top_predictor_32x8, svt_aom_dc_top_predictor_32x8_c, svt_aom_dc_top_predictor_32x8_sse2);
+    SET_AVX2(svt_aom_dc_top_predictor_32x16, svt_aom_dc_top_predictor_32x16_c, svt_aom_dc_top_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_dc_top_predictor_32x32, svt_aom_dc_top_predictor_32x32_c, svt_aom_dc_top_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_dc_top_predictor_32x64, svt_aom_dc_top_predictor_32x64_c, svt_aom_dc_top_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_dc_top_predictor_64x16, svt_aom_dc_top_predictor_64x16_c, svt_aom_dc_top_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_dc_top_predictor_64x32, svt_aom_dc_top_predictor_64x32_c, svt_aom_dc_top_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_dc_top_predictor_64x64, svt_aom_dc_top_predictor_64x64_c, svt_aom_dc_top_predictor_64x64_avx2);
 
-    svt_av1_filter_intra_predictor = svt_av1_filter_intra_predictor_c;
+    SET_SSE2(svt_aom_dc_left_predictor_4x4, svt_aom_dc_left_predictor_4x4_c, svt_aom_dc_left_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_4x8, svt_aom_dc_left_predictor_4x8_c, svt_aom_dc_left_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_4x16, svt_aom_dc_left_predictor_4x16_c, svt_aom_dc_left_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_8x4, svt_aom_dc_left_predictor_8x4_c, svt_aom_dc_left_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_8x8, svt_aom_dc_left_predictor_8x8_c, svt_aom_dc_left_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_8x16, svt_aom_dc_left_predictor_8x16_c, svt_aom_dc_left_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_8x32, svt_aom_dc_left_predictor_8x32_c, svt_aom_dc_left_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_16x4, svt_aom_dc_left_predictor_16x4_c, svt_aom_dc_left_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_16x8, svt_aom_dc_left_predictor_16x8_c, svt_aom_dc_left_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_16x16, svt_aom_dc_left_predictor_16x16_c, svt_aom_dc_left_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_16x32, svt_aom_dc_left_predictor_16x32_c, svt_aom_dc_left_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_16x64, svt_aom_dc_left_predictor_16x64_c, svt_aom_dc_left_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_dc_left_predictor_32x8, svt_aom_dc_left_predictor_32x8_c, svt_aom_dc_left_predictor_32x8_sse2);
+    SET_AVX2(svt_aom_dc_left_predictor_32x16, svt_aom_dc_left_predictor_32x16_c, svt_aom_dc_left_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_dc_left_predictor_32x32, svt_aom_dc_left_predictor_32x32_c, svt_aom_dc_left_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_dc_left_predictor_32x64, svt_aom_dc_left_predictor_32x64_c, svt_aom_dc_left_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_dc_left_predictor_64x16, svt_aom_dc_left_predictor_64x16_c, svt_aom_dc_left_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_dc_left_predictor_64x32, svt_aom_dc_left_predictor_64x32_c, svt_aom_dc_left_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_dc_left_predictor_64x64, svt_aom_dc_left_predictor_64x64_c, svt_aom_dc_left_predictor_64x64_avx2);
 
-    svt_av1_filter_intra_edge_high = svt_av1_filter_intra_edge_high_c;
+    SET_SSE2(svt_aom_dc_128_predictor_4x4, svt_aom_dc_128_predictor_4x4_c, svt_aom_dc_128_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_4x8, svt_aom_dc_128_predictor_4x8_c, svt_aom_dc_128_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_4x16, svt_aom_dc_128_predictor_4x16_c, svt_aom_dc_128_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_8x4, svt_aom_dc_128_predictor_8x4_c, svt_aom_dc_128_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_8x8, svt_aom_dc_128_predictor_8x8_c, svt_aom_dc_128_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_8x16, svt_aom_dc_128_predictor_8x16_c, svt_aom_dc_128_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_8x32, svt_aom_dc_128_predictor_8x32_c, svt_aom_dc_128_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_16x4, svt_aom_dc_128_predictor_16x4_c, svt_aom_dc_128_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_16x8, svt_aom_dc_128_predictor_16x8_c, svt_aom_dc_128_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_16x16, svt_aom_dc_128_predictor_16x16_c, svt_aom_dc_128_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_16x32, svt_aom_dc_128_predictor_16x32_c, svt_aom_dc_128_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_16x64, svt_aom_dc_128_predictor_16x64_c, svt_aom_dc_128_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_dc_128_predictor_32x8, svt_aom_dc_128_predictor_32x8_c, svt_aom_dc_128_predictor_32x8_sse2);
+    SET_AVX2(svt_aom_dc_128_predictor_32x16, svt_aom_dc_128_predictor_32x16_c, svt_aom_dc_128_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_dc_128_predictor_32x32, svt_aom_dc_128_predictor_32x32_c, svt_aom_dc_128_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_dc_128_predictor_32x64, svt_aom_dc_128_predictor_32x64_c, svt_aom_dc_128_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_dc_128_predictor_64x16, svt_aom_dc_128_predictor_64x16_c, svt_aom_dc_128_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_dc_128_predictor_64x32, svt_aom_dc_128_predictor_64x32_c, svt_aom_dc_128_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_dc_128_predictor_64x64, svt_aom_dc_128_predictor_64x64_c, svt_aom_dc_128_predictor_64x64_avx2);
 
-    svt_av1_filter_intra_edge = svt_av1_filter_intra_edge_c;
+    SET_SSSE3(svt_aom_smooth_h_predictor_4x4, svt_aom_smooth_h_predictor_4x4_c, svt_aom_smooth_h_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_4x8, svt_aom_smooth_h_predictor_4x8_c, svt_aom_smooth_h_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_4x16, svt_aom_smooth_h_predictor_4x16_c, svt_aom_smooth_h_predictor_4x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_8x4, svt_aom_smooth_h_predictor_8x4_c, svt_aom_smooth_h_predictor_8x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_8x8, svt_aom_smooth_h_predictor_8x8_c, svt_aom_smooth_h_predictor_8x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_8x16, svt_aom_smooth_h_predictor_8x16_c, svt_aom_smooth_h_predictor_8x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_8x32, svt_aom_smooth_h_predictor_8x32_c, svt_aom_smooth_h_predictor_8x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_16x4, svt_aom_smooth_h_predictor_16x4_c, svt_aom_smooth_h_predictor_16x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_16x8, svt_aom_smooth_h_predictor_16x8_c, svt_aom_smooth_h_predictor_16x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_16x16, svt_aom_smooth_h_predictor_16x16_c, svt_aom_smooth_h_predictor_16x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_16x32, svt_aom_smooth_h_predictor_16x32_c, svt_aom_smooth_h_predictor_16x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_16x64, svt_aom_smooth_h_predictor_16x64_c, svt_aom_smooth_h_predictor_16x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_32x8, svt_aom_smooth_h_predictor_32x8_c, svt_aom_smooth_h_predictor_32x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_32x16, svt_aom_smooth_h_predictor_32x16_c, svt_aom_smooth_h_predictor_32x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_32x32, svt_aom_smooth_h_predictor_32x32_c, svt_aom_smooth_h_predictor_32x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_32x64, svt_aom_smooth_h_predictor_32x64_c, svt_aom_smooth_h_predictor_32x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_64x16, svt_aom_smooth_h_predictor_64x16_c, svt_aom_smooth_h_predictor_64x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_64x32, svt_aom_smooth_h_predictor_64x32_c, svt_aom_smooth_h_predictor_64x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_h_predictor_64x64, svt_aom_smooth_h_predictor_64x64_c, svt_aom_smooth_h_predictor_64x64_ssse3);
 
-    svt_av1_upsample_intra_edge = svt_av1_upsample_intra_edge_c;
+    SET_SSSE3(svt_aom_smooth_v_predictor_4x4, svt_aom_smooth_v_predictor_4x4_c, svt_aom_smooth_v_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_4x8, svt_aom_smooth_v_predictor_4x8_c, svt_aom_smooth_v_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_4x16, svt_aom_smooth_v_predictor_4x16_c, svt_aom_smooth_v_predictor_4x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_8x4, svt_aom_smooth_v_predictor_8x4_c, svt_aom_smooth_v_predictor_8x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_8x8, svt_aom_smooth_v_predictor_8x8_c, svt_aom_smooth_v_predictor_8x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_8x16, svt_aom_smooth_v_predictor_8x16_c, svt_aom_smooth_v_predictor_8x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_8x32, svt_aom_smooth_v_predictor_8x32_c, svt_aom_smooth_v_predictor_8x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_16x4, svt_aom_smooth_v_predictor_16x4_c, svt_aom_smooth_v_predictor_16x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_16x8, svt_aom_smooth_v_predictor_16x8_c, svt_aom_smooth_v_predictor_16x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_16x16, svt_aom_smooth_v_predictor_16x16_c, svt_aom_smooth_v_predictor_16x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_16x32, svt_aom_smooth_v_predictor_16x32_c, svt_aom_smooth_v_predictor_16x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_16x64, svt_aom_smooth_v_predictor_16x64_c, svt_aom_smooth_v_predictor_16x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_32x8, svt_aom_smooth_v_predictor_32x8_c, svt_aom_smooth_v_predictor_32x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_32x16, svt_aom_smooth_v_predictor_32x16_c, svt_aom_smooth_v_predictor_32x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_32x32, svt_aom_smooth_v_predictor_32x32_c, svt_aom_smooth_v_predictor_32x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_32x64, svt_aom_smooth_v_predictor_32x64_c, svt_aom_smooth_v_predictor_32x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_64x16, svt_aom_smooth_v_predictor_64x16_c, svt_aom_smooth_v_predictor_64x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_64x32, svt_aom_smooth_v_predictor_64x32_c, svt_aom_smooth_v_predictor_64x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_v_predictor_64x64, svt_aom_smooth_v_predictor_64x64_c, svt_aom_smooth_v_predictor_64x64_ssse3);
 
-    svt_av1_build_compound_diffwtd_mask_d16 = svt_av1_build_compound_diffwtd_mask_d16_c;
+    SET_SSSE3(svt_aom_smooth_predictor_4x4, svt_aom_smooth_predictor_4x4_c, svt_aom_smooth_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_4x8, svt_aom_smooth_predictor_4x8_c, svt_aom_smooth_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_4x16, svt_aom_smooth_predictor_4x16_c, svt_aom_smooth_predictor_4x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_8x4, svt_aom_smooth_predictor_8x4_c, svt_aom_smooth_predictor_8x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_8x8, svt_aom_smooth_predictor_8x8_c, svt_aom_smooth_predictor_8x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_8x16, svt_aom_smooth_predictor_8x16_c, svt_aom_smooth_predictor_8x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_8x32, svt_aom_smooth_predictor_8x32_c, svt_aom_smooth_predictor_8x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_16x4, svt_aom_smooth_predictor_16x4_c, svt_aom_smooth_predictor_16x4_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_16x8, svt_aom_smooth_predictor_16x8_c, svt_aom_smooth_predictor_16x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_16x16, svt_aom_smooth_predictor_16x16_c, svt_aom_smooth_predictor_16x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_16x32, svt_aom_smooth_predictor_16x32_c, svt_aom_smooth_predictor_16x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_16x64, svt_aom_smooth_predictor_16x64_c, svt_aom_smooth_predictor_16x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_32x8, svt_aom_smooth_predictor_32x8_c, svt_aom_smooth_predictor_32x8_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_32x16, svt_aom_smooth_predictor_32x16_c, svt_aom_smooth_predictor_32x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_32x32, svt_aom_smooth_predictor_32x32_c, svt_aom_smooth_predictor_32x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_32x64, svt_aom_smooth_predictor_32x64_c, svt_aom_smooth_predictor_32x64_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_64x16, svt_aom_smooth_predictor_64x16_c, svt_aom_smooth_predictor_64x16_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_64x32, svt_aom_smooth_predictor_64x32_c, svt_aom_smooth_predictor_64x32_ssse3);
+    SET_SSSE3(svt_aom_smooth_predictor_64x64, svt_aom_smooth_predictor_64x64_c, svt_aom_smooth_predictor_64x64_ssse3);
 
-    svt_av1_highbd_wiener_convolve_add_src = svt_av1_highbd_wiener_convolve_add_src_c;
+    SET_SSE2(svt_aom_v_predictor_4x4, svt_aom_v_predictor_4x4_c, svt_aom_v_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_v_predictor_4x8, svt_aom_v_predictor_4x8_c, svt_aom_v_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_v_predictor_4x16, svt_aom_v_predictor_4x16_c, svt_aom_v_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_v_predictor_8x4, svt_aom_v_predictor_8x4_c, svt_aom_v_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_v_predictor_8x8, svt_aom_v_predictor_8x8_c, svt_aom_v_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_v_predictor_8x16, svt_aom_v_predictor_8x16_c, svt_aom_v_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_v_predictor_8x32, svt_aom_v_predictor_8x32_c, svt_aom_v_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_v_predictor_16x4, svt_aom_v_predictor_16x4_c, svt_aom_v_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_v_predictor_16x8, svt_aom_v_predictor_16x8_c, svt_aom_v_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_v_predictor_16x16, svt_aom_v_predictor_16x16_c, svt_aom_v_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_v_predictor_16x32, svt_aom_v_predictor_16x32_c, svt_aom_v_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_v_predictor_16x64, svt_aom_v_predictor_16x64_c, svt_aom_v_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_v_predictor_32x8, svt_aom_v_predictor_32x8_c, svt_aom_v_predictor_32x8_sse2);
+    SET_AVX2(svt_aom_v_predictor_32x16, svt_aom_v_predictor_32x16_c, svt_aom_v_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_v_predictor_32x32, svt_aom_v_predictor_32x32_c, svt_aom_v_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_v_predictor_32x64, svt_aom_v_predictor_32x64_c, svt_aom_v_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_v_predictor_64x16, svt_aom_v_predictor_64x16_c, svt_aom_v_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_v_predictor_64x32, svt_aom_v_predictor_64x32_c, svt_aom_v_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_v_predictor_64x64, svt_aom_v_predictor_64x64_c, svt_aom_v_predictor_64x64_avx2);
 
-    svt_apply_selfguided_restoration = svt_apply_selfguided_restoration_c;
+    SET_SSE2(svt_aom_h_predictor_4x4, svt_aom_h_predictor_4x4_c, svt_aom_h_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_h_predictor_4x8, svt_aom_h_predictor_4x8_c, svt_aom_h_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_h_predictor_4x16, svt_aom_h_predictor_4x16_c, svt_aom_h_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_h_predictor_8x4, svt_aom_h_predictor_8x4_c, svt_aom_h_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_h_predictor_8x8, svt_aom_h_predictor_8x8_c, svt_aom_h_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_h_predictor_8x16, svt_aom_h_predictor_8x16_c, svt_aom_h_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_h_predictor_8x32, svt_aom_h_predictor_8x32_c, svt_aom_h_predictor_8x32_sse2);
+    SET_SSE2(svt_aom_h_predictor_16x4, svt_aom_h_predictor_16x4_c, svt_aom_h_predictor_16x4_sse2);
+    SET_SSE2(svt_aom_h_predictor_16x8, svt_aom_h_predictor_16x8_c, svt_aom_h_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_h_predictor_16x16, svt_aom_h_predictor_16x16_c, svt_aom_h_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_h_predictor_16x32, svt_aom_h_predictor_16x32_c, svt_aom_h_predictor_16x32_sse2);
+    SET_SSE2(svt_aom_h_predictor_16x64, svt_aom_h_predictor_16x64_c, svt_aom_h_predictor_16x64_sse2);
+    SET_SSE2(svt_aom_h_predictor_32x8, svt_aom_h_predictor_32x8_c, svt_aom_h_predictor_32x8_sse2);
+    SET_SSE2(svt_aom_h_predictor_32x16, svt_aom_h_predictor_32x16_c, svt_aom_h_predictor_32x16_sse2);
+    SET_AVX2(svt_aom_h_predictor_32x32, svt_aom_h_predictor_32x32_c, svt_aom_h_predictor_32x32_avx2);
+    SET_SSE2(svt_aom_h_predictor_32x64, svt_aom_h_predictor_32x64_c, svt_aom_h_predictor_32x64_sse2);
+    SET_SSE2(svt_aom_h_predictor_64x16, svt_aom_h_predictor_64x16_c, svt_aom_h_predictor_64x16_sse2);
+    SET_SSE2(svt_aom_h_predictor_64x32, svt_aom_h_predictor_64x32_c, svt_aom_h_predictor_64x32_sse2);
+    SET_SSE2(svt_aom_h_predictor_64x64, svt_aom_h_predictor_64x64_c, svt_aom_h_predictor_64x64_sse2);
 
-    svt_av1_selfguided_restoration = svt_av1_selfguided_restoration_c;
+    SET_AVX2(svt_cdef_find_dir, svt_cdef_find_dir_c, svt_cdef_find_dir_avx2);
+    SET_AVX2(svt_cdef_filter_block, svt_cdef_filter_block_c, svt_cdef_filter_block_avx2);
+    /* No C version, use only internal in kerneal: svt_cdef_filter_block_avx2() */
+#ifdef ARCH_X86_64
+    if (flags & HAS_AVX2)    svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx2;
+#ifndef NON_AVX512_SUPPORT
+    if (flags & HAS_AVX512F) svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx512;
+#endif
+#endif
 
-    svt_av1_inv_txfm2d_add_16x16 = svt_av1_inv_txfm2d_add_16x16_c;
-    svt_av1_inv_txfm2d_add_32x32 = svt_av1_inv_txfm2d_add_32x32_c;
-    svt_av1_inv_txfm2d_add_4x4 = svt_av1_inv_txfm2d_add_4x4_c;
-    svt_av1_inv_txfm2d_add_64x64 = svt_av1_inv_txfm2d_add_64x64_c;
-    svt_av1_inv_txfm2d_add_8x8 = svt_av1_inv_txfm2d_add_8x8_c;
+    SET_AVX2(svt_copy_rect8_8bit_to_16bit, svt_copy_rect8_8bit_to_16bit_c, svt_copy_rect8_8bit_to_16bit_avx2);
+    SET_AVX2(svt_av1_highbd_warp_affine, svt_av1_highbd_warp_affine_c, svt_av1_highbd_warp_affine_avx2);
+    SET_AVX2(svt_av1_warp_affine, svt_av1_warp_affine_c, svt_av1_warp_affine_avx2);
 
-    svt_av1_inv_txfm2d_add_8x16 = svt_av1_inv_txfm2d_add_8x16_c;
-    svt_av1_inv_txfm2d_add_16x8 = svt_av1_inv_txfm2d_add_16x8_c;
-    svt_av1_inv_txfm2d_add_16x32 = svt_av1_inv_txfm2d_add_16x32_c;
-    svt_av1_inv_txfm2d_add_32x16 = svt_av1_inv_txfm2d_add_32x16_c;
-    svt_av1_inv_txfm2d_add_32x8 = svt_av1_inv_txfm2d_add_32x8_c;
-    svt_av1_inv_txfm2d_add_8x32 = svt_av1_inv_txfm2d_add_8x32_c;
-    svt_av1_inv_txfm2d_add_32x64 = svt_av1_inv_txfm2d_add_32x64_c;
-    svt_av1_inv_txfm2d_add_64x32 = svt_av1_inv_txfm2d_add_64x32_c;
-    svt_av1_inv_txfm2d_add_16x64 = svt_av1_inv_txfm2d_add_16x64_c;
-    svt_av1_inv_txfm2d_add_64x16 = svt_av1_inv_txfm2d_add_64x16_c;
-    svt_av1_inv_txfm2d_add_4x8 = svt_av1_inv_txfm2d_add_4x8_c;
-    svt_av1_inv_txfm2d_add_8x4 = svt_av1_inv_txfm2d_add_8x4_c;
-    svt_av1_inv_txfm2d_add_4x16 = svt_av1_inv_txfm2d_add_4x16_c;
-    svt_av1_inv_txfm2d_add_16x4 = svt_av1_inv_txfm2d_add_16x4_c;
-
-    svt_av1_inv_txfm_add = svt_av1_inv_txfm_add_c;
-
-    svt_compressed_packmsb = svt_compressed_packmsb_c;
-    svt_c_pack = svt_c_pack_c;
-    svt_unpack_avg = svt_unpack_avg_c;
-    svt_unpack_avg_safe_sub = svt_unpack_avg_safe_sub_c;
-    svt_un_pack8_bit_data = svt_un_pack8_bit_data_c;
-    svt_cfl_luma_subsampling_420_lbd = svt_cfl_luma_subsampling_420_lbd_c;
-    svt_cfl_luma_subsampling_420_hbd = svt_cfl_luma_subsampling_420_hbd_c;
-    svt_convert_8bit_to_16bit = svt_convert_8bit_to_16bit_c;
-    svt_convert_16bit_to_8bit = svt_convert_16bit_to_8bit_c;
-    svt_pack2d_16_bit_src_mul4 = svt_enc_msb_pack2_d;
-    svt_un_pack2d_16_bit_src_mul4 = svt_enc_msb_un_pack2_d;
-
-    svt_full_distortion_kernel_cbf_zero32_bits = svt_full_distortion_kernel_cbf_zero32_bits_c;
-    svt_full_distortion_kernel32_bits = svt_full_distortion_kernel32_bits_c;
-
-    svt_spatial_full_distortion_kernel = svt_spatial_full_distortion_kernel_c;
-    svt_full_distortion_kernel16_bits = svt_full_distortion_kernel16_bits_c;
-    svt_residual_kernel8bit = svt_residual_kernel8bit_c;
-
-    svt_residual_kernel16bit = svt_residual_kernel16bit_c;
-
-    svt_picture_average_kernel = svt_picture_average_kernel_c;
-    svt_picture_average_kernel1_line = svt_picture_average_kernel1_line_c;
-    svt_av1_wiener_convolve_add_src = svt_av1_wiener_convolve_add_src_c,
-
-
-    svt_av1_convolve_2d_copy_sr = svt_av1_convolve_2d_copy_sr_c;
-
-    svt_av1_convolve_2d_scale = svt_av1_convolve_2d_scale_c;
-
-    svt_av1_highbd_convolve_2d_copy_sr = svt_av1_highbd_convolve_2d_copy_sr_c;
-    svt_av1_highbd_jnt_convolve_2d_copy = svt_av1_highbd_jnt_convolve_2d_copy_c;
-    svt_av1_highbd_convolve_y_sr = svt_av1_highbd_convolve_y_sr_c;
-    svt_av1_highbd_convolve_2d_sr = svt_av1_highbd_convolve_2d_sr_c;
-
-    svt_av1_highbd_convolve_2d_scale = svt_av1_highbd_convolve_2d_scale_c;
-
-    svt_av1_highbd_jnt_convolve_2d = svt_av1_highbd_jnt_convolve_2d_c;
-    svt_av1_highbd_jnt_convolve_x = svt_av1_highbd_jnt_convolve_x_c;
-    svt_av1_highbd_jnt_convolve_y = svt_av1_highbd_jnt_convolve_y_c;
-    svt_av1_highbd_convolve_x_sr = svt_av1_highbd_convolve_x_sr_c;
-
-    svt_av1_convolve_2d_sr = svt_av1_convolve_2d_sr_c;
-    svt_av1_convolve_2d_copy_sr = svt_av1_convolve_2d_copy_sr_c;
-    svt_av1_convolve_x_sr = svt_av1_convolve_x_sr_c;
-    svt_av1_convolve_y_sr = svt_av1_convolve_y_sr_c;
-    svt_av1_jnt_convolve_2d = svt_av1_jnt_convolve_2d_c;
-    svt_av1_jnt_convolve_2d_copy = svt_av1_jnt_convolve_2d_copy_c;
-    svt_av1_jnt_convolve_x = svt_av1_jnt_convolve_x_c;
-    svt_av1_jnt_convolve_y = svt_av1_jnt_convolve_y_c;
-
-    svt_aom_convolve8_horiz = svt_aom_convolve8_horiz_c;
-    svt_aom_convolve8_vert = svt_aom_convolve8_vert_c;
-
-
-    svt_av1_build_compound_diffwtd_mask = svt_av1_build_compound_diffwtd_mask_c;
-    svt_av1_build_compound_diffwtd_mask_highbd = svt_av1_build_compound_diffwtd_mask_highbd_c;
-    svt_av1_wedge_sse_from_residuals = svt_av1_wedge_sse_from_residuals_c;
-
-    svt_aom_subtract_block = svt_aom_subtract_block_c;
-
-    svt_aom_lowbd_blend_a64_d16_mask = svt_aom_lowbd_blend_a64_d16_mask_c;
-    svt_aom_highbd_blend_a64_d16_mask = svt_aom_highbd_blend_a64_d16_mask_c;
-
-    svt_aom_highbd_subtract_block = svt_aom_highbd_subtract_block_c;
-
-    svt_aom_highbd_smooth_v_predictor_16x16 = svt_aom_highbd_smooth_v_predictor_16x16_c;
-    svt_aom_highbd_smooth_v_predictor_16x32 = svt_aom_highbd_smooth_v_predictor_16x32_c;
-    svt_aom_highbd_smooth_v_predictor_16x4 = svt_aom_highbd_smooth_v_predictor_16x4_c;
-    svt_aom_highbd_smooth_v_predictor_16x64 = svt_aom_highbd_smooth_v_predictor_16x64_c;
-    svt_aom_highbd_smooth_v_predictor_16x8 = svt_aom_highbd_smooth_v_predictor_16x8_c;
-    svt_aom_highbd_smooth_v_predictor_2x2 = svt_aom_highbd_smooth_v_predictor_2x2_c;
-    svt_aom_highbd_smooth_v_predictor_32x16 = svt_aom_highbd_smooth_v_predictor_32x16_c;
-    svt_aom_highbd_smooth_v_predictor_32x32 = svt_aom_highbd_smooth_v_predictor_32x32_c;
-    svt_aom_highbd_smooth_v_predictor_32x64 = svt_aom_highbd_smooth_v_predictor_32x64_c;
-    svt_aom_highbd_smooth_v_predictor_32x8 = svt_aom_highbd_smooth_v_predictor_32x8_c;
-    svt_aom_highbd_smooth_v_predictor_4x16 = svt_aom_highbd_smooth_v_predictor_4x16_c;
-    svt_aom_highbd_smooth_v_predictor_4x4 = svt_aom_highbd_smooth_v_predictor_4x4_c;
-    svt_aom_highbd_smooth_v_predictor_4x8 = svt_aom_highbd_smooth_v_predictor_4x8_c;
-    svt_aom_highbd_smooth_v_predictor_64x16 = svt_aom_highbd_smooth_v_predictor_64x16_c;
-    svt_aom_highbd_smooth_v_predictor_64x32 = svt_aom_highbd_smooth_v_predictor_64x32_c;
-    svt_aom_highbd_smooth_v_predictor_64x64 = svt_aom_highbd_smooth_v_predictor_64x64_c;
-    svt_aom_highbd_smooth_v_predictor_8x16 = svt_aom_highbd_smooth_v_predictor_8x16_c;
-    svt_aom_highbd_smooth_v_predictor_8x32 = svt_aom_highbd_smooth_v_predictor_8x32_c;
-    svt_aom_highbd_smooth_v_predictor_8x4 = svt_aom_highbd_smooth_v_predictor_8x4_c;
-    svt_aom_highbd_smooth_v_predictor_8x8 = svt_aom_highbd_smooth_v_predictor_8x8_c;
-
-
-    svt_av1_dr_prediction_z1 = svt_av1_dr_prediction_z1_c;
-    svt_av1_dr_prediction_z2 = svt_av1_dr_prediction_z2_c;
-    svt_av1_dr_prediction_z3 = svt_av1_dr_prediction_z3_c;
-    svt_av1_highbd_dr_prediction_z1 = svt_av1_highbd_dr_prediction_z1_c;
-    svt_av1_highbd_dr_prediction_z2 = svt_av1_highbd_dr_prediction_z2_c;
-    svt_av1_highbd_dr_prediction_z3 = svt_av1_highbd_dr_prediction_z3_c;
-
-    svt_aom_paeth_predictor_16x16 = svt_aom_paeth_predictor_16x16_c;
-    svt_aom_paeth_predictor_16x32 = svt_aom_paeth_predictor_16x32_c;
-    svt_aom_paeth_predictor_16x4 = svt_aom_paeth_predictor_16x4_c;
-    svt_aom_paeth_predictor_16x64 = svt_aom_paeth_predictor_16x64_c;
-    svt_aom_paeth_predictor_16x8 = svt_aom_paeth_predictor_16x8_c;
-    svt_aom_paeth_predictor_32x16 = svt_aom_paeth_predictor_32x16_c;
-    svt_aom_paeth_predictor_32x32 = svt_aom_paeth_predictor_32x32_c;
-    svt_aom_paeth_predictor_32x64 = svt_aom_paeth_predictor_32x64_c;
-    svt_aom_paeth_predictor_32x8 = svt_aom_paeth_predictor_32x8_c;
-    svt_aom_paeth_predictor_4x16 = svt_aom_paeth_predictor_4x16_c;
-    svt_aom_paeth_predictor_4x4 = svt_aom_paeth_predictor_4x4_c;
-    svt_aom_paeth_predictor_4x8 = svt_aom_paeth_predictor_4x8_c;
-    svt_aom_paeth_predictor_64x16 = svt_aom_paeth_predictor_64x16_c;
-    svt_aom_paeth_predictor_64x32 = svt_aom_paeth_predictor_64x32_c;
-    svt_aom_paeth_predictor_64x64 = svt_aom_paeth_predictor_64x64_c;
-    svt_aom_paeth_predictor_8x16 = svt_aom_paeth_predictor_8x16_c;
-    svt_aom_paeth_predictor_8x32 = svt_aom_paeth_predictor_8x32_c;
-    svt_aom_paeth_predictor_8x4 = svt_aom_paeth_predictor_8x4_c;
-    svt_aom_paeth_predictor_8x8 = svt_aom_paeth_predictor_8x8_c;
-
-    svt_aom_highbd_paeth_predictor_16x16 = svt_aom_highbd_paeth_predictor_16x16_c;
-    svt_aom_highbd_paeth_predictor_16x32 = svt_aom_highbd_paeth_predictor_16x32_c;
-    svt_aom_highbd_paeth_predictor_16x4 = svt_aom_highbd_paeth_predictor_16x4_c;
-    svt_aom_highbd_paeth_predictor_16x64 = svt_aom_highbd_paeth_predictor_16x64_c;
-    svt_aom_highbd_paeth_predictor_16x8 = svt_aom_highbd_paeth_predictor_16x8_c;
-    svt_aom_highbd_paeth_predictor_2x2 = svt_aom_highbd_paeth_predictor_2x2_c;
-    svt_aom_highbd_paeth_predictor_32x16 = svt_aom_highbd_paeth_predictor_32x16_c;
-    svt_aom_highbd_paeth_predictor_32x32 = svt_aom_highbd_paeth_predictor_32x32_c;
-    svt_aom_highbd_paeth_predictor_32x64 = svt_aom_highbd_paeth_predictor_32x64_c;
-    svt_aom_highbd_paeth_predictor_32x8 = svt_aom_highbd_paeth_predictor_32x8_c;
-    svt_aom_highbd_paeth_predictor_4x16 = svt_aom_highbd_paeth_predictor_4x16_c;
-    svt_aom_highbd_paeth_predictor_4x4 = svt_aom_highbd_paeth_predictor_4x4_c;
-    svt_aom_highbd_paeth_predictor_4x8 = svt_aom_highbd_paeth_predictor_4x8_c;
-    svt_aom_highbd_paeth_predictor_64x16 = svt_aom_highbd_paeth_predictor_64x16_c;
-    svt_aom_highbd_paeth_predictor_64x32 = svt_aom_highbd_paeth_predictor_64x32_c;
-    svt_aom_highbd_paeth_predictor_64x64 = svt_aom_highbd_paeth_predictor_64x64_c;
-    svt_aom_highbd_paeth_predictor_8x16 = svt_aom_highbd_paeth_predictor_8x16_c;
-    svt_aom_highbd_paeth_predictor_8x32 = svt_aom_highbd_paeth_predictor_8x32_c;
-    svt_aom_highbd_paeth_predictor_8x4 = svt_aom_highbd_paeth_predictor_8x4_c;
-    svt_aom_highbd_paeth_predictor_8x8 = svt_aom_highbd_paeth_predictor_8x8_c;
-    aom_sum_squares_i16 = svt_aom_sum_squares_i16_c;
-    svt_aom_dc_predictor_4x4 = svt_aom_dc_predictor_4x4_c;
-    svt_aom_dc_predictor_8x8 = svt_aom_dc_predictor_8x8_c;
-    svt_aom_dc_predictor_16x16 = svt_aom_dc_predictor_16x16_c;
-    svt_aom_dc_predictor_32x32 = svt_aom_dc_predictor_32x32_c;
-    svt_aom_dc_predictor_64x64 = svt_aom_dc_predictor_64x64_c;
-    svt_aom_dc_predictor_32x16 = svt_aom_dc_predictor_32x16_c;
-    svt_aom_dc_predictor_32x64 = svt_aom_dc_predictor_32x64_c;
-    svt_aom_dc_predictor_64x16 = svt_aom_dc_predictor_64x16_c;
-    svt_aom_dc_predictor_8x16 = svt_aom_dc_predictor_8x16_c;
-    svt_aom_dc_predictor_8x32 = svt_aom_dc_predictor_8x32_c;
-    svt_aom_dc_predictor_8x4 = svt_aom_dc_predictor_8x4_c;
-    svt_aom_dc_predictor_64x32 = svt_aom_dc_predictor_64x32_c;
-    svt_aom_dc_predictor_16x32 = svt_aom_dc_predictor_16x32_c;
-    svt_aom_dc_predictor_16x4 = svt_aom_dc_predictor_16x4_c;
-    svt_aom_dc_predictor_16x64 = svt_aom_dc_predictor_16x64_c;
-    svt_aom_dc_predictor_16x8 = svt_aom_dc_predictor_16x8_c;
-    svt_aom_dc_predictor_32x8 = svt_aom_dc_predictor_32x8_c;
-    svt_aom_dc_predictor_4x16 = svt_aom_dc_predictor_4x16_c;
-    svt_aom_dc_predictor_4x8 = svt_aom_dc_predictor_4x8_c;
-
-    svt_aom_dc_top_predictor_4x4 = svt_aom_dc_top_predictor_4x4_c;
-    svt_aom_dc_top_predictor_8x8 = svt_aom_dc_top_predictor_8x8_c;
-    svt_aom_dc_top_predictor_16x16 = svt_aom_dc_top_predictor_16x16_c;
-    svt_aom_dc_top_predictor_32x32 = svt_aom_dc_top_predictor_32x32_c;
-    svt_aom_dc_top_predictor_64x64 = svt_aom_dc_top_predictor_64x64_c;
-    svt_aom_dc_top_predictor_16x32 = svt_aom_dc_top_predictor_16x32_c;
-    svt_aom_dc_top_predictor_16x4 = svt_aom_dc_top_predictor_16x4_c;
-    svt_aom_dc_top_predictor_16x64 = svt_aom_dc_top_predictor_16x64_c;
-    svt_aom_dc_top_predictor_16x8 = svt_aom_dc_top_predictor_16x8_c;
-    svt_aom_dc_top_predictor_32x16 = svt_aom_dc_top_predictor_32x16_c;
-    svt_aom_dc_top_predictor_32x64 = svt_aom_dc_top_predictor_32x64_c;
-    svt_aom_dc_top_predictor_32x8 = svt_aom_dc_top_predictor_32x8_c;
-    svt_aom_dc_top_predictor_4x16 = svt_aom_dc_top_predictor_4x16_c;
-    svt_aom_dc_top_predictor_4x8 = svt_aom_dc_top_predictor_4x8_c;
-    svt_aom_dc_top_predictor_64x16 = svt_aom_dc_top_predictor_64x16_c;
-    svt_aom_dc_top_predictor_64x32 = svt_aom_dc_top_predictor_64x32_c;
-    svt_aom_dc_top_predictor_8x16 = svt_aom_dc_top_predictor_8x16_c;
-    svt_aom_dc_top_predictor_8x32 = svt_aom_dc_top_predictor_8x32_c;
-    svt_aom_dc_top_predictor_8x4 = svt_aom_dc_top_predictor_8x4_c;
-
-    svt_aom_dc_left_predictor_4x4 = svt_aom_dc_left_predictor_4x4_c;
-    svt_aom_dc_left_predictor_8x8 = svt_aom_dc_left_predictor_8x8_c;
-    svt_aom_dc_left_predictor_16x16 = svt_aom_dc_left_predictor_16x16_c;
-    svt_aom_dc_left_predictor_32x32 = svt_aom_dc_left_predictor_32x32_c;
-    svt_aom_dc_left_predictor_64x64 = svt_aom_dc_left_predictor_64x64_c;
-    svt_aom_dc_left_predictor_16x32 = svt_aom_dc_left_predictor_16x32_c;
-    svt_aom_dc_left_predictor_16x4 = svt_aom_dc_left_predictor_16x4_c;
-    svt_aom_dc_left_predictor_16x64 = svt_aom_dc_left_predictor_16x64_c;
-    svt_aom_dc_left_predictor_16x8 = svt_aom_dc_left_predictor_16x8_c;
-    svt_aom_dc_left_predictor_32x16 = svt_aom_dc_left_predictor_32x16_c;
-    svt_aom_dc_left_predictor_32x64 = svt_aom_dc_left_predictor_32x64_c;
-    svt_aom_dc_left_predictor_64x16 = svt_aom_dc_left_predictor_64x16_c;
-    svt_aom_dc_left_predictor_64x32 = svt_aom_dc_left_predictor_64x32_c;
-    svt_aom_dc_left_predictor_32x8 = svt_aom_dc_left_predictor_32x8_c;
-    svt_aom_dc_left_predictor_4x16 = svt_aom_dc_left_predictor_4x16_c;
-    svt_aom_dc_left_predictor_4x8 = svt_aom_dc_left_predictor_4x8_c;
-    svt_aom_dc_left_predictor_8x16 = svt_aom_dc_left_predictor_8x16_c;
-    svt_aom_dc_left_predictor_8x32 = svt_aom_dc_left_predictor_8x32_c;
-    svt_aom_dc_left_predictor_8x4 = svt_aom_dc_left_predictor_8x4_c;
-
-    svt_aom_dc_128_predictor_4x4 = svt_aom_dc_128_predictor_4x4_c;
-    svt_aom_dc_128_predictor_8x8 = svt_aom_dc_128_predictor_8x8_c;
-    svt_aom_dc_128_predictor_16x16 = svt_aom_dc_128_predictor_16x16_c;
-    svt_aom_dc_128_predictor_32x32 = svt_aom_dc_128_predictor_32x32_c;
-    svt_aom_dc_128_predictor_64x64 = svt_aom_dc_128_predictor_64x64_c;
-    svt_aom_dc_128_predictor_16x32 = svt_aom_dc_128_predictor_16x32_c;
-    svt_aom_dc_128_predictor_16x4 = svt_aom_dc_128_predictor_16x4_c;
-    svt_aom_dc_128_predictor_16x64 = svt_aom_dc_128_predictor_16x64_c;
-    svt_aom_dc_128_predictor_16x8 = svt_aom_dc_128_predictor_16x8_c;
-    svt_aom_dc_128_predictor_32x16 = svt_aom_dc_128_predictor_32x16_c;
-    svt_aom_dc_128_predictor_32x64 = svt_aom_dc_128_predictor_32x64_c;
-    svt_aom_dc_128_predictor_32x8 = svt_aom_dc_128_predictor_32x8_c;
-    svt_aom_dc_128_predictor_4x16 = svt_aom_dc_128_predictor_4x16_c;
-    svt_aom_dc_128_predictor_4x8 = svt_aom_dc_128_predictor_4x8_c;
-    svt_aom_dc_128_predictor_64x16 = svt_aom_dc_128_predictor_64x16_c;
-    svt_aom_dc_128_predictor_64x32 = svt_aom_dc_128_predictor_64x32_c;
-    svt_aom_dc_128_predictor_8x16 = svt_aom_dc_128_predictor_8x16_c;
-    svt_aom_dc_128_predictor_8x32 = svt_aom_dc_128_predictor_8x32_c;
-    svt_aom_dc_128_predictor_8x4 = svt_aom_dc_128_predictor_8x4_c;
-
-    svt_aom_smooth_h_predictor_16x32 = svt_aom_smooth_h_predictor_16x32_c;
-    svt_aom_smooth_h_predictor_16x4 = svt_aom_smooth_h_predictor_16x4_c;
-    svt_aom_smooth_h_predictor_16x64 = svt_aom_smooth_h_predictor_16x64_c;
-    svt_aom_smooth_h_predictor_16x8 = svt_aom_smooth_h_predictor_16x8_c;
-    svt_aom_smooth_h_predictor_32x16 = svt_aom_smooth_h_predictor_32x16_c;
-    svt_aom_smooth_h_predictor_32x64 = svt_aom_smooth_h_predictor_32x64_c;
-    svt_aom_smooth_h_predictor_32x8 = svt_aom_smooth_h_predictor_32x8_c;
-    svt_aom_smooth_h_predictor_4x16 = svt_aom_smooth_h_predictor_4x16_c;
-    svt_aom_smooth_h_predictor_4x8 = svt_aom_smooth_h_predictor_4x8_c;
-    svt_aom_smooth_h_predictor_64x16 = svt_aom_smooth_h_predictor_64x16_c;
-    svt_aom_smooth_h_predictor_64x32 = svt_aom_smooth_h_predictor_64x32_c;
-    svt_aom_smooth_h_predictor_8x16 = svt_aom_smooth_h_predictor_8x16_c;
-    svt_aom_smooth_h_predictor_8x32 = svt_aom_smooth_h_predictor_8x32_c;
-    svt_aom_smooth_h_predictor_8x4 = svt_aom_smooth_h_predictor_8x4_c;
-    svt_aom_smooth_h_predictor_64x64 = svt_aom_smooth_h_predictor_64x64_c;
-    svt_aom_smooth_h_predictor_32x32 = svt_aom_smooth_h_predictor_32x32_c;
-    svt_aom_smooth_h_predictor_16x16 = svt_aom_smooth_h_predictor_16x16_c;
-    svt_aom_smooth_h_predictor_8x8 = svt_aom_smooth_h_predictor_8x8_c;
-    svt_aom_smooth_h_predictor_4x4 = svt_aom_smooth_h_predictor_4x4_c;
-    svt_aom_smooth_v_predictor_16x32 = svt_aom_smooth_v_predictor_16x32_c;
-    svt_aom_smooth_v_predictor_16x4 = svt_aom_smooth_v_predictor_16x4_c;
-    svt_aom_smooth_v_predictor_16x64 = svt_aom_smooth_v_predictor_16x64_c;
-    svt_aom_smooth_v_predictor_16x8 = svt_aom_smooth_v_predictor_16x8_c;
-    svt_aom_smooth_v_predictor_32x16 = svt_aom_smooth_v_predictor_32x16_c;
-    svt_aom_smooth_v_predictor_32x64 = svt_aom_smooth_v_predictor_32x64_c;
-    svt_aom_smooth_v_predictor_32x8 = svt_aom_smooth_v_predictor_32x8_c;
-    svt_aom_smooth_v_predictor_4x16 = svt_aom_smooth_v_predictor_4x16_c;
-    svt_aom_smooth_v_predictor_4x8 = svt_aom_smooth_v_predictor_4x8_c;
-    svt_aom_smooth_v_predictor_64x16 = svt_aom_smooth_v_predictor_64x16_c;
-    svt_aom_smooth_v_predictor_64x32 = svt_aom_smooth_v_predictor_64x32_c;
-    svt_aom_smooth_v_predictor_8x16 = svt_aom_smooth_v_predictor_8x16_c;
-    svt_aom_smooth_v_predictor_8x32 = svt_aom_smooth_v_predictor_8x32_c;
-    svt_aom_smooth_v_predictor_8x4 = svt_aom_smooth_v_predictor_8x4_c;
-    svt_aom_smooth_v_predictor_64x64 = svt_aom_smooth_v_predictor_64x64_c;
-    svt_aom_smooth_v_predictor_32x32 = svt_aom_smooth_v_predictor_32x32_c;
-    svt_aom_smooth_v_predictor_16x16 = svt_aom_smooth_v_predictor_16x16_c;
-    svt_aom_smooth_v_predictor_8x8 = svt_aom_smooth_v_predictor_8x8_c;
-    svt_aom_smooth_v_predictor_4x4 = svt_aom_smooth_v_predictor_4x4_c;
-
-    svt_aom_smooth_predictor_16x32 = svt_aom_smooth_predictor_16x32_c;
-    svt_aom_smooth_predictor_16x4 = svt_aom_smooth_predictor_16x4_c;
-    svt_aom_smooth_predictor_16x64 = svt_aom_smooth_predictor_16x64_c;
-    svt_aom_smooth_predictor_16x8 = svt_aom_smooth_predictor_16x8_c;
-    svt_aom_smooth_predictor_32x16 = svt_aom_smooth_predictor_32x16_c;
-    svt_aom_smooth_predictor_32x64 = svt_aom_smooth_predictor_32x64_c;
-    svt_aom_smooth_predictor_32x8 = svt_aom_smooth_predictor_32x8_c;
-    svt_aom_smooth_predictor_4x16 = svt_aom_smooth_predictor_4x16_c;
-    svt_aom_smooth_predictor_4x8 = svt_aom_smooth_predictor_4x8_c;
-    svt_aom_smooth_predictor_64x16 = svt_aom_smooth_predictor_64x16_c;
-    svt_aom_smooth_predictor_64x32 = svt_aom_smooth_predictor_64x32_c;
-    svt_aom_smooth_predictor_8x16 = svt_aom_smooth_predictor_8x16_c;
-    svt_aom_smooth_predictor_8x32 = svt_aom_smooth_predictor_8x32_c;
-    svt_aom_smooth_predictor_8x4 = svt_aom_smooth_predictor_8x4_c;
-    svt_aom_smooth_predictor_64x64 = svt_aom_smooth_predictor_64x64_c;
-    svt_aom_smooth_predictor_32x32 = svt_aom_smooth_predictor_32x32_c;
-    svt_aom_smooth_predictor_16x16 = svt_aom_smooth_predictor_16x16_c;
-    svt_aom_smooth_predictor_8x8 = svt_aom_smooth_predictor_8x8_c;
-    svt_aom_smooth_predictor_4x4 = svt_aom_smooth_predictor_4x4_c;
-
-    svt_aom_v_predictor_4x4 = svt_aom_v_predictor_4x4_c;
-    svt_aom_v_predictor_8x8 = svt_aom_v_predictor_8x8_c;
-    svt_aom_v_predictor_16x16 = svt_aom_v_predictor_16x16_c;
-    svt_aom_v_predictor_32x32 = svt_aom_v_predictor_32x32_c;
-    svt_aom_v_predictor_64x64 = svt_aom_v_predictor_64x64_c;
-    svt_aom_v_predictor_16x32 = svt_aom_v_predictor_16x32_c;
-    svt_aom_v_predictor_16x4 = svt_aom_v_predictor_16x4_c;
-    svt_aom_v_predictor_16x64 = svt_aom_v_predictor_16x64_c;
-    svt_aom_v_predictor_16x8 = svt_aom_v_predictor_16x8_c;
-    svt_aom_v_predictor_32x16 = svt_aom_v_predictor_32x16_c;
-    svt_aom_v_predictor_32x64 = svt_aom_v_predictor_32x64_c;
-    svt_aom_v_predictor_32x8 = svt_aom_v_predictor_32x8_c;
-    svt_aom_v_predictor_4x16 = svt_aom_v_predictor_4x16_c;
-    svt_aom_v_predictor_4x8 = svt_aom_v_predictor_4x8_c;
-    svt_aom_v_predictor_64x16 = svt_aom_v_predictor_64x16_c;
-    svt_aom_v_predictor_64x32 = svt_aom_v_predictor_64x32_c;
-    svt_aom_v_predictor_8x16 = svt_aom_v_predictor_8x16_c;
-    svt_aom_v_predictor_8x32 = svt_aom_v_predictor_8x32_c;
-    svt_aom_v_predictor_8x4 = svt_aom_v_predictor_8x4_c;
-
-    svt_aom_h_predictor_4x4 = svt_aom_h_predictor_4x4_c;
-    svt_aom_h_predictor_8x8 = svt_aom_h_predictor_8x8_c;
-    svt_aom_h_predictor_16x16 = svt_aom_h_predictor_16x16_c;
-    svt_aom_h_predictor_32x32 = svt_aom_h_predictor_32x32_c;
-    svt_aom_h_predictor_64x64 = svt_aom_h_predictor_64x64_c;
-    svt_aom_h_predictor_16x32 = svt_aom_h_predictor_16x32_c;
-    svt_aom_h_predictor_16x4 = svt_aom_h_predictor_16x4_c;
-    svt_aom_h_predictor_16x64 = svt_aom_h_predictor_16x64_c;
-    svt_aom_h_predictor_16x8 = svt_aom_h_predictor_16x8_c;
-    svt_aom_h_predictor_32x16 = svt_aom_h_predictor_32x16_c;
-    svt_aom_h_predictor_32x64 = svt_aom_h_predictor_32x64_c;
-    svt_aom_h_predictor_32x8 = svt_aom_h_predictor_32x8_c;
-    svt_aom_h_predictor_4x16 = svt_aom_h_predictor_4x16_c;
-    svt_aom_h_predictor_4x8 = svt_aom_h_predictor_4x8_c;
-    svt_aom_h_predictor_64x16 = svt_aom_h_predictor_64x16_c;
-    svt_aom_h_predictor_64x32 = svt_aom_h_predictor_64x32_c;
-    svt_aom_h_predictor_8x16 = svt_aom_h_predictor_8x16_c;
-    svt_aom_h_predictor_8x32 = svt_aom_h_predictor_8x32_c;
-    svt_aom_h_predictor_8x4 = svt_aom_h_predictor_8x4_c;
-    svt_cdef_find_dir = svt_cdef_find_dir_c;
-
-    svt_cdef_filter_block = svt_cdef_filter_block_c;
-
-    svt_copy_rect8_8bit_to_16bit = svt_copy_rect8_8bit_to_16bit_c;
-
-
-    svt_av1_highbd_warp_affine = svt_av1_highbd_warp_affine_c;
-
-    svt_av1_warp_affine = svt_av1_warp_affine_c;
-
-    svt_aom_highbd_lpf_horizontal_14 = svt_aom_highbd_lpf_horizontal_14_c;
-    svt_aom_highbd_lpf_horizontal_4 = svt_aom_highbd_lpf_horizontal_4_c;
-    svt_aom_highbd_lpf_horizontal_6 = svt_aom_highbd_lpf_horizontal_6_c;
-    svt_aom_highbd_lpf_horizontal_8 = svt_aom_highbd_lpf_horizontal_8_c;
-    svt_aom_highbd_lpf_vertical_14 = svt_aom_highbd_lpf_vertical_14_c;
-    svt_aom_highbd_lpf_vertical_4 = svt_aom_highbd_lpf_vertical_4_c;
-    svt_aom_highbd_lpf_vertical_6 = svt_aom_highbd_lpf_vertical_6_c;
-    svt_aom_highbd_lpf_vertical_8 = svt_aom_highbd_lpf_vertical_8_c;
-    svt_aom_lpf_horizontal_14 = svt_aom_lpf_horizontal_14_c;
-    svt_aom_lpf_horizontal_4 = svt_aom_lpf_horizontal_4_c;
-    svt_aom_lpf_horizontal_6 = svt_aom_lpf_horizontal_6_c;
-    svt_aom_lpf_horizontal_8 = svt_aom_lpf_horizontal_8_c;
-    svt_aom_lpf_vertical_14 = svt_aom_lpf_vertical_14_c;
-    svt_aom_lpf_vertical_4 = svt_aom_lpf_vertical_4_c;
-    svt_aom_lpf_vertical_6 = svt_aom_lpf_vertical_6_c;
-    svt_aom_lpf_vertical_8 = svt_aom_lpf_vertical_8_c;
+    SET_SSE2(svt_aom_highbd_lpf_horizontal_4, svt_aom_highbd_lpf_horizontal_4_c, svt_aom_highbd_lpf_horizontal_4_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_horizontal_6, svt_aom_highbd_lpf_horizontal_6_c, svt_aom_highbd_lpf_horizontal_6_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_horizontal_8, svt_aom_highbd_lpf_horizontal_8_c, svt_aom_highbd_lpf_horizontal_8_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_horizontal_14, svt_aom_highbd_lpf_horizontal_14_c, svt_aom_highbd_lpf_horizontal_14_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_vertical_4, svt_aom_highbd_lpf_vertical_4_c, svt_aom_highbd_lpf_vertical_4_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_vertical_6, svt_aom_highbd_lpf_vertical_6_c, svt_aom_highbd_lpf_vertical_6_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_vertical_8, svt_aom_highbd_lpf_vertical_8_c, svt_aom_highbd_lpf_vertical_8_sse2);
+    SET_SSE2(svt_aom_highbd_lpf_vertical_14, svt_aom_highbd_lpf_vertical_14_c, svt_aom_highbd_lpf_vertical_14_sse2);
+    SET_SSE2(svt_aom_lpf_horizontal_4, svt_aom_lpf_horizontal_4_c, svt_aom_lpf_horizontal_4_sse2);
+    SET_SSE2(svt_aom_lpf_horizontal_6, svt_aom_lpf_horizontal_6_c, svt_aom_lpf_horizontal_6_sse2);
+    SET_SSE2(svt_aom_lpf_horizontal_8, svt_aom_lpf_horizontal_8_c, svt_aom_lpf_horizontal_8_sse2);
+    SET_SSE2(svt_aom_lpf_horizontal_14, svt_aom_lpf_horizontal_14_c, svt_aom_lpf_horizontal_14_sse2);
+    SET_SSE2(svt_aom_lpf_vertical_4, svt_aom_lpf_vertical_4_c, svt_aom_lpf_vertical_4_sse2);
+    SET_SSE2(svt_aom_lpf_vertical_6, svt_aom_lpf_vertical_6_c, svt_aom_lpf_vertical_6_sse2);
+    SET_SSE2(svt_aom_lpf_vertical_8, svt_aom_lpf_vertical_8_c, svt_aom_lpf_vertical_8_sse2);
+    SET_SSE2(svt_aom_lpf_vertical_14, svt_aom_lpf_vertical_14_c, svt_aom_lpf_vertical_14_sse2);
 
     // svt_aom_highbd_v_predictor
-    svt_aom_highbd_v_predictor_16x16 = svt_aom_highbd_v_predictor_16x16_c;
-    svt_aom_highbd_v_predictor_16x32 = svt_aom_highbd_v_predictor_16x32_c;
-    svt_aom_highbd_v_predictor_16x4 = svt_aom_highbd_v_predictor_16x4_c;
-    svt_aom_highbd_v_predictor_16x64 = svt_aom_highbd_v_predictor_16x64_c;
-    svt_aom_highbd_v_predictor_16x8 = svt_aom_highbd_v_predictor_16x8_c;
-    svt_aom_highbd_v_predictor_32x16 = svt_aom_highbd_v_predictor_32x16_c;
-    svt_aom_highbd_v_predictor_32x32 = svt_aom_highbd_v_predictor_32x32_c;
-    svt_aom_highbd_v_predictor_32x64 = svt_aom_highbd_v_predictor_32x64_c;
-    svt_aom_highbd_v_predictor_32x8 = svt_aom_highbd_v_predictor_32x8_c;
-    svt_aom_highbd_v_predictor_4x16 = svt_aom_highbd_v_predictor_4x16_c;
-    svt_aom_highbd_v_predictor_4x4 = svt_aom_highbd_v_predictor_4x4_c;
-    svt_aom_highbd_v_predictor_4x8 = svt_aom_highbd_v_predictor_4x8_c;
-    svt_aom_highbd_v_predictor_64x16 = svt_aom_highbd_v_predictor_64x16_c;
-    svt_aom_highbd_v_predictor_64x32 = svt_aom_highbd_v_predictor_64x32_c;
-    svt_aom_highbd_v_predictor_8x32 = svt_aom_highbd_v_predictor_8x32_c;
-    svt_aom_highbd_v_predictor_64x64 = svt_aom_highbd_v_predictor_64x64_c;
-    svt_aom_highbd_v_predictor_8x16 = svt_aom_highbd_v_predictor_8x16_c;
-    svt_aom_highbd_v_predictor_8x4 = svt_aom_highbd_v_predictor_8x4_c;
-    svt_aom_highbd_v_predictor_8x8 = svt_aom_highbd_v_predictor_8x8_c;
+    SET_SSE2(svt_aom_highbd_v_predictor_4x4, svt_aom_highbd_v_predictor_4x4_c, svt_aom_highbd_v_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_4x8, svt_aom_highbd_v_predictor_4x8_c, svt_aom_highbd_v_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_4x16, svt_aom_highbd_v_predictor_4x16_c, svt_aom_highbd_v_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_8x4, svt_aom_highbd_v_predictor_8x4_c, svt_aom_highbd_v_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_8x8, svt_aom_highbd_v_predictor_8x8_c, svt_aom_highbd_v_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_8x16, svt_aom_highbd_v_predictor_8x16_c, svt_aom_highbd_v_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_highbd_v_predictor_8x32, svt_aom_highbd_v_predictor_8x32_c, svt_aom_highbd_v_predictor_8x32_sse2);
+    SET_AVX2(svt_aom_highbd_v_predictor_16x4, svt_aom_highbd_v_predictor_16x4_c, svt_aom_highbd_v_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_v_predictor_16x8, svt_aom_highbd_v_predictor_16x8_c, svt_aom_highbd_v_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_v_predictor_16x16, svt_aom_highbd_v_predictor_16x16_c, svt_aom_highbd_v_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_v_predictor_16x32, svt_aom_highbd_v_predictor_16x32_c, svt_aom_highbd_v_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_v_predictor_16x64, svt_aom_highbd_v_predictor_16x64_c, svt_aom_highbd_v_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_32x8, svt_aom_highbd_v_predictor_32x8_c, svt_aom_highbd_v_predictor_32x8_avx2, aom_highbd_v_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_32x16, svt_aom_highbd_v_predictor_32x16_c, svt_aom_highbd_v_predictor_32x16_avx2, aom_highbd_v_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_32x32, svt_aom_highbd_v_predictor_32x32_c, svt_aom_highbd_v_predictor_32x32_avx2, aom_highbd_v_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_32x64, svt_aom_highbd_v_predictor_32x64_c, svt_aom_highbd_v_predictor_32x64_avx2, aom_highbd_v_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_64x16, svt_aom_highbd_v_predictor_64x16_c, svt_aom_highbd_v_predictor_64x16_avx2, aom_highbd_v_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_64x32, svt_aom_highbd_v_predictor_64x32_c, svt_aom_highbd_v_predictor_64x32_avx2, aom_highbd_v_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_v_predictor_64x64, svt_aom_highbd_v_predictor_64x64_c, svt_aom_highbd_v_predictor_64x64_avx2, aom_highbd_v_predictor_64x64_avx512);
 
     //aom_highbd_smooth_predictor
-    svt_aom_highbd_smooth_predictor_16x16 = svt_aom_highbd_smooth_predictor_16x16_c;
-    svt_aom_highbd_smooth_predictor_16x32 = svt_aom_highbd_smooth_predictor_16x32_c;
-    svt_aom_highbd_smooth_predictor_16x4 = svt_aom_highbd_smooth_predictor_16x4_c;
-    svt_aom_highbd_smooth_predictor_16x64 = svt_aom_highbd_smooth_predictor_16x64_c;
-    svt_aom_highbd_smooth_predictor_16x8 = svt_aom_highbd_smooth_predictor_16x8_c;
-    svt_aom_highbd_smooth_predictor_2x2 = svt_aom_highbd_smooth_predictor_2x2_c;
-    svt_aom_highbd_smooth_predictor_32x16 = svt_aom_highbd_smooth_predictor_32x16_c;
-    svt_aom_highbd_smooth_predictor_32x32 = svt_aom_highbd_smooth_predictor_32x32_c;
-    svt_aom_highbd_smooth_predictor_32x64 = svt_aom_highbd_smooth_predictor_32x64_c;
-    svt_aom_highbd_smooth_predictor_32x8 = svt_aom_highbd_smooth_predictor_32x8_c;
-    svt_aom_highbd_smooth_predictor_4x16 = svt_aom_highbd_smooth_predictor_4x16_c;
-    svt_aom_highbd_smooth_predictor_4x4 = svt_aom_highbd_smooth_predictor_4x4_c;
-    svt_aom_highbd_smooth_predictor_4x8 = svt_aom_highbd_smooth_predictor_4x8_c;
-    svt_aom_highbd_smooth_predictor_64x16 = svt_aom_highbd_smooth_predictor_64x16_c;
-    svt_aom_highbd_smooth_predictor_64x32 = svt_aom_highbd_smooth_predictor_64x32_c;
-    svt_aom_highbd_smooth_predictor_64x64 = svt_aom_highbd_smooth_predictor_64x64_c;
-    svt_aom_highbd_smooth_predictor_8x16 = svt_aom_highbd_smooth_predictor_8x16_c;
-    svt_aom_highbd_smooth_predictor_8x32 = svt_aom_highbd_smooth_predictor_8x32_c;
-    svt_aom_highbd_smooth_predictor_8x4 = svt_aom_highbd_smooth_predictor_8x4_c;
-    svt_aom_highbd_smooth_predictor_8x8 = svt_aom_highbd_smooth_predictor_8x8_c;
-
+    SET_ONLY_C(svt_aom_highbd_smooth_predictor_2x2, svt_aom_highbd_smooth_predictor_2x2_c);
+    SET_SSSE3(svt_aom_highbd_smooth_predictor_4x4, svt_aom_highbd_smooth_predictor_4x4_c, svt_aom_highbd_smooth_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_predictor_4x8, svt_aom_highbd_smooth_predictor_4x8_c, svt_aom_highbd_smooth_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_predictor_4x16, svt_aom_highbd_smooth_predictor_4x16_c, svt_aom_highbd_smooth_predictor_4x16_ssse3);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_8x4, svt_aom_highbd_smooth_predictor_8x4_c, svt_aom_highbd_smooth_predictor_8x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_8x8, svt_aom_highbd_smooth_predictor_8x8_c, svt_aom_highbd_smooth_predictor_8x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_8x16, svt_aom_highbd_smooth_predictor_8x16_c, svt_aom_highbd_smooth_predictor_8x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_8x32, svt_aom_highbd_smooth_predictor_8x32_c, svt_aom_highbd_smooth_predictor_8x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_16x4, svt_aom_highbd_smooth_predictor_16x4_c, svt_aom_highbd_smooth_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_16x8, svt_aom_highbd_smooth_predictor_16x8_c, svt_aom_highbd_smooth_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_16x16, svt_aom_highbd_smooth_predictor_16x16_c, svt_aom_highbd_smooth_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_16x32, svt_aom_highbd_smooth_predictor_16x32_c, svt_aom_highbd_smooth_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_predictor_16x64, svt_aom_highbd_smooth_predictor_16x64_c, svt_aom_highbd_smooth_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_32x8, svt_aom_highbd_smooth_predictor_32x8_c, svt_aom_highbd_smooth_predictor_32x8_avx2, aom_highbd_smooth_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_32x16, svt_aom_highbd_smooth_predictor_32x16_c, svt_aom_highbd_smooth_predictor_32x16_avx2, aom_highbd_smooth_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_32x32, svt_aom_highbd_smooth_predictor_32x32_c, svt_aom_highbd_smooth_predictor_32x32_avx2, aom_highbd_smooth_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_32x64, svt_aom_highbd_smooth_predictor_32x64_c, svt_aom_highbd_smooth_predictor_32x64_avx2, aom_highbd_smooth_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_64x16, svt_aom_highbd_smooth_predictor_64x16_c, svt_aom_highbd_smooth_predictor_64x16_avx2, aom_highbd_smooth_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_64x32, svt_aom_highbd_smooth_predictor_64x32_c, svt_aom_highbd_smooth_predictor_64x32_avx2, aom_highbd_smooth_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_predictor_64x64, svt_aom_highbd_smooth_predictor_64x64_c, svt_aom_highbd_smooth_predictor_64x64_avx2, aom_highbd_smooth_predictor_64x64_avx512);
 
     //aom_highbd_smooth_h_predictor
-    svt_aom_highbd_smooth_h_predictor_16x16 = svt_aom_highbd_smooth_h_predictor_16x16_c;
-    svt_aom_highbd_smooth_h_predictor_16x32 = svt_aom_highbd_smooth_h_predictor_16x32_c;
-    svt_aom_highbd_smooth_h_predictor_16x4 = svt_aom_highbd_smooth_h_predictor_16x4_c;
-    svt_aom_highbd_smooth_h_predictor_16x64 = svt_aom_highbd_smooth_h_predictor_16x64_c;
-    svt_aom_highbd_smooth_h_predictor_16x8 = svt_aom_highbd_smooth_h_predictor_16x8_c;
-    svt_aom_highbd_smooth_h_predictor_32x16 = svt_aom_highbd_smooth_h_predictor_32x16_c;
-    svt_aom_highbd_smooth_h_predictor_32x32 = svt_aom_highbd_smooth_h_predictor_32x32_c;
-    svt_aom_highbd_smooth_h_predictor_32x64 = svt_aom_highbd_smooth_h_predictor_32x64_c;
-    svt_aom_highbd_smooth_h_predictor_32x8 = svt_aom_highbd_smooth_h_predictor_32x8_c;
-    svt_aom_highbd_smooth_h_predictor_4x16 = svt_aom_highbd_smooth_h_predictor_4x16_c;
-    svt_aom_highbd_smooth_h_predictor_4x4 = svt_aom_highbd_smooth_h_predictor_4x4_c;
-    svt_aom_highbd_smooth_h_predictor_4x8 = svt_aom_highbd_smooth_h_predictor_4x8_c;
-    svt_aom_highbd_smooth_h_predictor_64x16 = svt_aom_highbd_smooth_h_predictor_64x16_c;
-    svt_aom_highbd_smooth_h_predictor_64x32 = svt_aom_highbd_smooth_h_predictor_64x32_c;
-    svt_aom_highbd_smooth_h_predictor_64x64 = svt_aom_highbd_smooth_h_predictor_64x64_c;
-    svt_aom_highbd_smooth_h_predictor_8x16 = svt_aom_highbd_smooth_h_predictor_8x16_c;
-    svt_aom_highbd_smooth_h_predictor_8x32 = svt_aom_highbd_smooth_h_predictor_8x32_c;
-    svt_aom_highbd_smooth_h_predictor_8x4 = svt_aom_highbd_smooth_h_predictor_8x4_c;
-    svt_aom_highbd_smooth_h_predictor_8x8 = svt_aom_highbd_smooth_h_predictor_8x8_c;
+    SET_SSSE3(svt_aom_highbd_smooth_h_predictor_4x4, svt_aom_highbd_smooth_h_predictor_4x4_c, svt_aom_highbd_smooth_h_predictor_4x4_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_h_predictor_4x8, svt_aom_highbd_smooth_h_predictor_4x8_c, svt_aom_highbd_smooth_h_predictor_4x8_ssse3);
+    SET_SSSE3(svt_aom_highbd_smooth_h_predictor_4x16, svt_aom_highbd_smooth_h_predictor_4x16_c, svt_aom_highbd_smooth_h_predictor_4x16_ssse3);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_8x4, svt_aom_highbd_smooth_h_predictor_8x4_c, svt_aom_highbd_smooth_h_predictor_8x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_8x8, svt_aom_highbd_smooth_h_predictor_8x8_c, svt_aom_highbd_smooth_h_predictor_8x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_8x16, svt_aom_highbd_smooth_h_predictor_8x16_c, svt_aom_highbd_smooth_h_predictor_8x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_8x32, svt_aom_highbd_smooth_h_predictor_8x32_c, svt_aom_highbd_smooth_h_predictor_8x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_16x4, svt_aom_highbd_smooth_h_predictor_16x4_c, svt_aom_highbd_smooth_h_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_16x8, svt_aom_highbd_smooth_h_predictor_16x8_c, svt_aom_highbd_smooth_h_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_16x16, svt_aom_highbd_smooth_h_predictor_16x16_c, svt_aom_highbd_smooth_h_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_16x32, svt_aom_highbd_smooth_h_predictor_16x32_c, svt_aom_highbd_smooth_h_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_smooth_h_predictor_16x64, svt_aom_highbd_smooth_h_predictor_16x64_c, svt_aom_highbd_smooth_h_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_32x8, svt_aom_highbd_smooth_h_predictor_32x8_c, svt_aom_highbd_smooth_h_predictor_32x8_avx2, aom_highbd_smooth_h_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_32x16, svt_aom_highbd_smooth_h_predictor_32x16_c, svt_aom_highbd_smooth_h_predictor_32x16_avx2, aom_highbd_smooth_h_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_32x32, svt_aom_highbd_smooth_h_predictor_32x32_c, svt_aom_highbd_smooth_h_predictor_32x32_avx2, aom_highbd_smooth_h_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_32x64, svt_aom_highbd_smooth_h_predictor_32x64_c, svt_aom_highbd_smooth_h_predictor_32x64_avx2, aom_highbd_smooth_h_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_64x16, svt_aom_highbd_smooth_h_predictor_64x16_c, svt_aom_highbd_smooth_h_predictor_64x16_avx2, aom_highbd_smooth_h_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_64x32, svt_aom_highbd_smooth_h_predictor_64x32_c, svt_aom_highbd_smooth_h_predictor_64x32_avx2, aom_highbd_smooth_h_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_smooth_h_predictor_64x64, svt_aom_highbd_smooth_h_predictor_64x64_c, svt_aom_highbd_smooth_h_predictor_64x64_avx2, aom_highbd_smooth_h_predictor_64x64_avx512);
 
     //aom_highbd_dc_128_predictor
-    svt_aom_highbd_dc_128_predictor_16x16 = svt_aom_highbd_dc_128_predictor_16x16_c;
-    svt_aom_highbd_dc_128_predictor_16x32 = svt_aom_highbd_dc_128_predictor_16x32_c;
-    svt_aom_highbd_dc_128_predictor_16x4 = svt_aom_highbd_dc_128_predictor_16x4_c;
-    svt_aom_highbd_dc_128_predictor_16x64 = svt_aom_highbd_dc_128_predictor_16x64_c;
-    svt_aom_highbd_dc_128_predictor_16x8 = svt_aom_highbd_dc_128_predictor_16x8_c;
-    svt_aom_highbd_dc_128_predictor_32x16 = svt_aom_highbd_dc_128_predictor_32x16_c;
-    svt_aom_highbd_dc_128_predictor_32x32 = svt_aom_highbd_dc_128_predictor_32x32_c;
-    svt_aom_highbd_dc_128_predictor_32x64 = svt_aom_highbd_dc_128_predictor_32x64_c;
-    svt_aom_highbd_dc_128_predictor_32x8 = svt_aom_highbd_dc_128_predictor_32x8_c;
-    svt_aom_highbd_dc_128_predictor_4x16 = svt_aom_highbd_dc_128_predictor_4x16_c;
-    svt_aom_highbd_dc_128_predictor_4x4 = svt_aom_highbd_dc_128_predictor_4x4_c;
-    svt_aom_highbd_dc_128_predictor_4x8 = svt_aom_highbd_dc_128_predictor_4x8_c;
-    svt_aom_highbd_dc_128_predictor_8x32 = svt_aom_highbd_dc_128_predictor_8x32_c;
-    svt_aom_highbd_dc_128_predictor_64x16 = svt_aom_highbd_dc_128_predictor_64x16_c;
-    svt_aom_highbd_dc_128_predictor_64x32 = svt_aom_highbd_dc_128_predictor_64x32_c;
-    svt_aom_highbd_dc_128_predictor_64x64 = svt_aom_highbd_dc_128_predictor_64x64_c;
-    svt_aom_highbd_dc_128_predictor_8x16 = svt_aom_highbd_dc_128_predictor_8x16_c;
-    svt_aom_highbd_dc_128_predictor_8x4 = svt_aom_highbd_dc_128_predictor_8x4_c;
-    svt_aom_highbd_dc_128_predictor_8x8 = svt_aom_highbd_dc_128_predictor_8x8_c;
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_4x4, svt_aom_highbd_dc_128_predictor_4x4_c, svt_aom_highbd_dc_128_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_4x8, svt_aom_highbd_dc_128_predictor_4x8_c, svt_aom_highbd_dc_128_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_4x16, svt_aom_highbd_dc_128_predictor_4x16_c, svt_aom_highbd_dc_128_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_8x4, svt_aom_highbd_dc_128_predictor_8x4_c, svt_aom_highbd_dc_128_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_8x8, svt_aom_highbd_dc_128_predictor_8x8_c, svt_aom_highbd_dc_128_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_8x16, svt_aom_highbd_dc_128_predictor_8x16_c, svt_aom_highbd_dc_128_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_128_predictor_8x32, svt_aom_highbd_dc_128_predictor_8x32_c, svt_aom_highbd_dc_128_predictor_8x32_sse2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_16x4, svt_aom_highbd_dc_128_predictor_16x4_c, svt_aom_highbd_dc_128_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_16x8, svt_aom_highbd_dc_128_predictor_16x8_c, svt_aom_highbd_dc_128_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_16x16, svt_aom_highbd_dc_128_predictor_16x16_c, svt_aom_highbd_dc_128_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_16x32, svt_aom_highbd_dc_128_predictor_16x32_c, svt_aom_highbd_dc_128_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_16x64, svt_aom_highbd_dc_128_predictor_16x64_c, svt_aom_highbd_dc_128_predictor_16x64_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_32x8, svt_aom_highbd_dc_128_predictor_32x8_c, svt_aom_highbd_dc_128_predictor_32x8_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_32x16, svt_aom_highbd_dc_128_predictor_32x16_c, svt_aom_highbd_dc_128_predictor_32x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_32x32, svt_aom_highbd_dc_128_predictor_32x32_c, svt_aom_highbd_dc_128_predictor_32x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_32x64, svt_aom_highbd_dc_128_predictor_32x64_c, svt_aom_highbd_dc_128_predictor_32x64_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_64x16, svt_aom_highbd_dc_128_predictor_64x16_c, svt_aom_highbd_dc_128_predictor_64x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_64x32, svt_aom_highbd_dc_128_predictor_64x32_c, svt_aom_highbd_dc_128_predictor_64x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_128_predictor_64x64, svt_aom_highbd_dc_128_predictor_64x64_c, svt_aom_highbd_dc_128_predictor_64x64_avx2);
 
     //aom_highbd_dc_left_predictor
-    svt_aom_highbd_dc_left_predictor_16x16 = svt_aom_highbd_dc_left_predictor_16x16_c;
-    svt_aom_highbd_dc_left_predictor_16x32 = svt_aom_highbd_dc_left_predictor_16x32_c;
-    svt_aom_highbd_dc_left_predictor_16x4 = svt_aom_highbd_dc_left_predictor_16x4_c;
-    svt_aom_highbd_dc_left_predictor_16x64 = svt_aom_highbd_dc_left_predictor_16x64_c;
-    svt_aom_highbd_dc_left_predictor_16x8 = svt_aom_highbd_dc_left_predictor_16x8_c;
-    svt_aom_highbd_dc_left_predictor_2x2 = svt_aom_highbd_dc_left_predictor_2x2_c;
-    svt_aom_highbd_dc_left_predictor_32x16 = svt_aom_highbd_dc_left_predictor_32x16_c;
-    svt_aom_highbd_dc_left_predictor_32x32 = svt_aom_highbd_dc_left_predictor_32x32_c;
-    svt_aom_highbd_dc_left_predictor_32x64 = svt_aom_highbd_dc_left_predictor_32x64_c;
-    svt_aom_highbd_dc_left_predictor_32x8 = svt_aom_highbd_dc_left_predictor_32x8_c;
-    svt_aom_highbd_dc_left_predictor_4x16 = svt_aom_highbd_dc_left_predictor_4x16_c;
-    svt_aom_highbd_dc_left_predictor_4x4 = svt_aom_highbd_dc_left_predictor_4x4_c;
-    svt_aom_highbd_dc_left_predictor_4x8 = svt_aom_highbd_dc_left_predictor_4x8_c;
-    svt_aom_highbd_dc_left_predictor_8x32 = svt_aom_highbd_dc_left_predictor_8x32_c;
-    svt_aom_highbd_dc_left_predictor_64x16 = svt_aom_highbd_dc_left_predictor_64x16_c;
-    svt_aom_highbd_dc_left_predictor_64x32 = svt_aom_highbd_dc_left_predictor_64x32_c;
-    svt_aom_highbd_dc_left_predictor_64x64 = svt_aom_highbd_dc_left_predictor_64x64_c;
-    svt_aom_highbd_dc_left_predictor_8x16 = svt_aom_highbd_dc_left_predictor_8x16_c;
-    svt_aom_highbd_dc_left_predictor_8x4 = svt_aom_highbd_dc_left_predictor_8x4_c;
-    svt_aom_highbd_dc_left_predictor_8x8 = svt_aom_highbd_dc_left_predictor_8x8_c;
+    SET_ONLY_C(svt_aom_highbd_dc_left_predictor_2x2, svt_aom_highbd_dc_left_predictor_2x2_c);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_4x4, svt_aom_highbd_dc_left_predictor_4x4_c, svt_aom_highbd_dc_left_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_4x8, svt_aom_highbd_dc_left_predictor_4x8_c, svt_aom_highbd_dc_left_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_4x16, svt_aom_highbd_dc_left_predictor_4x16_c, svt_aom_highbd_dc_left_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_8x4, svt_aom_highbd_dc_left_predictor_8x4_c, svt_aom_highbd_dc_left_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_8x8, svt_aom_highbd_dc_left_predictor_8x8_c, svt_aom_highbd_dc_left_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_8x16, svt_aom_highbd_dc_left_predictor_8x16_c, svt_aom_highbd_dc_left_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_left_predictor_8x32, svt_aom_highbd_dc_left_predictor_8x32_c, svt_aom_highbd_dc_left_predictor_8x32_sse2);
+    SET_AVX2(svt_aom_highbd_dc_left_predictor_16x4, svt_aom_highbd_dc_left_predictor_16x4_c, svt_aom_highbd_dc_left_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_dc_left_predictor_16x8, svt_aom_highbd_dc_left_predictor_16x8_c, svt_aom_highbd_dc_left_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_dc_left_predictor_16x16, svt_aom_highbd_dc_left_predictor_16x16_c, svt_aom_highbd_dc_left_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_left_predictor_16x32, svt_aom_highbd_dc_left_predictor_16x32_c, svt_aom_highbd_dc_left_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_left_predictor_16x64, svt_aom_highbd_dc_left_predictor_16x64_c, svt_aom_highbd_dc_left_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_32x8, svt_aom_highbd_dc_left_predictor_32x8_c, svt_aom_highbd_dc_left_predictor_32x8_avx2, aom_highbd_dc_left_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_32x16, svt_aom_highbd_dc_left_predictor_32x16_c, svt_aom_highbd_dc_left_predictor_32x16_avx2, aom_highbd_dc_left_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_32x32, svt_aom_highbd_dc_left_predictor_32x32_c, svt_aom_highbd_dc_left_predictor_32x32_avx2, aom_highbd_dc_left_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_32x64, svt_aom_highbd_dc_left_predictor_32x64_c, svt_aom_highbd_dc_left_predictor_32x64_avx2, aom_highbd_dc_left_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_64x16, svt_aom_highbd_dc_left_predictor_64x16_c, svt_aom_highbd_dc_left_predictor_64x16_avx2, aom_highbd_dc_left_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_64x32, svt_aom_highbd_dc_left_predictor_64x32_c, svt_aom_highbd_dc_left_predictor_64x32_avx2, aom_highbd_dc_left_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_left_predictor_64x64, svt_aom_highbd_dc_left_predictor_64x64_c, svt_aom_highbd_dc_left_predictor_64x64_avx2, aom_highbd_dc_left_predictor_64x64_avx512);
 
-    svt_aom_highbd_dc_predictor_16x16 = svt_aom_highbd_dc_predictor_16x16_c;
-    svt_aom_highbd_dc_predictor_16x32 = svt_aom_highbd_dc_predictor_16x32_c;
-    svt_aom_highbd_dc_predictor_16x4 = svt_aom_highbd_dc_predictor_16x4_c;
-    svt_aom_highbd_dc_predictor_16x64 = svt_aom_highbd_dc_predictor_16x64_c;
-    svt_aom_highbd_dc_predictor_16x8 = svt_aom_highbd_dc_predictor_16x8_c;
-    svt_aom_highbd_dc_predictor_2x2 = svt_aom_highbd_dc_predictor_2x2_c;
-    svt_aom_highbd_dc_predictor_32x16 = svt_aom_highbd_dc_predictor_32x16_c;
-    svt_aom_highbd_dc_predictor_32x32 = svt_aom_highbd_dc_predictor_32x32_c;
-    svt_aom_highbd_dc_predictor_32x64 = svt_aom_highbd_dc_predictor_32x64_c;
-    svt_aom_highbd_dc_predictor_32x8 = svt_aom_highbd_dc_predictor_32x8_c;
-    svt_aom_highbd_dc_predictor_4x16 = svt_aom_highbd_dc_predictor_4x16_c;
-    svt_aom_highbd_dc_predictor_4x4 = svt_aom_highbd_dc_predictor_4x4_c;
-    svt_aom_highbd_dc_predictor_4x8 = svt_aom_highbd_dc_predictor_4x8_c;
-    svt_aom_highbd_dc_predictor_64x16 = svt_aom_highbd_dc_predictor_64x16_c;
-    svt_aom_highbd_dc_predictor_64x32 = svt_aom_highbd_dc_predictor_64x32_c;
-    svt_aom_highbd_dc_predictor_64x64 = svt_aom_highbd_dc_predictor_64x64_c;
-    svt_aom_highbd_dc_predictor_8x16 = svt_aom_highbd_dc_predictor_8x16_c;
-    svt_aom_highbd_dc_predictor_8x4 = svt_aom_highbd_dc_predictor_8x4_c;
-    svt_aom_highbd_dc_predictor_8x8 = svt_aom_highbd_dc_predictor_8x8_c;
-    svt_aom_highbd_dc_predictor_8x32 = svt_aom_highbd_dc_predictor_8x32_c;
+    SET_ONLY_C(svt_aom_highbd_dc_predictor_2x2, svt_aom_highbd_dc_predictor_2x2_c);
+    SET_SSE2(svt_aom_highbd_dc_predictor_4x4, svt_aom_highbd_dc_predictor_4x4_c, svt_aom_highbd_dc_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_4x8, svt_aom_highbd_dc_predictor_4x8_c, svt_aom_highbd_dc_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_4x16, svt_aom_highbd_dc_predictor_4x16_c, svt_aom_highbd_dc_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_8x4, svt_aom_highbd_dc_predictor_8x4_c, svt_aom_highbd_dc_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_8x8, svt_aom_highbd_dc_predictor_8x8_c, svt_aom_highbd_dc_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_8x16, svt_aom_highbd_dc_predictor_8x16_c, svt_aom_highbd_dc_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_predictor_8x32, svt_aom_highbd_dc_predictor_8x32_c, svt_aom_highbd_dc_predictor_8x32_sse2);
+    SET_AVX2(svt_aom_highbd_dc_predictor_16x4, svt_aom_highbd_dc_predictor_16x4_c, svt_aom_highbd_dc_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_dc_predictor_16x8, svt_aom_highbd_dc_predictor_16x8_c, svt_aom_highbd_dc_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_dc_predictor_16x16, svt_aom_highbd_dc_predictor_16x16_c, svt_aom_highbd_dc_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_predictor_16x32, svt_aom_highbd_dc_predictor_16x32_c, svt_aom_highbd_dc_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_predictor_16x64, svt_aom_highbd_dc_predictor_16x64_c, svt_aom_highbd_dc_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_32x8, svt_aom_highbd_dc_predictor_32x8_c, svt_aom_highbd_dc_predictor_32x8_avx2, aom_highbd_dc_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_32x16, svt_aom_highbd_dc_predictor_32x16_c, svt_aom_highbd_dc_predictor_32x16_avx2, aom_highbd_dc_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_32x32, svt_aom_highbd_dc_predictor_32x32_c, svt_aom_highbd_dc_predictor_32x32_avx2, aom_highbd_dc_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_32x64, svt_aom_highbd_dc_predictor_32x64_c, svt_aom_highbd_dc_predictor_32x64_avx2, aom_highbd_dc_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_64x16, svt_aom_highbd_dc_predictor_64x16_c, svt_aom_highbd_dc_predictor_64x16_avx2, aom_highbd_dc_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_64x32, svt_aom_highbd_dc_predictor_64x32_c, svt_aom_highbd_dc_predictor_64x32_avx2, aom_highbd_dc_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_predictor_64x64, svt_aom_highbd_dc_predictor_64x64_c, svt_aom_highbd_dc_predictor_64x64_avx2, aom_highbd_dc_predictor_64x64_avx512);
 
     //aom_highbd_dc_top_predictor
-    svt_aom_highbd_dc_top_predictor_16x16 = svt_aom_highbd_dc_top_predictor_16x16_c;
-    svt_aom_highbd_dc_top_predictor_16x32 = svt_aom_highbd_dc_top_predictor_16x32_c;
-    svt_aom_highbd_dc_top_predictor_16x4 = svt_aom_highbd_dc_top_predictor_16x4_c;
-    svt_aom_highbd_dc_top_predictor_16x64 = svt_aom_highbd_dc_top_predictor_16x64_c;
-    svt_aom_highbd_dc_top_predictor_16x8 = svt_aom_highbd_dc_top_predictor_16x8_c;
-    svt_aom_highbd_dc_top_predictor_32x16 = svt_aom_highbd_dc_top_predictor_32x16_c;
-    svt_aom_highbd_dc_top_predictor_32x32 = svt_aom_highbd_dc_top_predictor_32x32_c;
-    svt_aom_highbd_dc_top_predictor_32x64 = svt_aom_highbd_dc_top_predictor_32x64_c;
-    svt_aom_highbd_dc_top_predictor_32x8 = svt_aom_highbd_dc_top_predictor_32x8_c;
-    svt_aom_highbd_dc_top_predictor_4x16 = svt_aom_highbd_dc_top_predictor_4x16_c;
-    svt_aom_highbd_dc_top_predictor_4x4 = svt_aom_highbd_dc_top_predictor_4x4_c;
-    svt_aom_highbd_dc_top_predictor_4x8 = svt_aom_highbd_dc_top_predictor_4x8_c;
-    svt_aom_highbd_dc_top_predictor_64x16 = svt_aom_highbd_dc_top_predictor_64x16_c;
-    svt_aom_highbd_dc_top_predictor_64x32 = svt_aom_highbd_dc_top_predictor_64x32_c;
-    svt_aom_highbd_dc_top_predictor_64x64 = svt_aom_highbd_dc_top_predictor_64x64_c;
-    svt_aom_highbd_dc_top_predictor_8x16 = svt_aom_highbd_dc_top_predictor_8x16_c;
-    svt_aom_highbd_dc_top_predictor_8x32 = svt_aom_highbd_dc_top_predictor_8x32_c;
-    svt_aom_highbd_dc_top_predictor_8x4 = svt_aom_highbd_dc_top_predictor_8x4_c;
-    svt_aom_highbd_dc_top_predictor_8x8 = svt_aom_highbd_dc_top_predictor_8x8_c;
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_4x4, svt_aom_highbd_dc_top_predictor_4x4_c, svt_aom_highbd_dc_top_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_4x8, svt_aom_highbd_dc_top_predictor_4x8_c, svt_aom_highbd_dc_top_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_4x16, svt_aom_highbd_dc_top_predictor_4x16_c, svt_aom_highbd_dc_top_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_8x4, svt_aom_highbd_dc_top_predictor_8x4_c, svt_aom_highbd_dc_top_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_8x8, svt_aom_highbd_dc_top_predictor_8x8_c, svt_aom_highbd_dc_top_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_dc_top_predictor_8x16, svt_aom_highbd_dc_top_predictor_8x16_c, svt_aom_highbd_dc_top_predictor_8x16_sse2);
+    SET_ONLY_C(svt_aom_highbd_dc_top_predictor_8x32, svt_aom_highbd_dc_top_predictor_8x32_c);
+    SET_AVX2(svt_aom_highbd_dc_top_predictor_16x4, svt_aom_highbd_dc_top_predictor_16x4_c, svt_aom_highbd_dc_top_predictor_16x4_avx2);
+    SET_AVX2(svt_aom_highbd_dc_top_predictor_16x8, svt_aom_highbd_dc_top_predictor_16x8_c, svt_aom_highbd_dc_top_predictor_16x8_avx2);
+    SET_AVX2(svt_aom_highbd_dc_top_predictor_16x16, svt_aom_highbd_dc_top_predictor_16x16_c, svt_aom_highbd_dc_top_predictor_16x16_avx2);
+    SET_AVX2(svt_aom_highbd_dc_top_predictor_16x32, svt_aom_highbd_dc_top_predictor_16x32_c, svt_aom_highbd_dc_top_predictor_16x32_avx2);
+    SET_AVX2(svt_aom_highbd_dc_top_predictor_16x64, svt_aom_highbd_dc_top_predictor_16x64_c, svt_aom_highbd_dc_top_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_32x8, svt_aom_highbd_dc_top_predictor_32x8_c, svt_aom_highbd_dc_top_predictor_32x8_avx2, aom_highbd_dc_top_predictor_32x8_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_32x16, svt_aom_highbd_dc_top_predictor_32x16_c, svt_aom_highbd_dc_top_predictor_32x16_avx2, aom_highbd_dc_top_predictor_32x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_32x32, svt_aom_highbd_dc_top_predictor_32x32_c, svt_aom_highbd_dc_top_predictor_32x32_avx2, aom_highbd_dc_top_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_32x64, svt_aom_highbd_dc_top_predictor_32x64_c, svt_aom_highbd_dc_top_predictor_32x64_avx2, aom_highbd_dc_top_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_64x16, svt_aom_highbd_dc_top_predictor_64x16_c, svt_aom_highbd_dc_top_predictor_64x16_avx2, aom_highbd_dc_top_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_64x32, svt_aom_highbd_dc_top_predictor_64x32_c, svt_aom_highbd_dc_top_predictor_64x32_avx2, aom_highbd_dc_top_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_dc_top_predictor_64x64, svt_aom_highbd_dc_top_predictor_64x64_c, svt_aom_highbd_dc_top_predictor_64x64_avx2, aom_highbd_dc_top_predictor_64x64_avx512);
 
     // svt_aom_highbd_h_predictor
-    svt_aom_highbd_h_predictor_16x4 = svt_aom_highbd_h_predictor_16x4_c;
-    svt_aom_highbd_h_predictor_16x64 = svt_aom_highbd_h_predictor_16x64_c;
-    svt_aom_highbd_h_predictor_16x8 = svt_aom_highbd_h_predictor_16x8_c;
-    svt_aom_highbd_h_predictor_32x16 = svt_aom_highbd_h_predictor_32x16_c;
-    svt_aom_highbd_h_predictor_32x32 = svt_aom_highbd_h_predictor_32x32_c;
-    svt_aom_highbd_h_predictor_32x64 = svt_aom_highbd_h_predictor_32x64_c;
-    svt_aom_highbd_h_predictor_32x8 = svt_aom_highbd_h_predictor_32x8_c;
-    svt_aom_highbd_h_predictor_4x16 = svt_aom_highbd_h_predictor_4x16_c;
-    svt_aom_highbd_h_predictor_4x4 = svt_aom_highbd_h_predictor_4x4_c;
-    svt_aom_highbd_h_predictor_4x8 = svt_aom_highbd_h_predictor_4x8_c;
-    svt_aom_highbd_h_predictor_64x16 = svt_aom_highbd_h_predictor_64x16_c;
-    svt_aom_highbd_h_predictor_64x32 = svt_aom_highbd_h_predictor_64x32_c;
-    svt_aom_highbd_h_predictor_8x32 = svt_aom_highbd_h_predictor_8x32_c;
-    svt_aom_highbd_h_predictor_64x64 = svt_aom_highbd_h_predictor_64x64_c;
-    svt_aom_highbd_h_predictor_8x16 = svt_aom_highbd_h_predictor_8x16_c;
-    svt_aom_highbd_h_predictor_8x4 = svt_aom_highbd_h_predictor_8x4_c;
-    svt_aom_highbd_h_predictor_8x8 = svt_aom_highbd_h_predictor_8x8_c;
-    svt_aom_highbd_h_predictor_16x16 = svt_aom_highbd_h_predictor_16x16_c;
-    svt_aom_highbd_h_predictor_16x32 = svt_aom_highbd_h_predictor_16x32_c;
-    svt_log2f = log2f_32;
-    svt_memcpy = svt_memcpy_c;
-#ifdef ARCH_X86_64
-    flags &= get_cpu_flags_to_use();
-    if (flags & HAS_SSE4_1) svt_aom_blend_a64_mask = svt_aom_blend_a64_mask_sse4_1;
-    if (flags & HAS_AVX2) svt_aom_blend_a64_mask = svt_aom_blend_a64_mask_avx2;
-    if (flags & HAS_SSE4_1) svt_aom_blend_a64_hmask = svt_aom_blend_a64_hmask_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_blend_a64_vmask = svt_aom_blend_a64_vmask_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_highbd_blend_a64_mask = svt_aom_highbd_blend_a64_mask_8bit_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_highbd_blend_a64_hmask_8bit = svt_aom_highbd_blend_a64_hmask_8bit_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_highbd_blend_a64_vmask_8bit = svt_aom_highbd_blend_a64_vmask_8bit_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_highbd_blend_a64_vmask_16bit = svt_aom_highbd_blend_a64_vmask_16bit_sse4_1;
-    if (flags & HAS_SSE4_1) svt_aom_highbd_blend_a64_hmask_16bit = svt_aom_highbd_blend_a64_hmask_16bit_sse4_1;
-    if (flags & HAS_AVX2) svt_cfl_predict_lbd = svt_cfl_predict_lbd_avx2;
-    if (flags & HAS_AVX2) svt_cfl_predict_hbd = svt_cfl_predict_hbd_avx2;
-    if (flags & HAS_SSE4_1) svt_av1_filter_intra_predictor = svt_av1_filter_intra_predictor_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_filter_intra_edge_high = svt_av1_filter_intra_edge_high_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_filter_intra_edge = svt_av1_filter_intra_edge_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_upsample_intra_edge = svt_av1_upsample_intra_edge_sse4_1;
-    if (flags & HAS_AVX2) svt_av1_build_compound_diffwtd_mask_d16 = svt_av1_build_compound_diffwtd_mask_d16_avx2;
-    if (flags & HAS_AVX2) svt_av1_highbd_wiener_convolve_add_src = svt_av1_highbd_wiener_convolve_add_src_avx2;
-    if (flags & HAS_AVX2) svt_apply_selfguided_restoration = svt_apply_selfguided_restoration_avx2;
-    if (flags & HAS_AVX2) svt_av1_selfguided_restoration = svt_av1_selfguided_restoration_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_4x4 = svt_av1_inv_txfm2d_add_4x4_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_8x8 = svt_av1_inv_txfm2d_add_8x8_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_8x16 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_16x8 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_32x8 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_8x32 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_SSE4_1) svt_av1_inv_txfm2d_add_4x8 = svt_av1_inv_txfm2d_add_4x8_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_inv_txfm2d_add_8x4 = svt_av1_inv_txfm2d_add_8x4_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_inv_txfm2d_add_4x16 = svt_av1_inv_txfm2d_add_4x16_sse4_1;
-    if (flags & HAS_SSE4_1) svt_av1_inv_txfm2d_add_16x4 = svt_av1_inv_txfm2d_add_16x4_sse4_1;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_16x16 = svt_av1_inv_txfm2d_add_16x16_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_32x32 = svt_av1_inv_txfm2d_add_32x32_avx2;
-    SET_SSE41_AVX2(svt_av1_inv_txfm2d_add_64x64,
-                   svt_av1_inv_txfm2d_add_64x64_c,
-                   svt_av1_inv_txfm2d_add_64x64_sse4_1,
-                   svt_av1_inv_txfm2d_add_64x64_avx2);
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_16x64 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_64x16 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_32x64 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_64x32 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_16x32 = svt_av1_highbd_inv_txfm_add_avx2;
-    if (flags & HAS_AVX2) svt_av1_inv_txfm2d_add_32x16 = svt_av1_highbd_inv_txfm_add_avx2;
-#ifndef NON_AVX512_SUPPORT
-    if (flags & HAS_AVX512F) {
-        svt_av1_inv_txfm2d_add_16x16 = svt_av1_inv_txfm2d_add_16x16_avx512;
-        svt_av1_inv_txfm2d_add_32x32 = svt_av1_inv_txfm2d_add_32x32_avx512;
-        svt_av1_inv_txfm2d_add_64x64 = svt_av1_inv_txfm2d_add_64x64_avx512;
-        svt_av1_inv_txfm2d_add_16x64 = svt_av1_inv_txfm2d_add_16x64_avx512;
-        svt_av1_inv_txfm2d_add_64x16 = svt_av1_inv_txfm2d_add_64x16_avx512;
-        svt_av1_inv_txfm2d_add_32x64 = svt_av1_inv_txfm2d_add_32x64_avx512;
-        svt_av1_inv_txfm2d_add_64x32 = svt_av1_inv_txfm2d_add_64x32_avx512;
-        svt_av1_inv_txfm2d_add_16x32 = svt_av1_inv_txfm2d_add_16x32_avx512;
-        svt_av1_inv_txfm2d_add_32x16 = svt_av1_inv_txfm2d_add_32x16_avx512;
-    }
-#endif
-
-        if (flags & HAS_SSSE3) svt_av1_inv_txfm_add = svt_av1_inv_txfm_add_ssse3;
-        if (flags & HAS_AVX2) svt_av1_inv_txfm_add = svt_av1_inv_txfm_add_avx2;
-        SET_AVX2(svt_compressed_packmsb, svt_compressed_packmsb_c, svt_compressed_packmsb_avx2_intrin);
-        SET_AVX2(svt_c_pack, svt_c_pack_c, svt_c_pack_avx2_intrin);
-        SET_SSE2_AVX2(svt_unpack_avg, svt_unpack_avg_c, svt_unpack_avg_sse2_intrin, svt_unpack_avg_avx2_intrin);
-        SET_AVX2(svt_unpack_avg_safe_sub, svt_unpack_avg_safe_sub_c, svt_unpack_avg_safe_sub_avx2_intrin);
-        SET_AVX2(svt_un_pack8_bit_data, svt_un_pack8_bit_data_c, svt_enc_un_pack8_bit_data_avx2_intrin);
-        SET_AVX2(svt_cfl_luma_subsampling_420_lbd,
-                 svt_cfl_luma_subsampling_420_lbd_c,
-                 svt_cfl_luma_subsampling_420_lbd_avx2);
-        SET_AVX2(svt_cfl_luma_subsampling_420_hbd,
-                 svt_cfl_luma_subsampling_420_hbd_c,
-                 svt_cfl_luma_subsampling_420_hbd_avx2);
-        SET_AVX2(svt_convert_8bit_to_16bit, svt_convert_8bit_to_16bit_c, svt_convert_8bit_to_16bit_avx2);
-        SET_AVX2(svt_convert_16bit_to_8bit, svt_convert_16bit_to_8bit_c, svt_convert_16bit_to_8bit_avx2);
-        SET_SSE2_AVX2(svt_pack2d_16_bit_src_mul4,
-                      svt_enc_msb_pack2_d,
-                      svt_enc_msb_pack2d_sse2_intrin,
-                      svt_enc_msb_pack2d_avx2_intrin_al);
-        SET_SSE2(svt_un_pack2d_16_bit_src_mul4, svt_enc_msb_un_pack2_d, svt_enc_msb_un_pack2d_sse2_intrin);
-        SET_AVX2(svt_full_distortion_kernel_cbf_zero32_bits,
-                 svt_full_distortion_kernel_cbf_zero32_bits_c,
-                 svt_full_distortion_kernel_cbf_zero32_bits_avx2);
-        SET_AVX2(svt_full_distortion_kernel32_bits,
-                 svt_full_distortion_kernel32_bits_c,
-                 svt_full_distortion_kernel32_bits_avx2);
-
-        SET_AVX2_AVX512(svt_spatial_full_distortion_kernel,
-                        svt_spatial_full_distortion_kernel_c,
-                        svt_spatial_full_distortion_kernel_avx2,
-                        svt_spatial_full_distortion_kernel_avx512);
-        SET_AVX2(svt_full_distortion_kernel16_bits,
-                 svt_full_distortion_kernel16_bits_c,
-                 svt_full_distortion_kernel16_bits_avx2);
-        SET_AVX2_AVX512(svt_residual_kernel8bit,
-                        svt_residual_kernel8bit_c,
-                        svt_residual_kernel8bit_avx2,
-                        svt_residual_kernel8bit_avx512);
-
-        SET_SSE2_AVX2(svt_residual_kernel16bit,
-                      svt_residual_kernel16bit_c,
-                      svt_residual_kernel16bit_sse2_intrin,
-                      svt_residual_kernel16bit_avx2);
-        SET_SSE2(svt_picture_average_kernel,
-                 svt_picture_average_kernel_c,
-                 svt_picture_average_kernel_sse2_intrin);
-        SET_SSE2(svt_picture_average_kernel1_line,
-                 svt_picture_average_kernel1_line_c,
-                 svt_picture_average_kernel1_line_sse2_intrin);
-        SET_AVX2_AVX512(svt_av1_wiener_convolve_add_src,
-            svt_av1_wiener_convolve_add_src_c,
-            svt_av1_wiener_convolve_add_src_avx2,
-            svt_av1_wiener_convolve_add_src_avx512);
-
-        if (flags & HAS_AVX2) svt_av1_convolve_2d_copy_sr = svt_av1_convolve_2d_copy_sr_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_convolve_2d_copy_sr = svt_av1_highbd_convolve_2d_copy_sr_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_jnt_convolve_2d_copy = svt_av1_highbd_jnt_convolve_2d_copy_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_convolve_y_sr = svt_av1_highbd_convolve_y_sr_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_convolve_2d_sr = svt_av1_highbd_convolve_2d_sr_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_jnt_convolve_2d = svt_av1_highbd_jnt_convolve_2d_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_jnt_convolve_x = svt_av1_highbd_jnt_convolve_x_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_jnt_convolve_y = svt_av1_highbd_jnt_convolve_y_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_convolve_x_sr = svt_av1_highbd_convolve_x_sr_avx2;
-        SET_AVX2_AVX512(svt_av1_convolve_2d_sr,
-            svt_av1_convolve_2d_sr_c,
-            svt_av1_convolve_2d_sr_avx2,
-            svt_av1_convolve_2d_sr_avx512);
-        SET_AVX2_AVX512(svt_av1_convolve_2d_copy_sr,
-            svt_av1_convolve_2d_copy_sr_c,
-            svt_av1_convolve_2d_copy_sr_avx2,
-            svt_av1_convolve_2d_copy_sr_avx512);
-        SET_AVX2_AVX512(svt_av1_convolve_x_sr,
-            svt_av1_convolve_x_sr_c,
-            svt_av1_convolve_x_sr_avx2,
-            svt_av1_convolve_x_sr_avx512);
-        SET_AVX2_AVX512(svt_av1_convolve_y_sr,
-            svt_av1_convolve_y_sr_c,
-            svt_av1_convolve_y_sr_avx2,
-            svt_av1_convolve_y_sr_avx512);
-        SET_AVX2_AVX512(svt_av1_jnt_convolve_2d,
-            svt_av1_jnt_convolve_2d_c,
-            svt_av1_jnt_convolve_2d_avx2,
-            svt_av1_jnt_convolve_2d_avx512);
-        SET_AVX2_AVX512(svt_av1_jnt_convolve_2d_copy,
-            svt_av1_jnt_convolve_2d_copy_c,
-            svt_av1_jnt_convolve_2d_copy_avx2,
-            svt_av1_jnt_convolve_2d_copy_avx512);
-        SET_AVX2_AVX512(svt_av1_jnt_convolve_x,
-            svt_av1_jnt_convolve_x_c,
-            svt_av1_jnt_convolve_x_avx2,
-            svt_av1_jnt_convolve_x_avx512);
-        SET_AVX2_AVX512(svt_av1_jnt_convolve_y,
-            svt_av1_jnt_convolve_y_c,
-            svt_av1_jnt_convolve_y_avx2,
-            svt_av1_jnt_convolve_y_avx512);
-
-        if (flags & HAS_AVX2) svt_aom_convolve8_horiz = svt_aom_convolve8_horiz_avx2;
-        if (flags & HAS_AVX2) svt_aom_convolve8_vert = svt_aom_convolve8_vert_avx2;
-        if (flags & HAS_AVX2) svt_av1_build_compound_diffwtd_mask = svt_av1_build_compound_diffwtd_mask_avx2;
-        if (flags & HAS_AVX2) svt_av1_build_compound_diffwtd_mask_highbd = svt_av1_build_compound_diffwtd_mask_highbd_avx2;
-        if (flags & HAS_AVX2) svt_av1_wedge_sse_from_residuals = svt_av1_wedge_sse_from_residuals_avx2;
-        if (flags & HAS_AVX2) svt_aom_subtract_block = svt_aom_subtract_block_avx2;
-        if (flags & HAS_AVX2) svt_aom_lowbd_blend_a64_d16_mask = svt_aom_lowbd_blend_a64_d16_mask_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_blend_a64_d16_mask = svt_aom_highbd_blend_a64_d16_mask_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_subtract_block = svt_aom_highbd_subtract_block_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_16x16 = svt_aom_highbd_smooth_v_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_16x32 = svt_aom_highbd_smooth_v_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_16x4 = svt_aom_highbd_smooth_v_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_16x64 = svt_aom_highbd_smooth_v_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_16x8 = svt_aom_highbd_smooth_v_predictor_16x8_avx2;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_v_predictor_4x16 = svt_aom_highbd_smooth_v_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_v_predictor_4x4 = svt_aom_highbd_smooth_v_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_v_predictor_4x8 = svt_aom_highbd_smooth_v_predictor_4x8_ssse3;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_8x16 = svt_aom_highbd_smooth_v_predictor_8x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_8x32 = svt_aom_highbd_smooth_v_predictor_8x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_8x4 = svt_aom_highbd_smooth_v_predictor_8x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_8x8 = svt_aom_highbd_smooth_v_predictor_8x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_32x8 = svt_aom_highbd_smooth_v_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_32x16 = svt_aom_highbd_smooth_v_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_32x32 = svt_aom_highbd_smooth_v_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_32x64 = svt_aom_highbd_smooth_v_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_64x16 = svt_aom_highbd_smooth_v_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_64x32 = svt_aom_highbd_smooth_v_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_v_predictor_64x64 = svt_aom_highbd_smooth_v_predictor_64x64_avx2;
-
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_smooth_v_predictor_32x8 = aom_highbd_smooth_v_predictor_32x8_avx512;
-            svt_aom_highbd_smooth_v_predictor_32x16 = aom_highbd_smooth_v_predictor_32x16_avx512;
-            svt_aom_highbd_smooth_v_predictor_32x32 = aom_highbd_smooth_v_predictor_32x32_avx512;
-            svt_aom_highbd_smooth_v_predictor_32x64 = aom_highbd_smooth_v_predictor_32x64_avx512;
-            svt_aom_highbd_smooth_v_predictor_64x16 = aom_highbd_smooth_v_predictor_64x16_avx512;
-            svt_aom_highbd_smooth_v_predictor_64x32 = aom_highbd_smooth_v_predictor_64x32_avx512;
-            svt_aom_highbd_smooth_v_predictor_64x64 = aom_highbd_smooth_v_predictor_64x64_avx512;
-        }
-#endif // !NON_AVX512_SUPPORT
-
-        if (flags & HAS_AVX2) svt_av1_dr_prediction_z1 = svt_av1_dr_prediction_z1_avx2;
-        if (flags & HAS_AVX2) svt_av1_dr_prediction_z2 = svt_av1_dr_prediction_z2_avx2;
-        if (flags & HAS_AVX2) svt_av1_dr_prediction_z3 = svt_av1_dr_prediction_z3_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_dr_prediction_z1 = svt_av1_highbd_dr_prediction_z1_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_dr_prediction_z2 = svt_av1_highbd_dr_prediction_z2_avx2;
-        if (flags & HAS_AVX2) svt_av1_highbd_dr_prediction_z3 = svt_av1_highbd_dr_prediction_z3_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_16x16 = svt_aom_paeth_predictor_16x16_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_16x16 = svt_aom_paeth_predictor_16x16_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_16x32 = svt_aom_paeth_predictor_16x32_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_16x32 = svt_aom_paeth_predictor_16x32_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_16x4 = svt_aom_paeth_predictor_16x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_16x64 = svt_aom_paeth_predictor_16x64_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_16x64 = svt_aom_paeth_predictor_16x64_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_16x8 = svt_aom_paeth_predictor_16x8_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_16x8 = svt_aom_paeth_predictor_16x8_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_32x16 = svt_aom_paeth_predictor_32x16_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_32x16 = svt_aom_paeth_predictor_32x16_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_32x32 = svt_aom_paeth_predictor_32x32_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_32x32 = svt_aom_paeth_predictor_32x32_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_32x64 = svt_aom_paeth_predictor_32x64_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_32x64 = svt_aom_paeth_predictor_32x64_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_32x8 = svt_aom_paeth_predictor_32x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_4x16 = svt_aom_paeth_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_4x4 = svt_aom_paeth_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_4x8 = svt_aom_paeth_predictor_4x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_64x16 = svt_aom_paeth_predictor_64x16_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_64x16 = svt_aom_paeth_predictor_64x16_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_64x32 = svt_aom_paeth_predictor_64x32_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_64x32 = svt_aom_paeth_predictor_64x32_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_64x64 = svt_aom_paeth_predictor_64x64_ssse3;
-        if (flags & HAS_AVX2) svt_aom_paeth_predictor_64x64 = svt_aom_paeth_predictor_64x64_avx2;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_8x16 = svt_aom_paeth_predictor_8x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_8x32 = svt_aom_paeth_predictor_8x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_8x4 = svt_aom_paeth_predictor_8x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_paeth_predictor_8x8 = svt_aom_paeth_predictor_8x8_ssse3;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_16x16 = svt_aom_highbd_paeth_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_16x32 = svt_aom_highbd_paeth_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_16x4 = svt_aom_highbd_paeth_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_16x64 = svt_aom_highbd_paeth_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_16x8 = svt_aom_highbd_paeth_predictor_16x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_2x2 = svt_aom_highbd_paeth_predictor_2x2_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_32x16 = svt_aom_highbd_paeth_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_32x32 = svt_aom_highbd_paeth_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_32x64 = svt_aom_highbd_paeth_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_32x8 = svt_aom_highbd_paeth_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_4x16 = svt_aom_highbd_paeth_predictor_4x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_4x4 = svt_aom_highbd_paeth_predictor_4x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_4x8 = svt_aom_highbd_paeth_predictor_4x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_64x16 = svt_aom_highbd_paeth_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_64x32 = svt_aom_highbd_paeth_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_64x64 = svt_aom_highbd_paeth_predictor_64x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_8x16 = svt_aom_highbd_paeth_predictor_8x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_8x32 = svt_aom_highbd_paeth_predictor_8x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_8x4 = svt_aom_highbd_paeth_predictor_8x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_paeth_predictor_8x8 = svt_aom_highbd_paeth_predictor_8x8_avx2;
-        if (flags & HAS_SSE2) aom_sum_squares_i16 = svt_aom_sum_squares_i16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_4x4 = svt_aom_dc_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_8x8 = svt_aom_dc_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_16x16 = svt_aom_dc_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_32x32 = svt_aom_dc_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_64x64 = svt_aom_dc_predictor_64x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_32x16 = svt_aom_dc_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_32x64 = svt_aom_dc_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_64x16 = svt_aom_dc_predictor_64x16_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_8x16 = svt_aom_dc_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_8x32 = svt_aom_dc_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_8x4 = svt_aom_dc_predictor_8x4_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_predictor_64x32 = svt_aom_dc_predictor_64x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_16x32 = svt_aom_dc_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_16x4 = svt_aom_dc_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_16x64 = svt_aom_dc_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_16x8 = svt_aom_dc_predictor_16x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_32x8 = svt_aom_dc_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_4x16 = svt_aom_dc_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_predictor_4x8 = svt_aom_dc_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_4x4 = svt_aom_dc_top_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_8x8 = svt_aom_dc_top_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_16x16 = svt_aom_dc_top_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_32x32 = svt_aom_dc_top_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_64x64 = svt_aom_dc_top_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_16x32 = svt_aom_dc_top_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_16x4 = svt_aom_dc_top_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_16x64 = svt_aom_dc_top_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_16x8 = svt_aom_dc_top_predictor_16x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_32x16 = svt_aom_dc_top_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_32x64 = svt_aom_dc_top_predictor_32x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_32x8 = svt_aom_dc_top_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_4x16 = svt_aom_dc_top_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_4x8 = svt_aom_dc_top_predictor_4x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_64x16 = svt_aom_dc_top_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_top_predictor_64x32 = svt_aom_dc_top_predictor_64x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_8x16 = svt_aom_dc_top_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_8x32 = svt_aom_dc_top_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_top_predictor_8x4 = svt_aom_dc_top_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_4x4 = svt_aom_dc_left_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_8x8 = svt_aom_dc_left_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_16x16 = svt_aom_dc_left_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_32x32 = svt_aom_dc_left_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_64x64 = svt_aom_dc_left_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_16x32 = svt_aom_dc_left_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_16x4 = svt_aom_dc_left_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_16x64 = svt_aom_dc_left_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_16x8 = svt_aom_dc_left_predictor_16x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_32x16 = svt_aom_dc_left_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_32x64 = svt_aom_dc_left_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_64x16 = svt_aom_dc_left_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_left_predictor_64x32 = svt_aom_dc_left_predictor_64x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_32x8 = svt_aom_dc_left_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_4x16 = svt_aom_dc_left_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_4x8 = svt_aom_dc_left_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_8x16 = svt_aom_dc_left_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_8x32 = svt_aom_dc_left_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_left_predictor_8x4 = svt_aom_dc_left_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_4x4 = svt_aom_dc_128_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_8x8 = svt_aom_dc_128_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_16x16 = svt_aom_dc_128_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_32x32 = svt_aom_dc_128_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_64x64 = svt_aom_dc_128_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_16x32 = svt_aom_dc_128_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_16x4 = svt_aom_dc_128_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_16x64 = svt_aom_dc_128_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_16x8 = svt_aom_dc_128_predictor_16x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_32x16 = svt_aom_dc_128_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_32x64 = svt_aom_dc_128_predictor_32x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_32x8 = svt_aom_dc_128_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_4x16 = svt_aom_dc_128_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_4x8 = svt_aom_dc_128_predictor_4x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_64x16 = svt_aom_dc_128_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_dc_128_predictor_64x32 = svt_aom_dc_128_predictor_64x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_8x16 = svt_aom_dc_128_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_8x32 = svt_aom_dc_128_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_dc_128_predictor_8x4 = svt_aom_dc_128_predictor_8x4_sse2;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_16x32 = svt_aom_smooth_h_predictor_16x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_16x4 = svt_aom_smooth_h_predictor_16x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_16x64 = svt_aom_smooth_h_predictor_16x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_16x8 = svt_aom_smooth_h_predictor_16x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_32x16 = svt_aom_smooth_h_predictor_32x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_32x64 = svt_aom_smooth_h_predictor_32x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_32x8 = svt_aom_smooth_h_predictor_32x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_4x16 = svt_aom_smooth_h_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_4x8 = svt_aom_smooth_h_predictor_4x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_64x16 = svt_aom_smooth_h_predictor_64x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_64x32 = svt_aom_smooth_h_predictor_64x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_8x16 = svt_aom_smooth_h_predictor_8x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_8x32 = svt_aom_smooth_h_predictor_8x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_8x4 = svt_aom_smooth_h_predictor_8x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_64x64 = svt_aom_smooth_h_predictor_64x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_32x32 = svt_aom_smooth_h_predictor_32x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_16x16 = svt_aom_smooth_h_predictor_16x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_8x8 = svt_aom_smooth_h_predictor_8x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_h_predictor_4x4 = svt_aom_smooth_h_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_16x32 = svt_aom_smooth_v_predictor_16x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_16x4 = svt_aom_smooth_v_predictor_16x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_16x64 = svt_aom_smooth_v_predictor_16x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_16x8 = svt_aom_smooth_v_predictor_16x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_32x16 = svt_aom_smooth_v_predictor_32x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_32x64 = svt_aom_smooth_v_predictor_32x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_32x8 = svt_aom_smooth_v_predictor_32x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_4x16 = svt_aom_smooth_v_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_4x8 = svt_aom_smooth_v_predictor_4x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_64x16 = svt_aom_smooth_v_predictor_64x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_64x32 = svt_aom_smooth_v_predictor_64x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_8x16 = svt_aom_smooth_v_predictor_8x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_8x32 = svt_aom_smooth_v_predictor_8x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_8x4 = svt_aom_smooth_v_predictor_8x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_64x64 = svt_aom_smooth_v_predictor_64x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_32x32 = svt_aom_smooth_v_predictor_32x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_16x16 = svt_aom_smooth_v_predictor_16x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_8x8 = svt_aom_smooth_v_predictor_8x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_v_predictor_4x4 = svt_aom_smooth_v_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_16x32 = svt_aom_smooth_predictor_16x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_16x4 = svt_aom_smooth_predictor_16x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_16x64 = svt_aom_smooth_predictor_16x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_16x8 = svt_aom_smooth_predictor_16x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_32x16 = svt_aom_smooth_predictor_32x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_32x64 = svt_aom_smooth_predictor_32x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_32x8 = svt_aom_smooth_predictor_32x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_4x16 = svt_aom_smooth_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_4x8 = svt_aom_smooth_predictor_4x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_64x16 = svt_aom_smooth_predictor_64x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_64x32 = svt_aom_smooth_predictor_64x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_8x16 = svt_aom_smooth_predictor_8x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_8x32 = svt_aom_smooth_predictor_8x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_8x4 = svt_aom_smooth_predictor_8x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_64x64 = svt_aom_smooth_predictor_64x64_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_32x32 = svt_aom_smooth_predictor_32x32_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_16x16 = svt_aom_smooth_predictor_16x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_8x8 = svt_aom_smooth_predictor_8x8_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_smooth_predictor_4x4 = svt_aom_smooth_predictor_4x4_ssse3;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_4x4 = svt_aom_v_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_8x8 = svt_aom_v_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_16x16 = svt_aom_v_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_32x32 = svt_aom_v_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_64x64 = svt_aom_v_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_16x32 = svt_aom_v_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_16x4 = svt_aom_v_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_16x64 = svt_aom_v_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_16x8 = svt_aom_v_predictor_16x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_32x16 = svt_aom_v_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_32x64 = svt_aom_v_predictor_32x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_32x8 = svt_aom_v_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_4x16 = svt_aom_v_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_4x8 = svt_aom_v_predictor_4x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_64x16 = svt_aom_v_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_v_predictor_64x32 = svt_aom_v_predictor_64x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_8x16 = svt_aom_v_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_8x32 = svt_aom_v_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_v_predictor_8x4 = svt_aom_v_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_4x4 = svt_aom_h_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_8x8 = svt_aom_h_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_16x16 = svt_aom_h_predictor_16x16_sse2;
-        if (flags & HAS_AVX2) svt_aom_h_predictor_32x32 = svt_aom_h_predictor_32x32_avx2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_64x64 = svt_aom_h_predictor_64x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_16x32 = svt_aom_h_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_16x4 = svt_aom_h_predictor_16x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_16x64 = svt_aom_h_predictor_16x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_16x8 = svt_aom_h_predictor_16x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_32x16 = svt_aom_h_predictor_32x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_32x64 = svt_aom_h_predictor_32x64_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_32x8 = svt_aom_h_predictor_32x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_4x16 = svt_aom_h_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_4x8 = svt_aom_h_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_64x16 = svt_aom_h_predictor_64x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_64x32 = svt_aom_h_predictor_64x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_8x16 = svt_aom_h_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_8x32 = svt_aom_h_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_h_predictor_8x4 = svt_aom_h_predictor_8x4_sse2;
-        if (flags & HAS_AVX2) svt_cdef_find_dir = svt_cdef_find_dir_avx2;
-        if (flags & HAS_AVX2) svt_cdef_filter_block = svt_cdef_filter_block_avx2;
-        if (flags & HAS_AVX2) svt_copy_rect8_8bit_to_16bit = svt_copy_rect8_8bit_to_16bit_avx2;
-        if (flags & HAS_AVX2) svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx2;
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx512;
-        }
-#endif
-        SET_AVX2(svt_av1_highbd_warp_affine, svt_av1_highbd_warp_affine_c, svt_av1_highbd_warp_affine_avx2);
-        if (flags & HAS_AVX2) svt_av1_warp_affine = svt_av1_warp_affine_avx2;
-        SET_SSE2(svt_aom_highbd_lpf_horizontal_14, svt_aom_highbd_lpf_horizontal_14_c, svt_aom_highbd_lpf_horizontal_14_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_horizontal_4, svt_aom_highbd_lpf_horizontal_4_c, svt_aom_highbd_lpf_horizontal_4_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_horizontal_6, svt_aom_highbd_lpf_horizontal_6_c, svt_aom_highbd_lpf_horizontal_6_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_horizontal_8, svt_aom_highbd_lpf_horizontal_8_c, svt_aom_highbd_lpf_horizontal_8_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_vertical_14, svt_aom_highbd_lpf_vertical_14_c, svt_aom_highbd_lpf_vertical_14_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_vertical_4, svt_aom_highbd_lpf_vertical_4_c, svt_aom_highbd_lpf_vertical_4_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_vertical_6, svt_aom_highbd_lpf_vertical_6_c, svt_aom_highbd_lpf_vertical_6_sse2);
-        SET_SSE2(svt_aom_highbd_lpf_vertical_8, svt_aom_highbd_lpf_vertical_8_c, svt_aom_highbd_lpf_vertical_8_sse2);
-        SET_SSE2(svt_aom_lpf_horizontal_14, svt_aom_lpf_horizontal_14_c, svt_aom_lpf_horizontal_14_sse2);
-        SET_SSE2(svt_aom_lpf_horizontal_4, svt_aom_lpf_horizontal_4_c, svt_aom_lpf_horizontal_4_sse2);
-        SET_SSE2(svt_aom_lpf_horizontal_6, svt_aom_lpf_horizontal_6_c, svt_aom_lpf_horizontal_6_sse2);
-        SET_SSE2(svt_aom_lpf_horizontal_8, svt_aom_lpf_horizontal_8_c, svt_aom_lpf_horizontal_8_sse2);
-        SET_SSE2(svt_aom_lpf_vertical_14, svt_aom_lpf_vertical_14_c, svt_aom_lpf_vertical_14_sse2);
-        SET_SSE2(svt_aom_lpf_vertical_4, svt_aom_lpf_vertical_4_c, svt_aom_lpf_vertical_4_sse2);
-        SET_SSE2(svt_aom_lpf_vertical_6, svt_aom_lpf_vertical_6_c, svt_aom_lpf_vertical_6_sse2);
-        SET_SSE2(svt_aom_lpf_vertical_8, svt_aom_lpf_vertical_8_c, svt_aom_lpf_vertical_8_sse2);
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_16x16 = svt_aom_highbd_v_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_16x32 = svt_aom_highbd_v_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_16x4 = svt_aom_highbd_v_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_16x64 = svt_aom_highbd_v_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_16x8 = svt_aom_highbd_v_predictor_16x8_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_4x16 = svt_aom_highbd_v_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_4x4 = svt_aom_highbd_v_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_4x8 = svt_aom_highbd_v_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_8x32 = svt_aom_highbd_v_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_8x16 = svt_aom_highbd_v_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_8x4 = svt_aom_highbd_v_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_v_predictor_8x8 = svt_aom_highbd_v_predictor_8x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_32x8 = svt_aom_highbd_v_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_32x16 = svt_aom_highbd_v_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_32x32 = svt_aom_highbd_v_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_32x64 = svt_aom_highbd_v_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_64x16 = svt_aom_highbd_v_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_64x32 = svt_aom_highbd_v_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_v_predictor_64x64 = svt_aom_highbd_v_predictor_64x64_avx2;
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_avx512;
-            svt_aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_avx512;
-            svt_aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_avx512;
-            svt_aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_avx512;
-            svt_aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_avx512;
-            svt_aom_highbd_v_predictor_64x32 = aom_highbd_v_predictor_64x32_avx512;
-            svt_aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_avx512;
-        }
-#endif // !NON_AVX512_SUPPORT
-
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_16x16 = svt_aom_highbd_smooth_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_16x32 = svt_aom_highbd_smooth_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_16x4 = svt_aom_highbd_smooth_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_16x64 = svt_aom_highbd_smooth_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_16x8 = svt_aom_highbd_smooth_predictor_16x8_avx2;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_predictor_4x16 = svt_aom_highbd_smooth_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_predictor_4x4 = svt_aom_highbd_smooth_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_predictor_4x8 = svt_aom_highbd_smooth_predictor_4x8_ssse3;
-
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_8x16 = svt_aom_highbd_smooth_predictor_8x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_8x32 = svt_aom_highbd_smooth_predictor_8x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_8x4 = svt_aom_highbd_smooth_predictor_8x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_8x8 = svt_aom_highbd_smooth_predictor_8x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_32x8 = svt_aom_highbd_smooth_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_32x16 = svt_aom_highbd_smooth_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_32x32 = svt_aom_highbd_smooth_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_32x64 = svt_aom_highbd_smooth_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_64x16 = svt_aom_highbd_smooth_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_64x32 = svt_aom_highbd_smooth_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_predictor_64x64 = svt_aom_highbd_smooth_predictor_64x64_avx2;
-
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_smooth_predictor_32x8 = aom_highbd_smooth_predictor_32x8_avx512;
-            svt_aom_highbd_smooth_predictor_32x16 = aom_highbd_smooth_predictor_32x16_avx512;
-            svt_aom_highbd_smooth_predictor_32x32 = aom_highbd_smooth_predictor_32x32_avx512;
-            svt_aom_highbd_smooth_predictor_32x64 = aom_highbd_smooth_predictor_32x64_avx512;
-            svt_aom_highbd_smooth_predictor_64x16 = aom_highbd_smooth_predictor_64x16_avx512;
-            svt_aom_highbd_smooth_predictor_64x32 = aom_highbd_smooth_predictor_64x32_avx512;
-            svt_aom_highbd_smooth_predictor_64x64 = aom_highbd_smooth_predictor_64x64_avx512;
-        }
-#endif // !NON_AVX512_SUPPORT
-
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_16x16 = svt_aom_highbd_smooth_h_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_16x32 = svt_aom_highbd_smooth_h_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_16x4 = svt_aom_highbd_smooth_h_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_16x64 = svt_aom_highbd_smooth_h_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_16x8 = svt_aom_highbd_smooth_h_predictor_16x8_avx2;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_h_predictor_4x16 = svt_aom_highbd_smooth_h_predictor_4x16_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_h_predictor_4x4 = svt_aom_highbd_smooth_h_predictor_4x4_ssse3;
-        if (flags & HAS_SSSE3) svt_aom_highbd_smooth_h_predictor_4x8 = svt_aom_highbd_smooth_h_predictor_4x8_ssse3;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_8x16 = svt_aom_highbd_smooth_h_predictor_8x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_8x32 = svt_aom_highbd_smooth_h_predictor_8x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_8x4 = svt_aom_highbd_smooth_h_predictor_8x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_8x8 = svt_aom_highbd_smooth_h_predictor_8x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_32x8 = svt_aom_highbd_smooth_h_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_32x16 = svt_aom_highbd_smooth_h_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_32x32 = svt_aom_highbd_smooth_h_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_32x64 = svt_aom_highbd_smooth_h_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_64x16 = svt_aom_highbd_smooth_h_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_64x32 = svt_aom_highbd_smooth_h_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_smooth_h_predictor_64x64 = svt_aom_highbd_smooth_h_predictor_64x64_avx2;
-
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_smooth_h_predictor_32x8 = aom_highbd_smooth_h_predictor_32x8_avx512;
-            svt_aom_highbd_smooth_h_predictor_32x16 = aom_highbd_smooth_h_predictor_32x16_avx512;
-            svt_aom_highbd_smooth_h_predictor_32x32 = aom_highbd_smooth_h_predictor_32x32_avx512;
-            svt_aom_highbd_smooth_h_predictor_32x64 = aom_highbd_smooth_h_predictor_32x64_avx512;
-            svt_aom_highbd_smooth_h_predictor_64x16 = aom_highbd_smooth_h_predictor_64x16_avx512;
-            svt_aom_highbd_smooth_h_predictor_64x32 = aom_highbd_smooth_h_predictor_64x32_avx512;
-            svt_aom_highbd_smooth_h_predictor_64x64 = aom_highbd_smooth_h_predictor_64x64_avx512;
-        }
-#endif
-
-        //aom_highbd_dc_128_predictor
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_16x16 = svt_aom_highbd_dc_128_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_16x32 = svt_aom_highbd_dc_128_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_16x4 = svt_aom_highbd_dc_128_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_16x64 = svt_aom_highbd_dc_128_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_16x8 = svt_aom_highbd_dc_128_predictor_16x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_32x16 = svt_aom_highbd_dc_128_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_32x32 = svt_aom_highbd_dc_128_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_32x64 = svt_aom_highbd_dc_128_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_32x8 = svt_aom_highbd_dc_128_predictor_32x8_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_4x16 = svt_aom_highbd_dc_128_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_4x4 = svt_aom_highbd_dc_128_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_4x8 = svt_aom_highbd_dc_128_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_8x32 = svt_aom_highbd_dc_128_predictor_8x32_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_64x16 = svt_aom_highbd_dc_128_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_64x32 = svt_aom_highbd_dc_128_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_128_predictor_64x64 = svt_aom_highbd_dc_128_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_8x16 = svt_aom_highbd_dc_128_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_8x4 = svt_aom_highbd_dc_128_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_128_predictor_8x8 = svt_aom_highbd_dc_128_predictor_8x8_sse2;
-
-        //aom_highbd_dc_left_predictor
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_16x16 = svt_aom_highbd_dc_left_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_16x32 = svt_aom_highbd_dc_left_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_16x4 = svt_aom_highbd_dc_left_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_16x64 = svt_aom_highbd_dc_left_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_16x8 = svt_aom_highbd_dc_left_predictor_16x8_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_4x16 = svt_aom_highbd_dc_left_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_4x4 = svt_aom_highbd_dc_left_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_4x8 = svt_aom_highbd_dc_left_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_8x32 = svt_aom_highbd_dc_left_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_8x16 = svt_aom_highbd_dc_left_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_8x4 = svt_aom_highbd_dc_left_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_left_predictor_8x8 = svt_aom_highbd_dc_left_predictor_8x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_32x8 = svt_aom_highbd_dc_left_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_32x16 = svt_aom_highbd_dc_left_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_32x32 = svt_aom_highbd_dc_left_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_32x64 = svt_aom_highbd_dc_left_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_64x16 = svt_aom_highbd_dc_left_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_64x32 = svt_aom_highbd_dc_left_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_left_predictor_64x64 = svt_aom_highbd_dc_left_predictor_64x64_avx2;
-
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_avx512;
-            svt_aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_avx512;
-            svt_aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_avx512;
-            svt_aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_avx512;
-            svt_aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_avx512;
-            svt_aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_avx512;
-            svt_aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_avx512;
-        }
-#endif // !NON_AVX512_SUPPORT
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_16x16 = svt_aom_highbd_dc_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_16x32 = svt_aom_highbd_dc_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_16x4 = svt_aom_highbd_dc_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_16x64 = svt_aom_highbd_dc_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_16x8 = svt_aom_highbd_dc_predictor_16x8_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_4x16 = svt_aom_highbd_dc_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_4x4 = svt_aom_highbd_dc_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_4x8 = svt_aom_highbd_dc_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_8x16 = svt_aom_highbd_dc_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_8x4 = svt_aom_highbd_dc_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_8x8 = svt_aom_highbd_dc_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_predictor_8x32 = svt_aom_highbd_dc_predictor_8x32_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_32x8 = svt_aom_highbd_dc_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_32x16 = svt_aom_highbd_dc_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_32x32 = svt_aom_highbd_dc_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_32x64 = svt_aom_highbd_dc_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_64x16 = svt_aom_highbd_dc_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_64x32 = svt_aom_highbd_dc_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_predictor_64x64 = svt_aom_highbd_dc_predictor_64x64_avx2;
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_avx512;
-            svt_aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_avx512;
-            svt_aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_avx512;
-            svt_aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_avx512;
-            svt_aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_avx512;
-            svt_aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_avx512;
-            svt_aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_avx512;
-        }
-#endif // !NON_AVX512_SUPPORT
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_16x16 = svt_aom_highbd_dc_top_predictor_16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_16x32 = svt_aom_highbd_dc_top_predictor_16x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_16x4 = svt_aom_highbd_dc_top_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_16x64 = svt_aom_highbd_dc_top_predictor_16x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_16x8 = svt_aom_highbd_dc_top_predictor_16x8_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_4x16 = svt_aom_highbd_dc_top_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_4x4 = svt_aom_highbd_dc_top_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_4x8 = svt_aom_highbd_dc_top_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_8x16 = svt_aom_highbd_dc_top_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_8x4 = svt_aom_highbd_dc_top_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_dc_top_predictor_8x8 = svt_aom_highbd_dc_top_predictor_8x8_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_32x8 = svt_aom_highbd_dc_top_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_32x16 = svt_aom_highbd_dc_top_predictor_32x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_32x32 = svt_aom_highbd_dc_top_predictor_32x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_32x64 = svt_aom_highbd_dc_top_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_64x16 = svt_aom_highbd_dc_top_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_64x32 = svt_aom_highbd_dc_top_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_dc_top_predictor_64x64 = svt_aom_highbd_dc_top_predictor_64x64_avx2;
-
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_avx512;
-            svt_aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_avx512;
-            svt_aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_avx512;
-            svt_aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_avx512;
-            svt_aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_avx512;
-            svt_aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_avx512;
-            svt_aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_avx512;
-        }
-#endif
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_16x4 = svt_aom_highbd_h_predictor_16x4_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_16x64 = svt_aom_highbd_h_predictor_16x64_avx2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_16x8 = svt_aom_highbd_h_predictor_16x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_4x16 = svt_aom_highbd_h_predictor_4x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_4x4 = svt_aom_highbd_h_predictor_4x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_4x8 = svt_aom_highbd_h_predictor_4x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_8x32 = svt_aom_highbd_h_predictor_8x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_8x16 = svt_aom_highbd_h_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_8x4 = svt_aom_highbd_h_predictor_8x4_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_8x8 = svt_aom_highbd_h_predictor_8x8_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_16x16 = svt_aom_highbd_h_predictor_16x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_16x32 = svt_aom_highbd_h_predictor_16x32_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_32x16 = svt_aom_highbd_h_predictor_32x16_sse2;
-        if (flags & HAS_SSE2) svt_aom_highbd_h_predictor_32x32 = svt_aom_highbd_h_predictor_32x32_sse2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_32x64 = svt_aom_highbd_h_predictor_32x64_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_32x8 = svt_aom_highbd_h_predictor_32x8_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_64x16 = svt_aom_highbd_h_predictor_64x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_64x32 = svt_aom_highbd_h_predictor_64x32_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_h_predictor_64x64 = svt_aom_highbd_h_predictor_64x64_avx2;
-        if (flags & HAS_SSE2) svt_log2f = Log2f_ASM;
-        if (flags & HAS_SSE2) svt_memcpy = svt_memcpy_intrin_sse;
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_avx512;
-            svt_aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_avx512;
-            svt_aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_avx512;
-            svt_aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_avx512;
-            svt_aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_avx512;
-            svt_aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_avx512;
-            svt_aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_avx512;
-        }
-#endif
-
-#endif
-
+    SET_SSE2(svt_aom_highbd_h_predictor_4x4, svt_aom_highbd_h_predictor_4x4_c, svt_aom_highbd_h_predictor_4x4_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_4x8, svt_aom_highbd_h_predictor_4x8_c, svt_aom_highbd_h_predictor_4x8_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_4x16, svt_aom_highbd_h_predictor_4x16_c, svt_aom_highbd_h_predictor_4x16_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_8x4, svt_aom_highbd_h_predictor_8x4_c, svt_aom_highbd_h_predictor_8x4_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_8x8, svt_aom_highbd_h_predictor_8x8_c, svt_aom_highbd_h_predictor_8x8_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_8x16, svt_aom_highbd_h_predictor_8x16_c, svt_aom_highbd_h_predictor_8x16_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_8x32, svt_aom_highbd_h_predictor_8x32_c, svt_aom_highbd_h_predictor_8x32_sse2);
+    SET_AVX2(svt_aom_highbd_h_predictor_16x4, svt_aom_highbd_h_predictor_16x4_c, svt_aom_highbd_h_predictor_16x4_avx2);
+    SET_SSE2(svt_aom_highbd_h_predictor_16x8, svt_aom_highbd_h_predictor_16x8_c, svt_aom_highbd_h_predictor_16x8_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_16x16, svt_aom_highbd_h_predictor_16x16_c, svt_aom_highbd_h_predictor_16x16_sse2);
+    SET_SSE2(svt_aom_highbd_h_predictor_16x32, svt_aom_highbd_h_predictor_16x32_c, svt_aom_highbd_h_predictor_16x32_sse2);
+    SET_AVX2(svt_aom_highbd_h_predictor_16x64, svt_aom_highbd_h_predictor_16x64_c, svt_aom_highbd_h_predictor_16x64_avx2);
+    SET_AVX2_AVX512(svt_aom_highbd_h_predictor_32x8, svt_aom_highbd_h_predictor_32x8_c, svt_aom_highbd_h_predictor_32x8_avx2, aom_highbd_h_predictor_32x8_avx512);
+    SET_SSE2_AVX512(svt_aom_highbd_h_predictor_32x16, svt_aom_highbd_h_predictor_32x16_c, svt_aom_highbd_h_predictor_32x16_sse2, aom_highbd_h_predictor_32x16_avx512);
+    SET_SSE2_AVX512(svt_aom_highbd_h_predictor_32x32, svt_aom_highbd_h_predictor_32x32_c, svt_aom_highbd_h_predictor_32x32_sse2, aom_highbd_h_predictor_32x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_h_predictor_32x64, svt_aom_highbd_h_predictor_32x64_c, svt_aom_highbd_h_predictor_32x64_avx2, aom_highbd_h_predictor_32x64_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_h_predictor_64x16, svt_aom_highbd_h_predictor_64x16_c, svt_aom_highbd_h_predictor_64x16_avx2, aom_highbd_h_predictor_64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_h_predictor_64x32, svt_aom_highbd_h_predictor_64x32_c, svt_aom_highbd_h_predictor_64x32_avx2, aom_highbd_h_predictor_64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_highbd_h_predictor_64x64, svt_aom_highbd_h_predictor_64x64_c, svt_aom_highbd_h_predictor_64x64_avx2, aom_highbd_h_predictor_64x64_avx512);
+    SET_SSE2(svt_log2f, log2f_32, Log2f_ASM);
+    SET_SSE2(svt_memcpy, svt_memcpy_c, svt_memcpy_intrin_sse);
 
 }

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -66,20 +66,6 @@
 extern "C" {
 #endif
 
-#define SET_SSE2(ptr, c, sse2) SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
-#define SET_SSE2_AVX2(ptr, c, sse2, avx2) SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
-#define SET_SSSE3(ptr, c, ssse3) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, 0, 0)
-#define SET_SSE41(ptr, c, sse4_1) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
-#define SET_SSE41(ptr, c, sse4_1) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
-#define SET_SSE41_AVX2(ptr, c, sse4_1, avx2) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, 0)
-#define SET_SSE41_AVX2_AVX512(ptr, c, sse4_1, avx2, avx512) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, avx512)
-#define SET_AVX2(ptr, c, avx2) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, 0)
-#define SET_AVX2_AVX512(ptr, c, avx2, avx512) \
-    SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, avx512)
-
-
     // Helper Functions
     CPU_FLAGS get_cpu_flags();
     CPU_FLAGS get_cpu_flags_to_use();

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -25,743 +25,365 @@
  * Instruction Set Support
  **************************************/
 
+#ifdef ARCH_X86_64
 #ifndef NON_AVX512_SUPPORT
-#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
-    do {                                                                                      \
-        ptr = c;                                                                              \
-        if (((uintptr_t)NULL != (uintptr_t)mmx) && (flags & HAS_MMX)) ptr = mmx;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse) && (flags & HAS_SSE)) ptr = sse;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse2) && (flags & HAS_SSE2)) ptr = sse2;           \
-        if (((uintptr_t)NULL != (uintptr_t)sse3) && (flags & HAS_SSE3)) ptr = sse3;           \
-        if (((uintptr_t)NULL != (uintptr_t)ssse3) && (flags & HAS_SSSE3)) ptr = ssse3;        \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;     \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;     \
-        if (((uintptr_t)NULL != (uintptr_t)avx) && (flags & HAS_AVX)) ptr = avx;              \
-        if (((uintptr_t)NULL != (uintptr_t)avx2) && (flags & HAS_AVX2)) ptr = avx2;           \
-        if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;    \
+#define SET_FUNCTIONS_AVX512(ptr, avx512)                                                         \
+    if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;
+#else /* NON_AVX512_SUPPORT */
+#define SET_FUNCTIONS_AVX512(ptr, avx512)
+#endif /* NON_AVX512_SUPPORT */
+
+#define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
+    if (((uintptr_t)NULL != (uintptr_t)mmx)    && (flags & HAS_MMX))    ptr = mmx;                \
+    if (((uintptr_t)NULL != (uintptr_t)sse)    && (flags & HAS_SSE))    ptr = sse;                \
+    if (((uintptr_t)NULL != (uintptr_t)sse2)   && (flags & HAS_SSE2))   ptr = sse2;               \
+    if (((uintptr_t)NULL != (uintptr_t)sse3)   && (flags & HAS_SSE3))   ptr = sse3;               \
+    if (((uintptr_t)NULL != (uintptr_t)ssse3)  && (flags & HAS_SSSE3))  ptr = ssse3;              \
+    if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;             \
+    if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;             \
+    if (((uintptr_t)NULL != (uintptr_t)avx)    && (flags & HAS_AVX))    ptr = avx;                \
+    if (((uintptr_t)NULL != (uintptr_t)avx2)   && (flags & HAS_AVX2))   ptr = avx2;               \
+    SET_FUNCTIONS_AVX512(ptr, avx512)
+#else /* ARCH_X86_64 */
+#define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)
+#endif /* ARCH_X86_64 */
+
+#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
+    do {                                                                                          \
+        if (ptr != 0) {                                                                           \
+            printf("Error: %s:%i: Pointer \"%s\" is set before!\n", __FILE__, __LINE__, #ptr);    \
+            assert(0);                                                                            \
+        }                                                                                         \
+        if ((uintptr_t)NULL == (uintptr_t)c) {                                                    \
+            printf("Error: %s:%i: Pointer \"%s\" on C is NULL!\n", __FILE__, __LINE__, #ptr);     \
+            assert(0);                                                                            \
+        }                                                                                         \
+        ptr = c;                                                                                  \
+        SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     } while (0)
-#else
-#define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
-    do {                                                                                      \
-        ptr = c;                                                                              \
-        if (((uintptr_t)NULL != (uintptr_t)mmx) && (flags & HAS_MMX)) ptr = mmx;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse) && (flags & HAS_SSE)) ptr = sse;              \
-        if (((uintptr_t)NULL != (uintptr_t)sse2) && (flags & HAS_SSE2)) ptr = sse2;           \
-        if (((uintptr_t)NULL != (uintptr_t)sse3) && (flags & HAS_SSE3)) ptr = sse3;           \
-        if (((uintptr_t)NULL != (uintptr_t)ssse3) && (flags & HAS_SSSE3)) ptr = ssse3;        \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_1) && (flags & HAS_SSE4_1)) ptr = sse4_1;     \
-        if (((uintptr_t)NULL != (uintptr_t)sse4_2) && (flags & HAS_SSE4_2)) ptr = sse4_2;     \
-        if (((uintptr_t)NULL != (uintptr_t)avx) && (flags & HAS_AVX)) ptr = avx;              \
-        if (((uintptr_t)NULL != (uintptr_t)avx2) && (flags & HAS_AVX2)) ptr = avx2;           \
-    } while (0)
-#endif
+
+/* Macros SET_* use local variable CPU_FLAGS flags */
+#define SET_ONLY_C(ptr, c)                                  SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#define SET_SSE2(ptr, c, sse2)                              SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
+#define SET_SSE2_AVX2(ptr, c, sse2, avx2)                   SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
+#define SET_SSE2_AVX512(ptr, c, sse2, avx512)               SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, avx512)
+#define SET_SSSE3(ptr, c, ssse3)                            SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, 0, 0)
+#define SET_SSSE3_AVX2(ptr, c, ssse3, avx2)                 SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, ssse3, 0, 0, 0, avx2, 0)
+#define SET_SSE41(ptr, c, sse4_1)                           SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, 0, 0)
+#define SET_SSE41_AVX2(ptr, c, sse4_1, avx2)                SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, 0)
+#define SET_SSE41_AVX2_AVX512(ptr, c, sse4_1, avx2, avx512) SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, sse4_1, 0, 0, avx2, avx512)
+#define SET_AVX2(ptr, c, avx2)                              SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, 0)
+#define SET_AVX2_AVX512(ptr, c, avx2, avx512)               SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, avx512)
+
 
 void setup_rtcd_internal(CPU_FLAGS flags) {
-    /** Should be done during library initialization,
-        but for safe limiting cpu flags again. */
-    (void)flags;
-    //to use C: flags=0
-    svt_aom_sse = svt_aom_sse_c;
-
-    svt_aom_highbd_sse = svt_aom_highbd_sse_c;
-
-    svt_av1_wedge_compute_delta_squares = svt_av1_wedge_compute_delta_squares_c;
-    svt_av1_wedge_sign_from_residuals = svt_av1_wedge_sign_from_residuals_c;
-
-    svt_compute_cdef_dist_16bit = compute_cdef_dist_c;
-    svt_compute_cdef_dist_8bit = compute_cdef_dist_8bit_c;
-
-    svt_av1_compute_stats = svt_av1_compute_stats_c;
-    svt_av1_compute_stats_highbd = svt_av1_compute_stats_highbd_c;
-
-    svt_av1_lowbd_pixel_proj_error = svt_av1_lowbd_pixel_proj_error_c;
-    svt_av1_highbd_pixel_proj_error = svt_av1_highbd_pixel_proj_error_c;
-    svt_av1_calc_frame_error = svt_av1_calc_frame_error_c;
-
-    svt_subtract_average = svt_subtract_average_c;
-
-    svt_get_proj_subspace = svt_get_proj_subspace_c;
-
-    svt_aom_mse16x16 = svt_aom_mse16x16_c;
-
-    svt_aom_quantize_b = svt_aom_quantize_b_c_ii;
-
-    svt_aom_highbd_quantize_b = svt_aom_highbd_quantize_b_c;
-
-    svt_av1_quantize_fp = svt_av1_quantize_fp_c;
-
-    svt_av1_quantize_fp_32x32 = svt_av1_quantize_fp_32x32_c;
-
-    svt_av1_quantize_fp_64x64 = svt_av1_quantize_fp_64x64_c;
-
-    svt_av1_highbd_quantize_fp = svt_av1_highbd_quantize_fp_c;
-
-    svt_aom_highbd_8_mse16x16 = svt_aom_highbd_8_mse16x16_c;
-
-
-    //SAD
-    svt_aom_sad4x4 = svt_aom_sad4x4_c;
-    svt_aom_sad4x4x4d = svt_aom_sad4x4x4d_c;
-    svt_aom_sad4x16 = svt_aom_sad4x16_c;
-    svt_aom_sad4x16x4d = svt_aom_sad4x16x4d_c;
-    svt_aom_sad4x8 = svt_aom_sad4x8_c;
-    svt_aom_sad4x8x4d = svt_aom_sad4x8x4d_c;
-    svt_aom_sad64x128x4d = svt_aom_sad64x128x4d_c;
-    svt_aom_sad64x16x4d = svt_aom_sad64x16x4d_c;
-    svt_aom_sad64x32x4d = svt_aom_sad64x32x4d_c;
-    svt_aom_sad64x64x4d = svt_aom_sad64x64x4d_c;
-    svt_aom_sad8x16 = svt_aom_sad8x16_c;
-    svt_aom_sad8x16x4d = svt_aom_sad8x16x4d_c;
-    svt_aom_sad8x32 = svt_aom_sad8x32_c;
-    svt_aom_sad8x32x4d = svt_aom_sad8x32x4d_c;
-    svt_aom_sad8x8 = svt_aom_sad8x8_c;
-    svt_aom_sad8x8x4d = svt_aom_sad8x8x4d_c;
-    svt_aom_sad16x4 = svt_aom_sad16x4_c;
-    svt_aom_sad16x4x4d = svt_aom_sad16x4x4d_c;
-    svt_aom_sad32x8 = svt_aom_sad32x8_c;
-    svt_aom_sad32x8x4d = svt_aom_sad32x8x4d_c;
-    svt_aom_sad16x64 = svt_aom_sad16x64_c;
-    svt_aom_sad16x64x4d = svt_aom_sad16x64x4d_c;
-    svt_aom_sad32x16 = svt_aom_sad32x16_c;
-    svt_aom_sad32x16x4d = svt_aom_sad32x16x4d_c;
-    svt_aom_sad16x32 = svt_aom_sad16x32_c;
-    svt_aom_sad16x32x4d = svt_aom_sad16x32x4d_c;
-    svt_aom_sad32x64 = svt_aom_sad32x64_c;
-    svt_aom_sad32x64x4d = svt_aom_sad32x64x4d_c;
-    svt_aom_sad32x32 = svt_aom_sad32x32_c;
-    svt_aom_sad32x32x4d = svt_aom_sad32x32x4d_c;
-    svt_aom_sad16x16 = svt_aom_sad16x16_c;
-    svt_aom_sad16x16x4d = svt_aom_sad16x16x4d_c;
-    svt_aom_sad16x8 = svt_aom_sad16x8_c;
-    svt_aom_sad16x8x4d = svt_aom_sad16x8x4d_c;
-    svt_aom_sad8x4 = svt_aom_sad8x4_c;
-    svt_aom_sad8x4x4d = svt_aom_sad8x4x4d_c;
-
-    svt_aom_sad64x128 = svt_aom_sad64x128_c;
-    svt_aom_sad64x16 = svt_aom_sad64x16_c;
-    svt_aom_sad64x32 = svt_aom_sad64x32_c;
-    svt_aom_sad64x64 = svt_aom_sad64x64_c;
-    svt_aom_sad128x128 = svt_aom_sad128x128_c;
-    svt_aom_sad128x128x4d = svt_aom_sad128x128x4d_c;
-    svt_aom_sad128x64 = svt_aom_sad128x64_c;
-    svt_aom_sad128x64x4d = svt_aom_sad128x64x4d_c;
-    svt_av1_txb_init_levels = svt_av1_txb_init_levels_c;
-    svt_aom_satd = svt_aom_satd_c;
-    svt_av1_block_error = svt_av1_block_error_c;
-    svt_aom_upsampled_pred = svt_aom_upsampled_pred_c;
-
-    svt_aom_obmc_sad128x128 = svt_aom_obmc_sad128x128_c;
-    svt_aom_obmc_sad128x64 = svt_aom_obmc_sad128x64_c;
-    svt_aom_obmc_sad16x16 = svt_aom_obmc_sad16x16_c;
-    svt_aom_obmc_sad16x32 = svt_aom_obmc_sad16x32_c;
-    svt_aom_obmc_sad16x4 = svt_aom_obmc_sad16x4_c;
-    svt_aom_obmc_sad16x64 = svt_aom_obmc_sad16x64_c;
-    svt_aom_obmc_sad16x8 = svt_aom_obmc_sad16x8_c;
-    svt_aom_obmc_sad32x16 = svt_aom_obmc_sad32x16_c;
-    svt_aom_obmc_sad32x32 = svt_aom_obmc_sad32x32_c;
-    svt_aom_obmc_sad32x64 = svt_aom_obmc_sad32x64_c;
-    svt_aom_obmc_sad32x8 = svt_aom_obmc_sad32x8_c;
-    svt_aom_obmc_sad4x16 = svt_aom_obmc_sad4x16_c;
-    svt_aom_obmc_sad4x4 = svt_aom_obmc_sad4x4_c;
-    svt_aom_obmc_sad4x8 = svt_aom_obmc_sad4x8_c;
-    svt_aom_obmc_sad64x128 = svt_aom_obmc_sad64x128_c;
-    svt_aom_obmc_sad64x16 = svt_aom_obmc_sad64x16_c;
-    svt_aom_obmc_sad64x32 = svt_aom_obmc_sad64x32_c;
-    svt_aom_obmc_sad64x64 = svt_aom_obmc_sad64x64_c;
-    svt_aom_obmc_sad8x16 = svt_aom_obmc_sad8x16_c;
-    svt_aom_obmc_sad8x32 = svt_aom_obmc_sad8x32_c;
-    svt_aom_obmc_sad8x4 = svt_aom_obmc_sad8x4_c;
-    svt_aom_obmc_sad8x8 = svt_aom_obmc_sad8x8_c;
-    svt_aom_obmc_sub_pixel_variance128x128 = svt_aom_obmc_sub_pixel_variance128x128_c;
-    svt_aom_obmc_sub_pixel_variance128x64 = svt_aom_obmc_sub_pixel_variance128x64_c;
-    svt_aom_obmc_sub_pixel_variance16x16 = svt_aom_obmc_sub_pixel_variance16x16_c;
-    svt_aom_obmc_sub_pixel_variance16x32 = svt_aom_obmc_sub_pixel_variance16x32_c;
-    svt_aom_obmc_sub_pixel_variance16x4 = svt_aom_obmc_sub_pixel_variance16x4_c;
-    svt_aom_obmc_sub_pixel_variance16x64 = svt_aom_obmc_sub_pixel_variance16x64_c;
-    svt_aom_obmc_sub_pixel_variance16x8 = svt_aom_obmc_sub_pixel_variance16x8_c;
-    svt_aom_obmc_sub_pixel_variance32x16 = svt_aom_obmc_sub_pixel_variance32x16_c;
-    svt_aom_obmc_sub_pixel_variance32x32 = svt_aom_obmc_sub_pixel_variance32x32_c;
-    svt_aom_obmc_sub_pixel_variance32x64 = svt_aom_obmc_sub_pixel_variance32x64_c;
-    svt_aom_obmc_sub_pixel_variance32x8 = svt_aom_obmc_sub_pixel_variance32x8_c;
-    svt_aom_obmc_sub_pixel_variance4x16 = svt_aom_obmc_sub_pixel_variance4x16_c;
-    svt_aom_obmc_sub_pixel_variance4x4 = svt_aom_obmc_sub_pixel_variance4x4_c;
-    svt_aom_obmc_sub_pixel_variance4x8 = svt_aom_obmc_sub_pixel_variance4x8_c;
-    svt_aom_obmc_sub_pixel_variance64x128 = svt_aom_obmc_sub_pixel_variance64x128_c;
-    svt_aom_obmc_sub_pixel_variance64x16 = svt_aom_obmc_sub_pixel_variance64x16_c;
-    svt_aom_obmc_sub_pixel_variance64x32 = svt_aom_obmc_sub_pixel_variance64x32_c;
-    svt_aom_obmc_sub_pixel_variance64x64 = svt_aom_obmc_sub_pixel_variance64x64_c;
-    svt_aom_obmc_sub_pixel_variance8x16 = svt_aom_obmc_sub_pixel_variance8x16_c;
-    svt_aom_obmc_sub_pixel_variance8x32 = svt_aom_obmc_sub_pixel_variance8x32_c;
-    svt_aom_obmc_sub_pixel_variance8x4 = svt_aom_obmc_sub_pixel_variance8x4_c;
-    svt_aom_obmc_sub_pixel_variance8x8 = svt_aom_obmc_sub_pixel_variance8x8_c;
-    svt_aom_obmc_variance128x128 = svt_aom_obmc_variance128x128_c;
-    svt_aom_obmc_variance128x64 = svt_aom_obmc_variance128x64_c;
-    svt_aom_obmc_variance16x16 = svt_aom_obmc_variance16x16_c;
-    svt_aom_obmc_variance16x32 = svt_aom_obmc_variance16x32_c;
-    svt_aom_obmc_variance16x4 = svt_aom_obmc_variance16x4_c;
-    svt_aom_obmc_variance16x64 = svt_aom_obmc_variance16x64_c;
-    svt_aom_obmc_variance16x8 = svt_aom_obmc_variance16x8_c;
-    svt_aom_obmc_variance32x16 = svt_aom_obmc_variance32x16_c;
-    svt_aom_obmc_variance32x32 = svt_aom_obmc_variance32x32_c;
-    svt_aom_obmc_variance32x64 = svt_aom_obmc_variance32x64_c;
-    svt_aom_obmc_variance32x8 = svt_aom_obmc_variance32x8_c;
-    svt_aom_obmc_variance4x16 = svt_aom_obmc_variance4x16_c;
-    svt_aom_obmc_variance4x4 = svt_aom_obmc_variance4x4_c;
-    svt_aom_obmc_variance4x8 = svt_aom_obmc_variance4x8_c;
-    svt_aom_obmc_variance64x128 = svt_aom_obmc_variance64x128_c;
-    svt_aom_obmc_variance64x16 = svt_aom_obmc_variance64x16_c;
-    svt_aom_obmc_variance64x32 = svt_aom_obmc_variance64x32_c;
-    svt_aom_obmc_variance64x64 = svt_aom_obmc_variance64x64_c;
-    svt_aom_obmc_variance8x16 = svt_aom_obmc_variance8x16_c;
-    svt_aom_obmc_variance8x32 = svt_aom_obmc_variance8x32_c;
-    svt_aom_obmc_variance8x4 = svt_aom_obmc_variance8x4_c;
-    svt_aom_obmc_variance8x8 = svt_aom_obmc_variance8x8_c;
-
-    //VARIANCE
-    svt_aom_variance4x4 = svt_aom_variance4x4_c;
-    svt_aom_variance4x8 = svt_aom_variance4x8_c;
-    svt_aom_variance4x16 = svt_aom_variance4x16_c;
-    svt_aom_variance8x4 = svt_aom_variance8x4_c;
-    svt_aom_variance8x8 = svt_aom_variance8x8_c;
-    svt_aom_variance8x16 = svt_aom_variance8x16_c;
-    svt_aom_variance8x32 = svt_aom_variance8x32_c;
-    svt_aom_variance16x4 = svt_aom_variance16x4_c;
-    svt_aom_variance16x8 = svt_aom_variance16x8_c;
-    svt_aom_variance16x16 = svt_aom_variance16x16_c;
-    svt_aom_variance16x32 = svt_aom_variance16x32_c;
-    svt_aom_variance16x64 = svt_aom_variance16x64_c;
-    svt_aom_variance32x8 = svt_aom_variance32x8_c;
-    svt_aom_variance32x16 = svt_aom_variance32x16_c;
-    svt_aom_variance32x32 = svt_aom_variance32x32_c;
-    svt_aom_variance32x64 = svt_aom_variance32x64_c;
-    svt_aom_variance64x16 = svt_aom_variance64x16_c;
-    svt_aom_variance64x32 = svt_aom_variance64x32_c;
-    svt_aom_variance64x64 = svt_aom_variance64x64_c;
-    svt_aom_variance64x128 = svt_aom_variance64x128_c;
-    svt_aom_variance128x64 = svt_aom_variance128x64_c;
-    svt_aom_variance128x128 = svt_aom_variance128x128_c;
-
-    // VARIANCE HBP
-    svt_aom_highbd_10_variance4x4 = svt_aom_highbd_10_variance4x4_c;
-    svt_aom_highbd_10_variance4x8 = svt_aom_highbd_10_variance4x8_c;
-    svt_aom_highbd_10_variance4x16 = svt_aom_highbd_10_variance4x16_c;
-    svt_aom_highbd_10_variance8x4 = svt_aom_highbd_10_variance8x4_c;
-    svt_aom_highbd_10_variance8x8 = svt_aom_highbd_10_variance8x8_c;
-    svt_aom_highbd_10_variance8x16 = svt_aom_highbd_10_variance8x16_c;
-    svt_aom_highbd_10_variance8x32 = svt_aom_highbd_10_variance8x32_c;
-    svt_aom_highbd_10_variance16x4 = svt_aom_highbd_10_variance16x4_c;
-    svt_aom_highbd_10_variance16x8 = svt_aom_highbd_10_variance16x8_c;
-    svt_aom_highbd_10_variance16x16 = svt_aom_highbd_10_variance16x16_c;
-    svt_aom_highbd_10_variance16x32 = svt_aom_highbd_10_variance16x32_c;
-    svt_aom_highbd_10_variance16x64 = svt_aom_highbd_10_variance16x64_c;
-    svt_aom_highbd_10_variance32x8 = svt_aom_highbd_10_variance32x8_c;
-    svt_aom_highbd_10_variance32x16 = svt_aom_highbd_10_variance32x16_c;
-    svt_aom_highbd_10_variance32x32 = svt_aom_highbd_10_variance32x32_c;
-    svt_aom_highbd_10_variance32x64 = svt_aom_highbd_10_variance32x64_c;
-    svt_aom_highbd_10_variance64x16 = svt_aom_highbd_10_variance64x16_c;
-    svt_aom_highbd_10_variance64x32 = svt_aom_highbd_10_variance64x32_c;
-    svt_aom_highbd_10_variance64x64 = svt_aom_highbd_10_variance64x64_c;
-    svt_aom_highbd_10_variance64x128 = svt_aom_highbd_10_variance64x128_c;
-    svt_aom_highbd_10_variance128x64 = svt_aom_highbd_10_variance128x64_c;
-    svt_aom_highbd_10_variance128x128 = svt_aom_highbd_10_variance128x128_c;
-
-    //QIQ
-    // transform
-    svt_av1_fwd_txfm2d_16x8 = svt_av1_fwd_txfm2d_16x8_c;
-    svt_av1_fwd_txfm2d_8x16 = svt_av1_fwd_txfm2d_8x16_c;
-
-    svt_av1_fwd_txfm2d_16x4 = svt_av1_fwd_txfm2d_16x4_c;
-    svt_av1_fwd_txfm2d_4x16 = svt_av1_fwd_txfm2d_4x16_c;
-
-    svt_av1_fwd_txfm2d_8x4 = svt_av1_fwd_txfm2d_8x4_c;
-    svt_av1_fwd_txfm2d_4x8 = svt_av1_fwd_txfm2d_4x8_c;
-
-    svt_av1_fwd_txfm2d_32x16 = svt_av1_fwd_txfm2d_32x16_c;
-    svt_av1_fwd_txfm2d_32x8 = svt_av1_fwd_txfm2d_32x8_c;
-    svt_av1_fwd_txfm2d_8x32 = svt_av1_fwd_txfm2d_8x32_c;
-    svt_av1_fwd_txfm2d_16x32 = svt_av1_fwd_txfm2d_16x32_c;
-    svt_av1_fwd_txfm2d_32x64 = svt_av1_fwd_txfm2d_32x64_c;
-    svt_av1_fwd_txfm2d_64x32 = svt_av1_fwd_txfm2d_64x32_c;
-    svt_av1_fwd_txfm2d_16x64 = svt_av1_fwd_txfm2d_16x64_c;
-    svt_av1_fwd_txfm2d_64x16 = svt_av1_fwd_txfm2d_64x16_c;
-    svt_av1_fwd_txfm2d_64x64 = svt_av1_transform_two_d_64x64_c;
-    svt_av1_fwd_txfm2d_32x32 = svt_av1_transform_two_d_32x32_c;
-    svt_av1_fwd_txfm2d_16x16 = svt_av1_transform_two_d_16x16_c;
-
-    svt_av1_fwd_txfm2d_8x8 = svt_av1_transform_two_d_8x8_c;
-    svt_av1_fwd_txfm2d_4x4 = svt_av1_transform_two_d_4x4_c;
-
-    svt_handle_transform16x64 = svt_handle_transform16x64_c;
-    svt_handle_transform32x64 = svt_handle_transform32x64_c;
-    svt_handle_transform64x16 = svt_handle_transform64x16_c;
-    svt_handle_transform64x32 = svt_handle_transform64x32_c;
-    svt_handle_transform64x64 = svt_handle_transform64x64_c;
-#if FEATURE_PARTIAL_FREQUENCY
-    handle_transform16x64_N2_N4 = handle_transform16x64_N2_N4_c;
-    handle_transform32x64_N2_N4 = handle_transform32x64_N2_N4_c;
-    handle_transform64x16_N2_N4 = handle_transform64x16_N2_N4_c;
-    handle_transform64x32_N2_N4 = handle_transform64x32_N2_N4_c;
-    handle_transform64x64_N2_N4 = handle_transform64x64_N2_N4_c;
-    svt_av1_fwd_txfm2d_16x8_N2 = svt_av1_fwd_txfm2d_16x8_N2_c;
-    svt_av1_fwd_txfm2d_8x16_N2 = svt_av1_fwd_txfm2d_8x16_N2_c;
-    svt_av1_fwd_txfm2d_16x4_N2 = svt_av1_fwd_txfm2d_16x4_N2_c;
-    svt_av1_fwd_txfm2d_4x16_N2 = svt_av1_fwd_txfm2d_4x16_N2_c;
-    svt_av1_fwd_txfm2d_8x4_N2 = svt_av1_fwd_txfm2d_8x4_N2_c;
-    svt_av1_fwd_txfm2d_4x8_N2 = svt_av1_fwd_txfm2d_4x8_N2_c;
-    svt_av1_fwd_txfm2d_32x16_N2 = svt_av1_fwd_txfm2d_32x16_N2_c;
-    svt_av1_fwd_txfm2d_32x8_N2  = svt_av1_fwd_txfm2d_32x8_N2_c;
-    svt_av1_fwd_txfm2d_8x32_N2  = svt_av1_fwd_txfm2d_8x32_N2_c;
-    svt_av1_fwd_txfm2d_16x32_N2 = svt_av1_fwd_txfm2d_16x32_N2_c;
-    svt_av1_fwd_txfm2d_32x64_N2 = svt_av1_fwd_txfm2d_32x64_N2_c;
-    svt_av1_fwd_txfm2d_64x32_N2 = svt_av1_fwd_txfm2d_64x32_N2_c;
-    svt_av1_fwd_txfm2d_16x64_N2 = svt_av1_fwd_txfm2d_16x64_N2_c;
-    svt_av1_fwd_txfm2d_64x16_N2 = svt_av1_fwd_txfm2d_64x16_N2_c;
-    svt_av1_fwd_txfm2d_64x64_N2 = av1_transform_two_d_64x64_N2_c;
-    svt_av1_fwd_txfm2d_32x32_N2 = av1_transform_two_d_32x32_N2_c;
-    svt_av1_fwd_txfm2d_16x16_N2 = av1_transform_two_d_16x16_N2_c;
-    svt_av1_fwd_txfm2d_8x8_N2 = av1_transform_two_d_8x8_N2_c;
-    svt_av1_fwd_txfm2d_4x4_N2 = av1_transform_two_d_4x4_N2_c;
-    svt_av1_fwd_txfm2d_16x8_N4 = svt_av1_fwd_txfm2d_16x8_N4_c;
-    svt_av1_fwd_txfm2d_8x16_N4 = svt_av1_fwd_txfm2d_8x16_N4_c;
-    svt_av1_fwd_txfm2d_16x4_N4 = svt_av1_fwd_txfm2d_16x4_N4_c;
-    svt_av1_fwd_txfm2d_4x16_N4 = svt_av1_fwd_txfm2d_4x16_N4_c;
-    svt_av1_fwd_txfm2d_8x4_N4 = svt_av1_fwd_txfm2d_8x4_N4_c;
-    svt_av1_fwd_txfm2d_4x8_N4 = svt_av1_fwd_txfm2d_4x8_N4_c;
-    svt_av1_fwd_txfm2d_32x16_N4 = svt_av1_fwd_txfm2d_32x16_N4_c;
-    svt_av1_fwd_txfm2d_32x8_N4  = svt_av1_fwd_txfm2d_32x8_N4_c;
-    svt_av1_fwd_txfm2d_8x32_N4  = svt_av1_fwd_txfm2d_8x32_N4_c;
-    svt_av1_fwd_txfm2d_16x32_N4 = svt_av1_fwd_txfm2d_16x32_N4_c;
-    svt_av1_fwd_txfm2d_32x64_N4 = svt_av1_fwd_txfm2d_32x64_N4_c;
-    svt_av1_fwd_txfm2d_64x32_N4 = svt_av1_fwd_txfm2d_64x32_N4_c;
-    svt_av1_fwd_txfm2d_16x64_N4 = svt_av1_fwd_txfm2d_16x64_N4_c;
-    svt_av1_fwd_txfm2d_64x16_N4 = svt_av1_fwd_txfm2d_64x16_N4_c;
-    svt_av1_fwd_txfm2d_64x64_N4 = av1_transform_two_d_64x64_N4_c;
-    svt_av1_fwd_txfm2d_32x32_N4 = av1_transform_two_d_32x32_N4_c;
-    svt_av1_fwd_txfm2d_16x16_N4 = av1_transform_two_d_16x16_N4_c;
-    svt_av1_fwd_txfm2d_8x8_N4 = av1_transform_two_d_8x8_N4_c;
-    svt_av1_fwd_txfm2d_4x4_N4 = av1_transform_two_d_4x4_N4_c;
-#endif /*FEATURE_PARTIAL_FREQUENCY*/
-
-    svt_aom_fft2x2_float = svt_aom_fft2x2_float_c;
-    svt_aom_fft4x4_float = svt_aom_fft4x4_float_c;
-    svt_aom_fft16x16_float = svt_aom_fft16x16_float_c;
-    svt_aom_fft32x32_float = svt_aom_fft32x32_float_c;
-    svt_aom_fft8x8_float = svt_aom_fft8x8_float_c;
-
-    svt_aom_ifft16x16_float = svt_aom_ifft16x16_float_c;
-    svt_aom_ifft32x32_float = svt_aom_ifft32x32_float_c;
-    svt_aom_ifft8x8_float = svt_aom_ifft8x8_float_c;
-    svt_aom_ifft2x2_float = svt_aom_ifft2x2_float_c;
-    svt_aom_ifft4x4_float = svt_aom_ifft4x4_float_c;
-    svt_av1_get_gradient_hist = svt_av1_get_gradient_hist_c;
-
-    svt_search_one_dual = svt_search_one_dual_c;
-    svt_sad_loop_kernel = svt_sad_loop_kernel_c;
-#if !FIX_REMOVE_UNUSED_CODE
-    svt_av1_apply_filtering = svt_av1_apply_filtering_c;
-#endif
-    svt_av1_apply_temporal_filter_planewise = svt_av1_apply_temporal_filter_planewise_c;
-    svt_av1_apply_temporal_filter_planewise_hbd = svt_av1_apply_temporal_filter_planewise_hbd_c;
-#if !FIX_REMOVE_UNUSED_CODE
-    svt_av1_apply_filtering_highbd = svt_av1_apply_filtering_highbd_c;
-#endif
-    svt_ext_sad_calculation_8x8_16x16 = svt_ext_sad_calculation_8x8_16x16_c;
-    svt_ext_sad_calculation_32x32_64x64 = svt_ext_sad_calculation_32x32_64x64_c;
-    svt_ext_all_sad_calculation_8x8_16x16 = svt_ext_all_sad_calculation_8x8_16x16_c;
-    svt_ext_eight_sad_calculation_32x32_64x64 = svt_ext_eight_sad_calculation_32x32_64x64_c;
-    svt_initialize_buffer_32bits = svt_initialize_buffer_32bits_c;
-    svt_nxm_sad_kernel_sub_sampled = svt_nxm_sad_kernel_helper_c;
-    svt_nxm_sad_kernel = svt_nxm_sad_kernel_helper_c;
-    svt_compute_mean_square_values_8x8 = svt_compute_mean_squared_values_c;
-    svt_compute_sub_mean_8x8 = svt_compute_sub_mean_8x8_c;
-    svt_compute_interm_var_four8x8 = svt_compute_interm_var_four8x8_c;
-    sad_16b_kernel = sad_16b_kernel_c;
-    svt_av1_compute_cross_correlation = svt_av1_compute_cross_correlation_c;
-    svt_av1_k_means_dim1 = av1_k_means_dim1_c;
-    svt_av1_k_means_dim2 = av1_k_means_dim2_c;
-    svt_av1_calc_indices_dim1 = av1_calc_indices_dim1_c;
-    svt_av1_calc_indices_dim2 = av1_calc_indices_dim2_c;
-
-    svt_av1_get_nz_map_contexts = svt_av1_get_nz_map_contexts_c;
-
-    variance_highbd = variance_highbd_c;
-    svt_av1_haar_ac_sad_8x8_uint8_input = svt_av1_haar_ac_sad_8x8_uint8_input_c;
 
 #ifdef ARCH_X86_64
+    /** Should be done during library initialization,
+        but for safe limiting cpu flags again. */
     flags &= get_cpu_flags_to_use();
-    if (flags & HAS_AVX2) svt_aom_sse = svt_aom_sse_avx2;
-    if (flags & HAS_AVX2) svt_aom_highbd_sse = svt_aom_highbd_sse_avx2;
-    if (flags & HAS_AVX2) svt_av1_wedge_compute_delta_squares = svt_av1_wedge_compute_delta_squares_avx2;
-    if (flags & HAS_AVX2) svt_av1_wedge_sign_from_residuals = svt_av1_wedge_sign_from_residuals_avx2;
-    if (flags & HAS_AVX2) svt_compute_cdef_dist_16bit = compute_cdef_dist_16bit_avx2;
-    if (flags & HAS_AVX2) svt_compute_cdef_dist_8bit = compute_cdef_dist_8bit_avx2;
-    if (flags & HAS_AVX2) svt_av1_compute_stats = svt_av1_compute_stats_avx2;
-    if (flags & HAS_AVX2) svt_av1_compute_stats_highbd = svt_av1_compute_stats_highbd_avx2;
-#ifndef NON_AVX512_SUPPORT
-    if (flags & HAS_AVX512F) {
-        svt_av1_compute_stats = svt_av1_compute_stats_avx512;
-        svt_av1_compute_stats_highbd = svt_av1_compute_stats_highbd_avx512;
-    }
+    //to use C: flags=0
+#else
+    (void)flags;
 #endif
-        if (flags & HAS_AVX2) svt_av1_highbd_pixel_proj_error = svt_av1_highbd_pixel_proj_error_avx2;
-        if (flags & HAS_AVX2) svt_av1_calc_frame_error = svt_av1_calc_frame_error_avx2;
-        if (flags & HAS_AVX2) svt_subtract_average = svt_subtract_average_avx2;
-        if (flags & HAS_AVX2) svt_get_proj_subspace = svt_get_proj_subspace_avx2;
-        if (flags & HAS_AVX2) svt_search_one_dual = svt_search_one_dual_avx2;
-        if (flags & HAS_AVX2) svt_aom_mse16x16 = svt_aom_mse16x16_avx2;
-        if (flags & HAS_AVX2) svt_aom_quantize_b = svt_aom_quantize_b_avx2;
-        if (flags & HAS_AVX2) svt_aom_highbd_quantize_b = svt_aom_highbd_quantize_b_avx2;
-        if (flags & HAS_AVX2) svt_av1_lowbd_pixel_proj_error = svt_av1_lowbd_pixel_proj_error_avx2;
-#ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX512F) {
-            svt_av1_lowbd_pixel_proj_error = svt_av1_lowbd_pixel_proj_error_avx512;
-        }
-#endif
-            if (flags & HAS_AVX2) svt_av1_quantize_fp = svt_av1_quantize_fp_avx2;
-            if (flags & HAS_AVX2) svt_av1_quantize_fp_32x32 = svt_av1_quantize_fp_32x32_avx2;
-            if (flags & HAS_AVX2) svt_av1_quantize_fp_64x64 = svt_av1_quantize_fp_64x64_avx2;
-            if (flags & HAS_AVX2) svt_av1_highbd_quantize_fp = svt_av1_highbd_quantize_fp_avx2;
-            if (flags & HAS_SSE2) svt_aom_highbd_8_mse16x16 = svt_aom_highbd_8_mse16x16_sse2;
-            if (flags & HAS_AVX2) svt_aom_sad4x4 = svt_aom_sad4x4_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad4x4x4d = svt_aom_sad4x4x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad4x16 = svt_aom_sad4x16_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad4x16x4d = svt_aom_sad4x16x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad4x8 = svt_aom_sad4x8_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad4x8x4d = svt_aom_sad4x8x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x128x4d = svt_aom_sad64x128x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x16x4d = svt_aom_sad64x16x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x32x4d = svt_aom_sad64x32x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x64x4d = svt_aom_sad64x64x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x16 = svt_aom_sad8x16_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x16x4d = svt_aom_sad8x16x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x32 = svt_aom_sad8x32_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x32x4d = svt_aom_sad8x32x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x8 = svt_aom_sad8x8_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x8x4d = svt_aom_sad8x8x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x4 = svt_aom_sad16x4_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x4x4d = svt_aom_sad16x4x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x8 = svt_aom_sad32x8_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x8x4d = svt_aom_sad32x8x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x64 = svt_aom_sad16x64_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x64x4d = svt_aom_sad16x64x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x16 = svt_aom_sad32x16_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x16x4d = svt_aom_sad32x16x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x32 = svt_aom_sad16x32_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x32x4d = svt_aom_sad16x32x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x64 = svt_aom_sad32x64_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x64x4d = svt_aom_sad32x64x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x32 = svt_aom_sad32x32_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad32x32x4d = svt_aom_sad32x32x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x16 = svt_aom_sad16x16_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x16x4d = svt_aom_sad16x16x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x8 = svt_aom_sad16x8_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad16x8x4d = svt_aom_sad16x8x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x4 = svt_aom_sad8x4_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad8x4x4d = svt_aom_sad8x4x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x128 = svt_aom_sad64x128_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x16 = svt_aom_sad64x16_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x32 = svt_aom_sad64x32_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad64x64 = svt_aom_sad64x64_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad128x128 = svt_aom_sad128x128_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad128x128x4d = svt_aom_sad128x128x4d_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad128x64 = svt_aom_sad128x64_avx2;
-            if (flags & HAS_AVX2) svt_aom_sad128x64x4d = svt_aom_sad128x64x4d_avx2;
-            if (flags & HAS_AVX2) svt_av1_txb_init_levels = svt_av1_txb_init_levels_avx2;
-            if (flags & HAS_AVX2) svt_aom_satd = svt_aom_satd_avx2;
-            if (flags & HAS_AVX2) svt_av1_block_error = svt_av1_block_error_avx2;
-#ifndef NON_AVX512_SUPPORT
-            if (flags & HAS_AVX512F) {
-                svt_aom_sad64x128 = svt_aom_sad64x128_avx512;
-                svt_aom_sad64x16 = svt_aom_sad64x16_avx512;
-                svt_aom_sad64x32 = svt_aom_sad64x32_avx512;
-                svt_aom_sad64x64 = svt_aom_sad64x64_avx512;
-                svt_aom_sad128x128 = svt_aom_sad128x128_avx512;
-                svt_aom_sad128x128x4d = svt_aom_sad128x128x4d_avx512;
-                svt_aom_sad128x64 = svt_aom_sad128x64_avx512;
-                svt_aom_sad128x64x4d = svt_aom_sad128x64x4d_avx512;
-                svt_av1_txb_init_levels = svt_av1_txb_init_levels_avx512;
-            }
-#endif // !NON_AVX512_SUPPORT
-                if (flags & HAS_AVX2) svt_aom_upsampled_pred = svt_aom_upsampled_pred_sse2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad128x128 = svt_aom_obmc_sad128x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad128x64 = svt_aom_obmc_sad128x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad16x16 = svt_aom_obmc_sad16x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad16x32 = svt_aom_obmc_sad16x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad16x4 = svt_aom_obmc_sad16x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad16x64 = svt_aom_obmc_sad16x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad16x8 = svt_aom_obmc_sad16x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad32x16 = svt_aom_obmc_sad32x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad32x32 = svt_aom_obmc_sad32x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad32x64 = svt_aom_obmc_sad32x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad32x8 = svt_aom_obmc_sad32x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad4x16 = svt_aom_obmc_sad4x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad4x4 = svt_aom_obmc_sad4x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad4x8 = svt_aom_obmc_sad4x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad64x128 = svt_aom_obmc_sad64x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad64x16 = svt_aom_obmc_sad64x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad64x32 = svt_aom_obmc_sad64x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad64x64 = svt_aom_obmc_sad64x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad8x16 = svt_aom_obmc_sad8x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad8x32 = svt_aom_obmc_sad8x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad8x4 = svt_aom_obmc_sad8x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_sad8x8 = svt_aom_obmc_sad8x8_avx2;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance128x128 = svt_aom_obmc_sub_pixel_variance128x128_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance128x64 = svt_aom_obmc_sub_pixel_variance128x64_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance16x16 = svt_aom_obmc_sub_pixel_variance16x16_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance16x32 = svt_aom_obmc_sub_pixel_variance16x32_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance16x4 = svt_aom_obmc_sub_pixel_variance16x4_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance16x64 = svt_aom_obmc_sub_pixel_variance16x64_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance16x8 = svt_aom_obmc_sub_pixel_variance16x8_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance32x16 = svt_aom_obmc_sub_pixel_variance32x16_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance32x32 = svt_aom_obmc_sub_pixel_variance32x32_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance32x64 = svt_aom_obmc_sub_pixel_variance32x64_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance32x8 = svt_aom_obmc_sub_pixel_variance32x8_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance4x16 = svt_aom_obmc_sub_pixel_variance4x16_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance4x4 = svt_aom_obmc_sub_pixel_variance4x4_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance4x8 = svt_aom_obmc_sub_pixel_variance4x8_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance64x128 = svt_aom_obmc_sub_pixel_variance64x128_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance64x16 = svt_aom_obmc_sub_pixel_variance64x16_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance64x32 = svt_aom_obmc_sub_pixel_variance64x32_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance64x64 = svt_aom_obmc_sub_pixel_variance64x64_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance8x16 = svt_aom_obmc_sub_pixel_variance8x16_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance8x32 = svt_aom_obmc_sub_pixel_variance8x32_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance8x4 = svt_aom_obmc_sub_pixel_variance8x4_sse4_1;
-                if (flags & HAS_SSE4_1) svt_aom_obmc_sub_pixel_variance8x8 = svt_aom_obmc_sub_pixel_variance8x8_sse4_1;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance128x128 = svt_aom_obmc_variance128x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance128x64 = svt_aom_obmc_variance128x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance16x16 = svt_aom_obmc_variance16x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance16x32 = svt_aom_obmc_variance16x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance16x4 = svt_aom_obmc_variance16x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance16x64 = svt_aom_obmc_variance16x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance16x8 = svt_aom_obmc_variance16x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance32x16 = svt_aom_obmc_variance32x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance32x32 = svt_aom_obmc_variance32x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance32x64 = svt_aom_obmc_variance32x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance32x8 = svt_aom_obmc_variance32x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance4x16 = svt_aom_obmc_variance4x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance4x4 = svt_aom_obmc_variance4x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance4x8 = svt_aom_obmc_variance4x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance64x128 = svt_aom_obmc_variance64x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance64x16 = svt_aom_obmc_variance64x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance64x32 = svt_aom_obmc_variance64x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance64x64 = svt_aom_obmc_variance64x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance8x16 = svt_aom_obmc_variance8x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance8x32 = svt_aom_obmc_variance8x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance8x4 = svt_aom_obmc_variance8x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_obmc_variance8x8 = svt_aom_obmc_variance8x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance4x4 = svt_aom_variance4x4_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance4x8 = svt_aom_variance4x8_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance4x16 = svt_aom_variance4x16_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance8x4 = svt_aom_variance8x4_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance8x8 = svt_aom_variance8x8_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance8x16 = svt_aom_variance8x16_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance8x32 = svt_aom_variance8x32_sse2;
-                if (flags & HAS_AVX2) svt_aom_variance16x4 = svt_aom_variance16x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance16x8 = svt_aom_variance16x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance16x16 = svt_aom_variance16x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance16x32 = svt_aom_variance16x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance16x64 = svt_aom_variance16x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance32x8 = svt_aom_variance32x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance32x16 = svt_aom_variance32x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance32x32 = svt_aom_variance32x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance32x64 = svt_aom_variance32x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance64x16 = svt_aom_variance64x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance64x32 = svt_aom_variance64x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance64x64 = svt_aom_variance64x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance64x128 = svt_aom_variance64x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance128x64 = svt_aom_variance128x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_variance128x128 = svt_aom_variance128x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance8x8 = svt_aom_highbd_10_variance8x8_sse2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance8x16 = svt_aom_highbd_10_variance8x16_sse2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance8x32 = svt_aom_highbd_10_variance8x32_sse2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance16x4 = svt_aom_highbd_10_variance16x4_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance16x8 = svt_aom_highbd_10_variance16x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance16x16 = svt_aom_highbd_10_variance16x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance16x32 = svt_aom_highbd_10_variance16x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance16x64 = svt_aom_highbd_10_variance16x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance32x8 = svt_aom_highbd_10_variance32x8_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance32x16 = svt_aom_highbd_10_variance32x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance32x32 = svt_aom_highbd_10_variance32x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance32x64 = svt_aom_highbd_10_variance32x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance64x16 = svt_aom_highbd_10_variance64x16_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance64x32 = svt_aom_highbd_10_variance64x32_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance64x64 = svt_aom_highbd_10_variance64x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance64x128 = svt_aom_highbd_10_variance64x128_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance128x64 = svt_aom_highbd_10_variance128x64_avx2;
-                if (flags & HAS_AVX2) svt_aom_highbd_10_variance128x128 = svt_aom_highbd_10_variance128x128_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x8 = svt_av1_fwd_txfm2d_16x8_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x16 = svt_av1_fwd_txfm2d_8x16_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x4 = svt_av1_fwd_txfm2d_16x4_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x16 = svt_av1_fwd_txfm2d_4x16_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x4 = svt_av1_fwd_txfm2d_8x4_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x8 = svt_av1_fwd_txfm2d_4x8_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x8 = svt_av1_fwd_txfm2d_32x8_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x32 = svt_av1_fwd_txfm2d_8x32_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x64 = svt_av1_fwd_txfm2d_64x64_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x32 = svt_av1_fwd_txfm2d_32x32_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x16 = svt_av1_fwd_txfm2d_16x16_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x64 = svt_av1_fwd_txfm2d_32x64_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x32 = svt_av1_fwd_txfm2d_64x32_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x64 = svt_av1_fwd_txfm2d_16x64_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x16 = svt_av1_fwd_txfm2d_64x16_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x16 = svt_av1_fwd_txfm2d_32x16_avx2;
-                if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x32 = svt_av1_fwd_txfm2d_16x32_avx2;
-#ifndef NON_AVX512_SUPPORT
-                if (flags & HAS_AVX512F) {
-                    svt_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;
-                    svt_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
-                    svt_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
-                    svt_av1_fwd_txfm2d_32x64 = av1_fwd_txfm2d_32x64_avx512;
-                    svt_av1_fwd_txfm2d_64x32 = av1_fwd_txfm2d_64x32_avx512;
-                    svt_av1_fwd_txfm2d_16x64 = av1_fwd_txfm2d_16x64_avx512;
-                    svt_av1_fwd_txfm2d_64x16 = av1_fwd_txfm2d_64x16_avx512;
-                    svt_av1_fwd_txfm2d_32x16 = av1_fwd_txfm2d_32x16_avx512;
-                    svt_av1_fwd_txfm2d_16x32 = av1_fwd_txfm2d_16x32_avx512;
-                }
-#endif
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x8 = svt_av1_fwd_txfm2d_8x8_avx2;
-                    if (flags & HAS_SSE4_1) svt_av1_fwd_txfm2d_4x4 = svt_av1_fwd_txfm2d_4x4_sse4_1;
-                    if (flags & HAS_AVX2) svt_handle_transform16x64 = svt_handle_transform16x64_avx2;
-                    if (flags & HAS_AVX2) svt_handle_transform32x64 = svt_handle_transform32x64_avx2;
-                    if (flags & HAS_AVX2) svt_handle_transform64x16 = svt_handle_transform64x16_avx2;
-                    if (flags & HAS_AVX2) svt_handle_transform64x32 = svt_handle_transform64x32_avx2;
-                    if (flags & HAS_AVX2) svt_handle_transform64x64 = svt_handle_transform64x64_avx2;
+
+    SET_AVX2(svt_aom_sse, svt_aom_sse_c, svt_aom_sse_avx2);
+    SET_AVX2(svt_aom_highbd_sse, svt_aom_highbd_sse_c, svt_aom_highbd_sse_avx2);
+    SET_AVX2(svt_av1_wedge_compute_delta_squares, svt_av1_wedge_compute_delta_squares_c, svt_av1_wedge_compute_delta_squares_avx2);
+    SET_AVX2(svt_av1_wedge_sign_from_residuals, svt_av1_wedge_sign_from_residuals_c, svt_av1_wedge_sign_from_residuals_avx2);
+    SET_AVX2(svt_compute_cdef_dist_16bit, compute_cdef_dist_c, compute_cdef_dist_16bit_avx2);
+    SET_AVX2(svt_compute_cdef_dist_8bit, compute_cdef_dist_8bit_c, compute_cdef_dist_8bit_avx2);
+    SET_AVX2_AVX512(svt_av1_compute_stats, svt_av1_compute_stats_c, svt_av1_compute_stats_avx2, svt_av1_compute_stats_avx512);
+    SET_AVX2_AVX512(svt_av1_compute_stats_highbd, svt_av1_compute_stats_highbd_c, svt_av1_compute_stats_highbd_avx2, svt_av1_compute_stats_highbd_avx512);
+    SET_AVX2_AVX512(svt_av1_lowbd_pixel_proj_error, svt_av1_lowbd_pixel_proj_error_c, svt_av1_lowbd_pixel_proj_error_avx2, svt_av1_lowbd_pixel_proj_error_avx512);
+    SET_AVX2(svt_av1_highbd_pixel_proj_error, svt_av1_highbd_pixel_proj_error_c, svt_av1_highbd_pixel_proj_error_avx2);
+    SET_AVX2(svt_av1_calc_frame_error, svt_av1_calc_frame_error_c, svt_av1_calc_frame_error_avx2);
+    SET_AVX2(svt_subtract_average, svt_subtract_average_c, svt_subtract_average_avx2);
+    SET_AVX2(svt_get_proj_subspace, svt_get_proj_subspace_c, svt_get_proj_subspace_avx2);
+    SET_AVX2(svt_aom_quantize_b, svt_aom_quantize_b_c_ii, svt_aom_quantize_b_avx2);
+    SET_AVX2(svt_aom_highbd_quantize_b, svt_aom_highbd_quantize_b_c, svt_aom_highbd_quantize_b_avx2);
+    SET_AVX2(svt_av1_quantize_fp, svt_av1_quantize_fp_c, svt_av1_quantize_fp_avx2);
+    SET_AVX2(svt_av1_quantize_fp_32x32, svt_av1_quantize_fp_32x32_c, svt_av1_quantize_fp_32x32_avx2);
+    SET_AVX2(svt_av1_quantize_fp_64x64, svt_av1_quantize_fp_64x64_c, svt_av1_quantize_fp_64x64_avx2);
+    SET_AVX2(svt_av1_highbd_quantize_fp, svt_av1_highbd_quantize_fp_c, svt_av1_highbd_quantize_fp_avx2);
+    SET_SSE2(svt_aom_highbd_8_mse16x16, svt_aom_highbd_8_mse16x16_c, svt_aom_highbd_8_mse16x16_sse2);
+
+    //SAD
+    SET_AVX2(svt_aom_mse16x16, svt_aom_mse16x16_c, svt_aom_mse16x16_avx2);
+    SET_AVX2(svt_aom_sad4x4, svt_aom_sad4x4_c, svt_aom_sad4x4_avx2);
+    SET_AVX2(svt_aom_sad4x4x4d, svt_aom_sad4x4x4d_c, svt_aom_sad4x4x4d_avx2);
+    SET_AVX2(svt_aom_sad4x16, svt_aom_sad4x16_c, svt_aom_sad4x16_avx2);
+    SET_AVX2(svt_aom_sad4x16x4d, svt_aom_sad4x16x4d_c, svt_aom_sad4x16x4d_avx2);
+    SET_AVX2(svt_aom_sad4x8, svt_aom_sad4x8_c, svt_aom_sad4x8_avx2);
+    SET_AVX2(svt_aom_sad4x8x4d, svt_aom_sad4x8x4d_c, svt_aom_sad4x8x4d_avx2);
+    SET_AVX2(svt_aom_sad64x128x4d, svt_aom_sad64x128x4d_c, svt_aom_sad64x128x4d_avx2);
+    SET_AVX2(svt_aom_sad64x16x4d, svt_aom_sad64x16x4d_c, svt_aom_sad64x16x4d_avx2);
+    SET_AVX2(svt_aom_sad64x32x4d, svt_aom_sad64x32x4d_c, svt_aom_sad64x32x4d_avx2);
+    SET_AVX2(svt_aom_sad64x64x4d, svt_aom_sad64x64x4d_c, svt_aom_sad64x64x4d_avx2);
+    SET_AVX2(svt_aom_sad8x16, svt_aom_sad8x16_c, svt_aom_sad8x16_avx2);
+    SET_AVX2(svt_aom_sad8x16x4d, svt_aom_sad8x16x4d_c, svt_aom_sad8x16x4d_avx2);
+    SET_AVX2(svt_aom_sad8x32, svt_aom_sad8x32_c, svt_aom_sad8x32_avx2);
+    SET_AVX2(svt_aom_sad8x32x4d, svt_aom_sad8x32x4d_c, svt_aom_sad8x32x4d_avx2);
+    SET_AVX2(svt_aom_sad8x8, svt_aom_sad8x8_c, svt_aom_sad8x8_avx2);
+    SET_AVX2(svt_aom_sad8x8x4d, svt_aom_sad8x8x4d_c, svt_aom_sad8x8x4d_avx2);
+    SET_AVX2(svt_aom_sad16x4, svt_aom_sad16x4_c, svt_aom_sad16x4_avx2);
+    SET_AVX2(svt_aom_sad16x4x4d, svt_aom_sad16x4x4d_c, svt_aom_sad16x4x4d_avx2);
+    SET_AVX2(svt_aom_sad32x8, svt_aom_sad32x8_c, svt_aom_sad32x8_avx2);
+    SET_AVX2(svt_aom_sad32x8x4d, svt_aom_sad32x8x4d_c, svt_aom_sad32x8x4d_avx2);
+    SET_AVX2(svt_aom_sad16x64, svt_aom_sad16x64_c, svt_aom_sad16x64_avx2);
+    SET_AVX2(svt_aom_sad16x64x4d, svt_aom_sad16x64x4d_c, svt_aom_sad16x64x4d_avx2);
+    SET_AVX2(svt_aom_sad32x16, svt_aom_sad32x16_c, svt_aom_sad32x16_avx2);
+    SET_AVX2(svt_aom_sad32x16x4d, svt_aom_sad32x16x4d_c, svt_aom_sad32x16x4d_avx2);
+    SET_AVX2(svt_aom_sad16x32, svt_aom_sad16x32_c, svt_aom_sad16x32_avx2);
+    SET_AVX2(svt_aom_sad16x32x4d, svt_aom_sad16x32x4d_c, svt_aom_sad16x32x4d_avx2);
+    SET_AVX2(svt_aom_sad32x64, svt_aom_sad32x64_c, svt_aom_sad32x64_avx2);
+    SET_AVX2(svt_aom_sad32x64x4d, svt_aom_sad32x64x4d_c, svt_aom_sad32x64x4d_avx2);
+    SET_AVX2(svt_aom_sad32x32, svt_aom_sad32x32_c, svt_aom_sad32x32_avx2);
+    SET_AVX2(svt_aom_sad32x32x4d, svt_aom_sad32x32x4d_c, svt_aom_sad32x32x4d_avx2);
+    SET_AVX2(svt_aom_sad16x16, svt_aom_sad16x16_c, svt_aom_sad16x16_avx2);
+    SET_AVX2(svt_aom_sad16x16x4d, svt_aom_sad16x16x4d_c, svt_aom_sad16x16x4d_avx2);
+    SET_AVX2(svt_aom_sad16x8, svt_aom_sad16x8_c, svt_aom_sad16x8_avx2);
+    SET_AVX2(svt_aom_sad16x8x4d, svt_aom_sad16x8x4d_c, svt_aom_sad16x8x4d_avx2);
+    SET_AVX2(svt_aom_sad8x4, svt_aom_sad8x4_c, svt_aom_sad8x4_avx2);
+    SET_AVX2(svt_aom_sad8x4x4d, svt_aom_sad8x4x4d_c, svt_aom_sad8x4x4d_avx2);
+    SET_AVX2_AVX512(svt_aom_sad64x16, svt_aom_sad64x16_c, svt_aom_sad64x16_avx2, svt_aom_sad64x16_avx512);
+    SET_AVX2_AVX512(svt_aom_sad64x32, svt_aom_sad64x32_c, svt_aom_sad64x32_avx2, svt_aom_sad64x32_avx512);
+    SET_AVX2_AVX512(svt_aom_sad64x64, svt_aom_sad64x64_c, svt_aom_sad64x64_avx2, svt_aom_sad64x64_avx512);
+    SET_AVX2_AVX512(svt_aom_sad64x128, svt_aom_sad64x128_c, svt_aom_sad64x128_avx2, svt_aom_sad64x128_avx512);
+    SET_AVX2_AVX512(svt_aom_sad128x128, svt_aom_sad128x128_c, svt_aom_sad128x128_avx2, svt_aom_sad128x128_avx512);
+    SET_AVX2_AVX512(svt_aom_sad128x128x4d, svt_aom_sad128x128x4d_c, svt_aom_sad128x128x4d_avx2, svt_aom_sad128x128x4d_avx512);
+    SET_AVX2_AVX512(svt_aom_sad128x64, svt_aom_sad128x64_c, svt_aom_sad128x64_avx2, svt_aom_sad128x64_avx512);
+    SET_AVX2_AVX512(svt_aom_sad128x64x4d, svt_aom_sad128x64x4d_c, svt_aom_sad128x64x4d_avx2, svt_aom_sad128x64x4d_avx512);
+    SET_AVX2_AVX512(svt_av1_txb_init_levels, svt_av1_txb_init_levels_c, svt_av1_txb_init_levels_avx2, svt_av1_txb_init_levels_avx512);
+    SET_AVX2(svt_aom_satd, svt_aom_satd_c, svt_aom_satd_avx2);
+    SET_AVX2(svt_av1_block_error, svt_av1_block_error_c, svt_av1_block_error_avx2);
+    SET_AVX2(svt_aom_upsampled_pred, svt_aom_upsampled_pred_c, svt_aom_upsampled_pred_sse2);
+
+    SET_AVX2(svt_aom_obmc_sad4x4, svt_aom_obmc_sad4x4_c, svt_aom_obmc_sad4x4_avx2);
+    SET_AVX2(svt_aom_obmc_sad4x8, svt_aom_obmc_sad4x8_c, svt_aom_obmc_sad4x8_avx2);
+    SET_AVX2(svt_aom_obmc_sad4x16, svt_aom_obmc_sad4x16_c, svt_aom_obmc_sad4x16_avx2);
+    SET_AVX2(svt_aom_obmc_sad8x4, svt_aom_obmc_sad8x4_c, svt_aom_obmc_sad8x4_avx2);
+    SET_AVX2(svt_aom_obmc_sad8x8, svt_aom_obmc_sad8x8_c, svt_aom_obmc_sad8x8_avx2);
+    SET_AVX2(svt_aom_obmc_sad8x16, svt_aom_obmc_sad8x16_c, svt_aom_obmc_sad8x16_avx2);
+    SET_AVX2(svt_aom_obmc_sad8x32, svt_aom_obmc_sad8x32_c, svt_aom_obmc_sad8x32_avx2);
+    SET_AVX2(svt_aom_obmc_sad16x4, svt_aom_obmc_sad16x4_c, svt_aom_obmc_sad16x4_avx2);
+    SET_AVX2(svt_aom_obmc_sad16x8, svt_aom_obmc_sad16x8_c, svt_aom_obmc_sad16x8_avx2);
+    SET_AVX2(svt_aom_obmc_sad16x16, svt_aom_obmc_sad16x16_c, svt_aom_obmc_sad16x16_avx2);
+    SET_AVX2(svt_aom_obmc_sad16x32, svt_aom_obmc_sad16x32_c, svt_aom_obmc_sad16x32_avx2);
+    SET_AVX2(svt_aom_obmc_sad16x64, svt_aom_obmc_sad16x64_c, svt_aom_obmc_sad16x64_avx2);
+    SET_AVX2(svt_aom_obmc_sad32x8, svt_aom_obmc_sad32x8_c, svt_aom_obmc_sad32x8_avx2);
+    SET_AVX2(svt_aom_obmc_sad32x16, svt_aom_obmc_sad32x16_c, svt_aom_obmc_sad32x16_avx2);
+    SET_AVX2(svt_aom_obmc_sad32x32, svt_aom_obmc_sad32x32_c, svt_aom_obmc_sad32x32_avx2);
+    SET_AVX2(svt_aom_obmc_sad32x64, svt_aom_obmc_sad32x64_c, svt_aom_obmc_sad32x64_avx2);
+    SET_AVX2(svt_aom_obmc_sad64x16, svt_aom_obmc_sad64x16_c, svt_aom_obmc_sad64x16_avx2);
+    SET_AVX2(svt_aom_obmc_sad64x32, svt_aom_obmc_sad64x32_c, svt_aom_obmc_sad64x32_avx2);
+    SET_AVX2(svt_aom_obmc_sad64x64, svt_aom_obmc_sad64x64_c, svt_aom_obmc_sad64x64_avx2);
+    SET_AVX2(svt_aom_obmc_sad64x128, svt_aom_obmc_sad64x128_c, svt_aom_obmc_sad64x128_avx2);
+    SET_AVX2(svt_aom_obmc_sad128x64, svt_aom_obmc_sad128x64_c, svt_aom_obmc_sad128x64_avx2);
+    SET_AVX2(svt_aom_obmc_sad128x128, svt_aom_obmc_sad128x128_c, svt_aom_obmc_sad128x128_avx2);
+
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance4x4, svt_aom_obmc_sub_pixel_variance4x4_c, svt_aom_obmc_sub_pixel_variance4x4_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance4x8, svt_aom_obmc_sub_pixel_variance4x8_c, svt_aom_obmc_sub_pixel_variance4x8_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance4x16, svt_aom_obmc_sub_pixel_variance4x16_c, svt_aom_obmc_sub_pixel_variance4x16_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance8x4, svt_aom_obmc_sub_pixel_variance8x4_c, svt_aom_obmc_sub_pixel_variance8x4_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance8x8, svt_aom_obmc_sub_pixel_variance8x8_c, svt_aom_obmc_sub_pixel_variance8x8_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance8x16, svt_aom_obmc_sub_pixel_variance8x16_c, svt_aom_obmc_sub_pixel_variance8x16_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance8x32, svt_aom_obmc_sub_pixel_variance8x32_c, svt_aom_obmc_sub_pixel_variance8x32_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance16x4, svt_aom_obmc_sub_pixel_variance16x4_c, svt_aom_obmc_sub_pixel_variance16x4_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance16x8, svt_aom_obmc_sub_pixel_variance16x8_c, svt_aom_obmc_sub_pixel_variance16x8_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance16x16, svt_aom_obmc_sub_pixel_variance16x16_c, svt_aom_obmc_sub_pixel_variance16x16_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance16x32, svt_aom_obmc_sub_pixel_variance16x32_c, svt_aom_obmc_sub_pixel_variance16x32_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance16x64, svt_aom_obmc_sub_pixel_variance16x64_c, svt_aom_obmc_sub_pixel_variance16x64_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance32x8, svt_aom_obmc_sub_pixel_variance32x8_c, svt_aom_obmc_sub_pixel_variance32x8_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance32x16, svt_aom_obmc_sub_pixel_variance32x16_c, svt_aom_obmc_sub_pixel_variance32x16_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance32x32, svt_aom_obmc_sub_pixel_variance32x32_c, svt_aom_obmc_sub_pixel_variance32x32_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance32x64, svt_aom_obmc_sub_pixel_variance32x64_c, svt_aom_obmc_sub_pixel_variance32x64_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance64x16, svt_aom_obmc_sub_pixel_variance64x16_c, svt_aom_obmc_sub_pixel_variance64x16_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance64x32, svt_aom_obmc_sub_pixel_variance64x32_c, svt_aom_obmc_sub_pixel_variance64x32_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance64x64, svt_aom_obmc_sub_pixel_variance64x64_c, svt_aom_obmc_sub_pixel_variance64x64_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance64x128, svt_aom_obmc_sub_pixel_variance64x128_c, svt_aom_obmc_sub_pixel_variance64x128_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance128x64, svt_aom_obmc_sub_pixel_variance128x64_c, svt_aom_obmc_sub_pixel_variance128x64_sse4_1);
+    SET_SSE41(svt_aom_obmc_sub_pixel_variance128x128, svt_aom_obmc_sub_pixel_variance128x128_c, svt_aom_obmc_sub_pixel_variance128x128_sse4_1);
+
+    SET_AVX2(svt_aom_obmc_variance4x4, svt_aom_obmc_variance4x4_c, svt_aom_obmc_variance4x4_avx2);
+    SET_AVX2(svt_aom_obmc_variance4x8, svt_aom_obmc_variance4x8_c, svt_aom_obmc_variance4x8_avx2);
+    SET_AVX2(svt_aom_obmc_variance4x16, svt_aom_obmc_variance4x16_c, svt_aom_obmc_variance4x16_avx2);
+    SET_AVX2(svt_aom_obmc_variance8x4, svt_aom_obmc_variance8x4_c, svt_aom_obmc_variance8x4_avx2);
+    SET_AVX2(svt_aom_obmc_variance8x8, svt_aom_obmc_variance8x8_c, svt_aom_obmc_variance8x8_avx2);
+    SET_AVX2(svt_aom_obmc_variance8x16, svt_aom_obmc_variance8x16_c, svt_aom_obmc_variance8x16_avx2);
+    SET_AVX2(svt_aom_obmc_variance8x32, svt_aom_obmc_variance8x32_c, svt_aom_obmc_variance8x32_avx2);
+    SET_AVX2(svt_aom_obmc_variance16x4, svt_aom_obmc_variance16x4_c, svt_aom_obmc_variance16x4_avx2);
+    SET_AVX2(svt_aom_obmc_variance16x8, svt_aom_obmc_variance16x8_c, svt_aom_obmc_variance16x8_avx2);
+    SET_AVX2(svt_aom_obmc_variance16x16, svt_aom_obmc_variance16x16_c, svt_aom_obmc_variance16x16_avx2);
+    SET_AVX2(svt_aom_obmc_variance16x32, svt_aom_obmc_variance16x32_c, svt_aom_obmc_variance16x32_avx2);
+    SET_AVX2(svt_aom_obmc_variance16x64, svt_aom_obmc_variance16x64_c, svt_aom_obmc_variance16x64_avx2);
+    SET_AVX2(svt_aom_obmc_variance32x8, svt_aom_obmc_variance32x8_c, svt_aom_obmc_variance32x8_avx2);
+    SET_AVX2(svt_aom_obmc_variance32x16, svt_aom_obmc_variance32x16_c, svt_aom_obmc_variance32x16_avx2);
+    SET_AVX2(svt_aom_obmc_variance32x32, svt_aom_obmc_variance32x32_c, svt_aom_obmc_variance32x32_avx2);
+    SET_AVX2(svt_aom_obmc_variance32x64, svt_aom_obmc_variance32x64_c, svt_aom_obmc_variance32x64_avx2);
+    SET_AVX2(svt_aom_obmc_variance64x16, svt_aom_obmc_variance64x16_c, svt_aom_obmc_variance64x16_avx2);
+    SET_AVX2(svt_aom_obmc_variance64x32, svt_aom_obmc_variance64x32_c, svt_aom_obmc_variance64x32_avx2);
+    SET_AVX2(svt_aom_obmc_variance64x64, svt_aom_obmc_variance64x64_c, svt_aom_obmc_variance64x64_avx2);
+    SET_AVX2(svt_aom_obmc_variance64x128, svt_aom_obmc_variance64x128_c, svt_aom_obmc_variance64x128_avx2);
+    SET_AVX2(svt_aom_obmc_variance128x64, svt_aom_obmc_variance128x64_c, svt_aom_obmc_variance128x64_avx2);
+    SET_AVX2(svt_aom_obmc_variance128x128, svt_aom_obmc_variance128x128_c, svt_aom_obmc_variance128x128_avx2);
+
+    //VARIANCE
+    SET_AVX2(svt_aom_variance4x4, svt_aom_variance4x4_c, svt_aom_variance4x4_sse2);
+    SET_AVX2(svt_aom_variance4x8, svt_aom_variance4x8_c, svt_aom_variance4x8_sse2);
+    SET_AVX2(svt_aom_variance4x16, svt_aom_variance4x16_c, svt_aom_variance4x16_sse2);
+    SET_AVX2(svt_aom_variance8x4, svt_aom_variance8x4_c, svt_aom_variance8x4_sse2);
+    SET_AVX2(svt_aom_variance8x8, svt_aom_variance8x8_c, svt_aom_variance8x8_sse2);
+    SET_AVX2(svt_aom_variance8x16, svt_aom_variance8x16_c, svt_aom_variance8x16_sse2);
+    SET_AVX2(svt_aom_variance8x32, svt_aom_variance8x32_c, svt_aom_variance8x32_sse2);
+    SET_AVX2(svt_aom_variance16x4, svt_aom_variance16x4_c, svt_aom_variance16x4_avx2);
+    SET_AVX2(svt_aom_variance16x8, svt_aom_variance16x8_c, svt_aom_variance16x8_avx2);
+    SET_AVX2(svt_aom_variance16x16, svt_aom_variance16x16_c, svt_aom_variance16x16_avx2);
+    SET_AVX2(svt_aom_variance16x32, svt_aom_variance16x32_c, svt_aom_variance16x32_avx2);
+    SET_AVX2(svt_aom_variance16x64, svt_aom_variance16x64_c, svt_aom_variance16x64_avx2);
+    SET_AVX2(svt_aom_variance32x8, svt_aom_variance32x8_c, svt_aom_variance32x8_avx2);
+    SET_AVX2(svt_aom_variance32x16, svt_aom_variance32x16_c, svt_aom_variance32x16_avx2);
+    SET_AVX2(svt_aom_variance32x32, svt_aom_variance32x32_c, svt_aom_variance32x32_avx2);
+    SET_AVX2(svt_aom_variance32x64, svt_aom_variance32x64_c, svt_aom_variance32x64_avx2);
+    SET_AVX2(svt_aom_variance64x16, svt_aom_variance64x16_c, svt_aom_variance64x16_avx2);
+    SET_AVX2(svt_aom_variance64x32, svt_aom_variance64x32_c, svt_aom_variance64x32_avx2);
+    SET_AVX2(svt_aom_variance64x64, svt_aom_variance64x64_c, svt_aom_variance64x64_avx2);
+    SET_AVX2(svt_aom_variance64x128, svt_aom_variance64x128_c, svt_aom_variance64x128_avx2);
+    SET_AVX2(svt_aom_variance128x64, svt_aom_variance128x64_c, svt_aom_variance128x64_avx2);
+    SET_AVX2(svt_aom_variance128x128, svt_aom_variance128x128_c, svt_aom_variance128x128_avx2);
+
+    //VARIANCEHBP
+    SET_ONLY_C(svt_aom_highbd_10_variance4x4, svt_aom_highbd_10_variance4x4_c);
+    SET_ONLY_C(svt_aom_highbd_10_variance4x8, svt_aom_highbd_10_variance4x8_c);
+    SET_ONLY_C(svt_aom_highbd_10_variance4x16, svt_aom_highbd_10_variance4x16_c);
+    SET_ONLY_C(svt_aom_highbd_10_variance8x4, svt_aom_highbd_10_variance8x4_c);
+    SET_AVX2(svt_aom_highbd_10_variance8x8, svt_aom_highbd_10_variance8x8_c, svt_aom_highbd_10_variance8x8_sse2);
+    SET_AVX2(svt_aom_highbd_10_variance8x16, svt_aom_highbd_10_variance8x16_c, svt_aom_highbd_10_variance8x16_sse2);
+    SET_AVX2(svt_aom_highbd_10_variance8x32, svt_aom_highbd_10_variance8x32_c, svt_aom_highbd_10_variance8x32_sse2);
+    SET_AVX2(svt_aom_highbd_10_variance16x4, svt_aom_highbd_10_variance16x4_c, svt_aom_highbd_10_variance16x4_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance16x8, svt_aom_highbd_10_variance16x8_c, svt_aom_highbd_10_variance16x8_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance16x16, svt_aom_highbd_10_variance16x16_c, svt_aom_highbd_10_variance16x16_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance16x32, svt_aom_highbd_10_variance16x32_c, svt_aom_highbd_10_variance16x32_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance16x64, svt_aom_highbd_10_variance16x64_c, svt_aom_highbd_10_variance16x64_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance32x8, svt_aom_highbd_10_variance32x8_c, svt_aom_highbd_10_variance32x8_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance32x16, svt_aom_highbd_10_variance32x16_c, svt_aom_highbd_10_variance32x16_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance32x32, svt_aom_highbd_10_variance32x32_c, svt_aom_highbd_10_variance32x32_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance32x64, svt_aom_highbd_10_variance32x64_c, svt_aom_highbd_10_variance32x64_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance64x16, svt_aom_highbd_10_variance64x16_c, svt_aom_highbd_10_variance64x16_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance64x32, svt_aom_highbd_10_variance64x32_c, svt_aom_highbd_10_variance64x32_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance64x64, svt_aom_highbd_10_variance64x64_c, svt_aom_highbd_10_variance64x64_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance64x128, svt_aom_highbd_10_variance64x128_c, svt_aom_highbd_10_variance64x128_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance128x64, svt_aom_highbd_10_variance128x64_c, svt_aom_highbd_10_variance128x64_avx2);
+    SET_AVX2(svt_aom_highbd_10_variance128x128, svt_aom_highbd_10_variance128x128_c, svt_aom_highbd_10_variance128x128_avx2);
+
+    //QIQ
+    //transform
+    SET_SSE41(svt_av1_fwd_txfm2d_4x4, svt_av1_transform_two_d_4x4_c, svt_av1_fwd_txfm2d_4x4_sse4_1);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x8, svt_av1_fwd_txfm2d_4x8_c, svt_av1_fwd_txfm2d_4x8_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x16, svt_av1_fwd_txfm2d_4x16_c, svt_av1_fwd_txfm2d_4x16_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x4, svt_av1_fwd_txfm2d_8x4_c, svt_av1_fwd_txfm2d_8x4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x8, svt_av1_transform_two_d_8x8_c, svt_av1_fwd_txfm2d_8x8_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x16, svt_av1_fwd_txfm2d_8x16_c, svt_av1_fwd_txfm2d_8x16_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x32, svt_av1_fwd_txfm2d_8x32_c, svt_av1_fwd_txfm2d_8x32_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x4, svt_av1_fwd_txfm2d_16x4_c, svt_av1_fwd_txfm2d_16x4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x8, svt_av1_fwd_txfm2d_16x8_c, svt_av1_fwd_txfm2d_16x8_avx2);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_16x16, svt_av1_transform_two_d_16x16_c, svt_av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_16x16_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_16x32, svt_av1_fwd_txfm2d_16x32_c, svt_av1_fwd_txfm2d_16x32_avx2, av1_fwd_txfm2d_16x32_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_16x64, svt_av1_fwd_txfm2d_16x64_c, svt_av1_fwd_txfm2d_16x64_avx2, av1_fwd_txfm2d_16x64_avx512);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x8, svt_av1_fwd_txfm2d_32x8_c, svt_av1_fwd_txfm2d_32x8_avx2);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_32x16, svt_av1_fwd_txfm2d_32x16_c, svt_av1_fwd_txfm2d_32x16_avx2, av1_fwd_txfm2d_32x16_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_32x32, svt_av1_transform_two_d_32x32_c, svt_av1_fwd_txfm2d_32x32_avx2, av1_fwd_txfm2d_32x32_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_32x64, svt_av1_fwd_txfm2d_32x64_c, svt_av1_fwd_txfm2d_32x64_avx2, av1_fwd_txfm2d_32x64_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x16, svt_av1_fwd_txfm2d_64x16_c, svt_av1_fwd_txfm2d_64x16_avx2, av1_fwd_txfm2d_64x16_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x32, svt_av1_fwd_txfm2d_64x32_c, svt_av1_fwd_txfm2d_64x32_avx2, av1_fwd_txfm2d_64x32_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x64, svt_av1_transform_two_d_64x64_c, svt_av1_fwd_txfm2d_64x64_avx2, av1_fwd_txfm2d_64x64_avx512);
+    SET_AVX2(svt_handle_transform16x64, svt_handle_transform16x64_c, svt_handle_transform16x64_avx2);
+    SET_AVX2(svt_handle_transform32x64, svt_handle_transform32x64_c, svt_handle_transform32x64_avx2);
+    SET_AVX2(svt_handle_transform64x16, svt_handle_transform64x16_c, svt_handle_transform64x16_avx2);
+    SET_AVX2(svt_handle_transform64x32, svt_handle_transform64x32_c, svt_handle_transform64x32_avx2);
+    SET_AVX2(svt_handle_transform64x64, svt_handle_transform64x64_c, svt_handle_transform64x64_avx2);
 #if FEATURE_PARTIAL_FREQUENCY
-                    if (flags & HAS_AVX2) handle_transform16x64_N2_N4 = handle_transform16x64_N2_N4_avx2;
-                    if (flags & HAS_AVX2) handle_transform32x64_N2_N4 = handle_transform32x64_N2_N4_avx2;
-                    if (flags & HAS_AVX2) handle_transform64x16_N2_N4 = handle_transform64x16_N2_N4_avx2;
-                    if (flags & HAS_AVX2) handle_transform64x32_N2_N4 = handle_transform64x32_N2_N4_avx2;
-                    if (flags & HAS_AVX2) handle_transform64x64_N2_N4 = handle_transform64x64_N2_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x8_N2 = svt_av1_fwd_txfm2d_16x8_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x16_N2 = svt_av1_fwd_txfm2d_8x16_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x4_N2 = svt_av1_fwd_txfm2d_16x4_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x16_N2 = svt_av1_fwd_txfm2d_4x16_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x4_N2 = svt_av1_fwd_txfm2d_8x4_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x8_N2 = svt_av1_fwd_txfm2d_4x8_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x8_N2 = svt_av1_fwd_txfm2d_32x8_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x32_N2 = svt_av1_fwd_txfm2d_8x32_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x64_N2 = svt_av1_fwd_txfm2d_64x64_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x32_N2 = svt_av1_fwd_txfm2d_32x32_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x16_N2 = svt_av1_fwd_txfm2d_16x16_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x64_N2 = svt_av1_fwd_txfm2d_32x64_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x32_N2 = svt_av1_fwd_txfm2d_64x32_N2_avx2;
-#ifndef NON_AVX512_SUPPORT
-                    if (flags & HAS_AVX512F) {
-                        svt_av1_fwd_txfm2d_32x32_N2 = av1_fwd_txfm2d_32x32_N2_avx512;
-                        svt_av1_fwd_txfm2d_32x64_N2 = av1_fwd_txfm2d_32x64_N2_avx512;
-                        svt_av1_fwd_txfm2d_64x32_N2 = av1_fwd_txfm2d_64x32_N2_avx512;
-                        svt_av1_fwd_txfm2d_64x64_N2 = av1_fwd_txfm2d_64x64_N2_avx512;
-                    }
-#endif
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x64_N2 = svt_av1_fwd_txfm2d_16x64_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x16_N2 = svt_av1_fwd_txfm2d_64x16_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x16_N2 = svt_av1_fwd_txfm2d_32x16_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x32_N2 = svt_av1_fwd_txfm2d_16x32_N2_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x8_N2 = svt_av1_fwd_txfm2d_8x8_N2_avx2;
-                    if (flags & HAS_SSE4_1) svt_av1_fwd_txfm2d_4x4_N2 = svt_av1_fwd_txfm2d_4x4_N2_sse4_1;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x8_N4 = svt_av1_fwd_txfm2d_16x8_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x16_N4 = svt_av1_fwd_txfm2d_8x16_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x4_N4 = svt_av1_fwd_txfm2d_16x4_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x16_N4 = svt_av1_fwd_txfm2d_4x16_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x4_N4 = svt_av1_fwd_txfm2d_8x4_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_4x8_N4 = svt_av1_fwd_txfm2d_4x8_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x8_N4 = svt_av1_fwd_txfm2d_32x8_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x32_N4 = svt_av1_fwd_txfm2d_8x32_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x64_N4 = svt_av1_fwd_txfm2d_64x64_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x32_N4 = svt_av1_fwd_txfm2d_32x32_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x16_N4 = svt_av1_fwd_txfm2d_16x16_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x64_N4 = svt_av1_fwd_txfm2d_32x64_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x32_N4 = svt_av1_fwd_txfm2d_64x32_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x64_N4 = svt_av1_fwd_txfm2d_16x64_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_64x16_N4 = svt_av1_fwd_txfm2d_64x16_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_32x16_N4 = svt_av1_fwd_txfm2d_32x16_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_16x32_N4 = svt_av1_fwd_txfm2d_16x32_N4_avx2;
-                    if (flags & HAS_AVX2) svt_av1_fwd_txfm2d_8x8_N4 = svt_av1_fwd_txfm2d_8x8_N4_avx2;
-                    if (flags & HAS_SSE4_1) svt_av1_fwd_txfm2d_4x4_N4 = svt_av1_fwd_txfm2d_4x4_N4_sse4_1;
-#ifndef NON_AVX512_SUPPORT
-                    if (flags & HAS_AVX512F) {
-                        svt_av1_fwd_txfm2d_64x64_N4 = av1_fwd_txfm2d_64x64_N4_avx512;
-                    }
-#endif
-#endif
-                    if (flags & HAS_SSE2) svt_aom_fft4x4_float = svt_aom_fft4x4_float_sse2;
-                    if (flags & HAS_AVX2) svt_aom_fft16x16_float = svt_aom_fft16x16_float_avx2;
-                    if (flags & HAS_AVX2) svt_aom_fft32x32_float = svt_aom_fft32x32_float_avx2;
-                    if (flags & HAS_AVX2) svt_aom_fft8x8_float = svt_aom_fft8x8_float_avx2;
-                    if (flags & HAS_AVX2) svt_aom_ifft16x16_float = svt_aom_ifft16x16_float_avx2;
-                    if (flags & HAS_AVX2) svt_aom_ifft32x32_float = svt_aom_ifft32x32_float_avx2;
-                    if (flags & HAS_AVX2) svt_aom_ifft8x8_float = svt_aom_ifft8x8_float_avx2;
-                    if (flags & HAS_SSE2) svt_aom_ifft4x4_float = svt_aom_ifft4x4_float_sse2;
-                    if (flags & HAS_AVX2) svt_av1_get_gradient_hist = svt_av1_get_gradient_hist_avx2;
-                    SET_AVX2_AVX512(svt_search_one_dual,
-                                    svt_search_one_dual_c,
-                                    svt_search_one_dual_avx2,
-                                    svt_search_one_dual_avx512);
-                    SET_SSE41_AVX2_AVX512(svt_sad_loop_kernel,
-                                          svt_sad_loop_kernel_c,
-                                          svt_sad_loop_kernel_sse4_1_intrin,
-                                          svt_sad_loop_kernel_avx2_intrin,
-                                          svt_sad_loop_kernel_avx512_intrin);
+    SET_AVX2(handle_transform16x64_N2_N4, handle_transform16x64_N2_N4_c, handle_transform16x64_N2_N4_avx2);
+    SET_AVX2(handle_transform32x64_N2_N4, handle_transform32x64_N2_N4_c, handle_transform32x64_N2_N4_avx2);
+    SET_AVX2(handle_transform64x16_N2_N4, handle_transform64x16_N2_N4_c, handle_transform64x16_N2_N4_avx2);
+    SET_AVX2(handle_transform64x32_N2_N4, handle_transform64x32_N2_N4_c, handle_transform64x32_N2_N4_avx2);
+    SET_AVX2(handle_transform64x64_N2_N4, handle_transform64x64_N2_N4_c, handle_transform64x64_N2_N4_avx2);
+    SET_SSE41(svt_av1_fwd_txfm2d_4x4_N2, av1_transform_two_d_4x4_N2_c, svt_av1_fwd_txfm2d_4x4_N2_sse4_1);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x8_N2, svt_av1_fwd_txfm2d_4x8_N2_c, svt_av1_fwd_txfm2d_4x8_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x16_N2, svt_av1_fwd_txfm2d_4x16_N2_c, svt_av1_fwd_txfm2d_4x16_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x4_N2, svt_av1_fwd_txfm2d_8x4_N2_c, svt_av1_fwd_txfm2d_8x4_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x8_N2, av1_transform_two_d_8x8_N2_c, svt_av1_fwd_txfm2d_8x8_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x16_N2, svt_av1_fwd_txfm2d_8x16_N2_c, svt_av1_fwd_txfm2d_8x16_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x32_N2, svt_av1_fwd_txfm2d_8x32_N2_c, svt_av1_fwd_txfm2d_8x32_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x4_N2, svt_av1_fwd_txfm2d_16x4_N2_c, svt_av1_fwd_txfm2d_16x4_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x8_N2, svt_av1_fwd_txfm2d_16x8_N2_c, svt_av1_fwd_txfm2d_16x8_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x16_N2, av1_transform_two_d_16x16_N2_c, svt_av1_fwd_txfm2d_16x16_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x32_N2, svt_av1_fwd_txfm2d_16x32_N2_c, svt_av1_fwd_txfm2d_16x32_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x64_N2, svt_av1_fwd_txfm2d_16x64_N2_c, svt_av1_fwd_txfm2d_16x64_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x8_N2, svt_av1_fwd_txfm2d_32x8_N2_c, svt_av1_fwd_txfm2d_32x8_N2_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x16_N2, svt_av1_fwd_txfm2d_32x16_N2_c, svt_av1_fwd_txfm2d_32x16_N2_avx2);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_32x32_N2, av1_transform_two_d_32x32_N2_c, svt_av1_fwd_txfm2d_32x32_N2_avx2, av1_fwd_txfm2d_32x32_N2_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_32x64_N2, svt_av1_fwd_txfm2d_32x64_N2_c, svt_av1_fwd_txfm2d_32x64_N2_avx2, av1_fwd_txfm2d_32x64_N2_avx512);
+    SET_AVX2(svt_av1_fwd_txfm2d_64x16_N2, svt_av1_fwd_txfm2d_64x16_N2_c, svt_av1_fwd_txfm2d_64x16_N2_avx2);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x32_N2, svt_av1_fwd_txfm2d_64x32_N2_c, svt_av1_fwd_txfm2d_64x32_N2_avx2, av1_fwd_txfm2d_64x32_N2_avx512);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x64_N2, av1_transform_two_d_64x64_N2_c, svt_av1_fwd_txfm2d_64x64_N2_avx2, av1_fwd_txfm2d_64x64_N2_avx512);
+    SET_SSE41(svt_av1_fwd_txfm2d_4x4_N4, av1_transform_two_d_4x4_N4_c, svt_av1_fwd_txfm2d_4x4_N4_sse4_1);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x8_N4, svt_av1_fwd_txfm2d_4x8_N4_c, svt_av1_fwd_txfm2d_4x8_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_4x16_N4, svt_av1_fwd_txfm2d_4x16_N4_c, svt_av1_fwd_txfm2d_4x16_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x4_N4, svt_av1_fwd_txfm2d_8x4_N4_c, svt_av1_fwd_txfm2d_8x4_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x8_N4, av1_transform_two_d_8x8_N4_c, svt_av1_fwd_txfm2d_8x8_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x16_N4, svt_av1_fwd_txfm2d_8x16_N4_c, svt_av1_fwd_txfm2d_8x16_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_8x32_N4, svt_av1_fwd_txfm2d_8x32_N4_c, svt_av1_fwd_txfm2d_8x32_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x4_N4, svt_av1_fwd_txfm2d_16x4_N4_c, svt_av1_fwd_txfm2d_16x4_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x8_N4, svt_av1_fwd_txfm2d_16x8_N4_c, svt_av1_fwd_txfm2d_16x8_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x16_N4, av1_transform_two_d_16x16_N4_c, svt_av1_fwd_txfm2d_16x16_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x32_N4, svt_av1_fwd_txfm2d_16x32_N4_c, svt_av1_fwd_txfm2d_16x32_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_16x64_N4, svt_av1_fwd_txfm2d_16x64_N4_c, svt_av1_fwd_txfm2d_16x64_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x8_N4, svt_av1_fwd_txfm2d_32x8_N4_c, svt_av1_fwd_txfm2d_32x8_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x16_N4, svt_av1_fwd_txfm2d_32x16_N4_c, svt_av1_fwd_txfm2d_32x16_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x32_N4, av1_transform_two_d_32x32_N4_c, svt_av1_fwd_txfm2d_32x32_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_32x64_N4, svt_av1_fwd_txfm2d_32x64_N4_c, svt_av1_fwd_txfm2d_32x64_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_64x16_N4, svt_av1_fwd_txfm2d_64x16_N4_c, svt_av1_fwd_txfm2d_64x16_N4_avx2);
+    SET_AVX2(svt_av1_fwd_txfm2d_64x32_N4, svt_av1_fwd_txfm2d_64x32_N4_c, svt_av1_fwd_txfm2d_64x32_N4_avx2);
+    SET_AVX2_AVX512(svt_av1_fwd_txfm2d_64x64_N4, av1_transform_two_d_64x64_N4_c, svt_av1_fwd_txfm2d_64x64_N4_avx2, av1_fwd_txfm2d_64x64_N4_avx512);
+#endif /*FEATURE_PARTIAL_FREQUENCY*/
+    SET_ONLY_C(svt_aom_fft2x2_float, svt_aom_fft2x2_float_c);
+    SET_SSE2(svt_aom_fft4x4_float, svt_aom_fft4x4_float_c, svt_aom_fft4x4_float_sse2);
+    SET_AVX2(svt_aom_fft16x16_float, svt_aom_fft16x16_float_c, svt_aom_fft16x16_float_avx2);
+    SET_AVX2(svt_aom_fft32x32_float, svt_aom_fft32x32_float_c, svt_aom_fft32x32_float_avx2);
+    SET_AVX2(svt_aom_fft8x8_float, svt_aom_fft8x8_float_c, svt_aom_fft8x8_float_avx2);
+    SET_AVX2(svt_aom_ifft16x16_float, svt_aom_ifft16x16_float_c, svt_aom_ifft16x16_float_avx2);
+    SET_AVX2(svt_aom_ifft32x32_float, svt_aom_ifft32x32_float_c, svt_aom_ifft32x32_float_avx2);
+    SET_AVX2(svt_aom_ifft8x8_float, svt_aom_ifft8x8_float_c, svt_aom_ifft8x8_float_avx2);
+    SET_ONLY_C(svt_aom_ifft2x2_float, svt_aom_ifft2x2_float_c);
+    SET_SSE2(svt_aom_ifft4x4_float, svt_aom_ifft4x4_float_c, svt_aom_ifft4x4_float_sse2);
+    SET_AVX2(svt_av1_get_gradient_hist, svt_av1_get_gradient_hist_c, svt_av1_get_gradient_hist_avx2);
+    SET_SSE2(svt_av1_get_nz_map_contexts, svt_av1_get_nz_map_contexts_c, svt_av1_get_nz_map_contexts_sse2);
+    SET_AVX2_AVX512(svt_search_one_dual, svt_search_one_dual_c, svt_search_one_dual_avx2, svt_search_one_dual_avx512);
+    SET_SSE41_AVX2_AVX512(svt_sad_loop_kernel, svt_sad_loop_kernel_c, svt_sad_loop_kernel_sse4_1_intrin, svt_sad_loop_kernel_avx2_intrin, svt_sad_loop_kernel_avx512_intrin);
 #if !FIX_REMOVE_UNUSED_CODE
-                    SET_SSE41(
-                        svt_av1_apply_filtering, svt_av1_apply_filtering_c, svt_av1_apply_temporal_filter_sse4_1);
+    SET_SSE41(svt_av1_apply_filtering, svt_av1_apply_filtering_c, svt_av1_apply_temporal_filter_sse4_1);
+    SET_SSE41(svt_av1_apply_filtering_highbd, svt_av1_apply_filtering_highbd_c, svt_av1_highbd_apply_temporal_filter_sse4_1);
 #endif
-                    SET_AVX2(svt_av1_apply_temporal_filter_planewise,
-                        svt_av1_apply_temporal_filter_planewise_c,
-                        svt_av1_apply_temporal_filter_planewise_avx2);
-                    SET_AVX2(svt_av1_apply_temporal_filter_planewise_hbd,
-                        svt_av1_apply_temporal_filter_planewise_hbd_c,
-                        svt_av1_apply_temporal_filter_planewise_hbd_avx2);
-#if !FIX_REMOVE_UNUSED_CODE
-                    SET_SSE41(svt_av1_apply_filtering_highbd,
-                        svt_av1_apply_filtering_highbd_c,
-                        svt_av1_highbd_apply_temporal_filter_sse4_1);
-#endif
-                    SET_AVX2(svt_ext_sad_calculation_8x8_16x16,
-                             svt_ext_sad_calculation_8x8_16x16_c,
-                             svt_ext_sad_calculation_8x8_16x16_avx2_intrin);
-                    SET_SSE41(svt_ext_sad_calculation_32x32_64x64,
-                              svt_ext_sad_calculation_32x32_64x64_c,
-                              svt_ext_sad_calculation_32x32_64x64_sse4_intrin);
-                    SET_AVX2(svt_ext_all_sad_calculation_8x8_16x16,
-                             svt_ext_all_sad_calculation_8x8_16x16_c,
-                             svt_ext_all_sad_calculation_8x8_16x16_avx2);
-                    SET_AVX2(svt_ext_eight_sad_calculation_32x32_64x64,
-                             svt_ext_eight_sad_calculation_32x32_64x64_c,
-                             svt_ext_eight_sad_calculation_32x32_64x64_avx2);
-                    SET_SSE2(svt_initialize_buffer_32bits,
-                             svt_initialize_buffer_32bits_c,
-                             svt_initialize_buffer_32bits_sse2_intrin);
-                    SET_AVX2(svt_nxm_sad_kernel_sub_sampled,
-                             svt_nxm_sad_kernel_helper_c,
-                             svt_nxm_sad_kernel_sub_sampled_helper_avx2);
-
-                    SET_AVX2(svt_nxm_sad_kernel, svt_nxm_sad_kernel_helper_c, svt_nxm_sad_kernel_helper_avx2);
-                    SET_SSE2(svt_compute_mean_square_values_8x8,
-                             svt_compute_mean_squared_values_c,
-                             svt_compute_mean_of_squared_values8x8_sse2_intrin);
-                    SET_SSE2(svt_compute_sub_mean_8x8,
-                             svt_compute_sub_mean_8x8_c,
-                             svt_compute_sub_mean8x8_sse2_intrin);
-
-                    SET_SSE2_AVX2(svt_compute_interm_var_four8x8,
-                                  svt_compute_interm_var_four8x8_c,
-                                  svt_compute_interm_var_four8x8_helper_sse2,
-                                  svt_compute_interm_var_four8x8_avx2_intrin);
-                    SET_AVX2(sad_16b_kernel, sad_16b_kernel_c, sad_16bit_kernel_avx2);
-                    SET_AVX2(svt_av1_compute_cross_correlation,
-                        svt_av1_compute_cross_correlation_c,
-                        svt_av1_compute_cross_correlation_avx2);
-                    SET_AVX2(svt_av1_k_means_dim1, av1_k_means_dim1_c, av1_k_means_dim1_avx2);
-                    SET_AVX2(svt_av1_k_means_dim2, av1_k_means_dim2_c, av1_k_means_dim2_avx2);
-                    SET_AVX2(svt_av1_calc_indices_dim1, av1_calc_indices_dim1_c, av1_calc_indices_dim1_avx2);
-                    SET_AVX2(svt_av1_calc_indices_dim2, av1_calc_indices_dim2_c, av1_calc_indices_dim2_avx2);
-                    if (flags & HAS_SSE2) svt_av1_get_nz_map_contexts = svt_av1_get_nz_map_contexts_sse2;
-
-                    SET_AVX2(variance_highbd, variance_highbd_c, variance_highbd_avx2);
-                    SET_AVX2(svt_av1_haar_ac_sad_8x8_uint8_input,
-                             svt_av1_haar_ac_sad_8x8_uint8_input_c,
-                             svt_av1_haar_ac_sad_8x8_uint8_input_avx2);
-#endif
+    SET_AVX2(svt_av1_apply_temporal_filter_planewise, svt_av1_apply_temporal_filter_planewise_c, svt_av1_apply_temporal_filter_planewise_avx2);
+    SET_AVX2(svt_av1_apply_temporal_filter_planewise_hbd, svt_av1_apply_temporal_filter_planewise_hbd_c, svt_av1_apply_temporal_filter_planewise_hbd_avx2);
+    SET_AVX2(svt_ext_sad_calculation_8x8_16x16, svt_ext_sad_calculation_8x8_16x16_c, svt_ext_sad_calculation_8x8_16x16_avx2_intrin);
+    SET_SSE41(svt_ext_sad_calculation_32x32_64x64, svt_ext_sad_calculation_32x32_64x64_c, svt_ext_sad_calculation_32x32_64x64_sse4_intrin);
+    SET_AVX2(svt_ext_all_sad_calculation_8x8_16x16, svt_ext_all_sad_calculation_8x8_16x16_c, svt_ext_all_sad_calculation_8x8_16x16_avx2);
+    SET_AVX2(svt_ext_eight_sad_calculation_32x32_64x64, svt_ext_eight_sad_calculation_32x32_64x64_c, svt_ext_eight_sad_calculation_32x32_64x64_avx2);
+    SET_SSE2(svt_initialize_buffer_32bits, svt_initialize_buffer_32bits_c, svt_initialize_buffer_32bits_sse2_intrin);
+    SET_AVX2(svt_nxm_sad_kernel_sub_sampled, svt_nxm_sad_kernel_helper_c, svt_nxm_sad_kernel_sub_sampled_helper_avx2);
+    SET_AVX2(svt_nxm_sad_kernel, svt_nxm_sad_kernel_helper_c, svt_nxm_sad_kernel_helper_avx2);
+    SET_SSE2(svt_compute_mean_square_values_8x8, svt_compute_mean_squared_values_c, svt_compute_mean_of_squared_values8x8_sse2_intrin);
+    SET_SSE2(svt_compute_sub_mean_8x8, svt_compute_sub_mean_8x8_c, svt_compute_sub_mean8x8_sse2_intrin);
+    SET_SSE2_AVX2(svt_compute_interm_var_four8x8, svt_compute_interm_var_four8x8_c, svt_compute_interm_var_four8x8_helper_sse2, svt_compute_interm_var_four8x8_avx2_intrin);
+    SET_AVX2(sad_16b_kernel, sad_16b_kernel_c, sad_16bit_kernel_avx2);
+    SET_AVX2(svt_av1_compute_cross_correlation, svt_av1_compute_cross_correlation_c, svt_av1_compute_cross_correlation_avx2);
+    SET_AVX2(svt_av1_k_means_dim1, av1_k_means_dim1_c, av1_k_means_dim1_avx2);
+    SET_AVX2(svt_av1_k_means_dim2, av1_k_means_dim2_c, av1_k_means_dim2_avx2);
+    SET_AVX2(svt_av1_calc_indices_dim1, av1_calc_indices_dim1_c, av1_calc_indices_dim1_avx2);
+    SET_AVX2(svt_av1_calc_indices_dim2, av1_calc_indices_dim2_c, av1_calc_indices_dim2_avx2);
+    SET_AVX2(variance_highbd, variance_highbd_c, variance_highbd_avx2);
+    SET_AVX2(svt_av1_haar_ac_sad_8x8_uint8_input, svt_av1_haar_ac_sad_8x8_uint8_input_c, svt_av1_haar_ac_sad_8x8_uint8_input_avx2);
 
 }


### PR DESCRIPTION
# Description
Cleanup set pointers on kernel when initializing codec in files common_dsp_rtcd.c and aom_dsp_rtcd.c
All kernels are set by macros, to be more readable.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@spawlows

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
