### PR TITLE
Sanitizer: Fix part of data race issues(#1308)

### DIFF
--- a/.github/workflows/sanitizers-known-warnings.txt
+++ b/.github/workflows/sanitizers-known-warnings.txt
@@ -3,16 +3,41 @@
 #Known warnings are tracked in issue: #1308
 
 #Race warnings (data races and use-after-free reports):
+#1]
 race:svt_memcpy_small
 race:svt_memcpy_sse
 race:mode_decision_kernel
+#mode_decision_kernel() is run two times with that same pcs_ptr in separated tasks,
+#when: enc_dec_tasks_ptr->input_type is ENCDEC_TASKS_MDC_INPUT or ENCDEC_TASKS_ENCDEC_INPUT.
+#Some calculation are done double on that same memory.
+#Example for one of the warnings is to change in mode_decision_kernel:
+#((EbReferenceObject *)
+#     pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+#    ->average_intensity = pcs_ptr->parent_pcs_ptr->average_intensity[0];
+#to:
+#if (ENCDEC_TASKS_MDC_INPUT == input_type) {
+#    ((EbReferenceObject *)
+#         pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+#        ->average_intensity = pcs_ptr->parent_pcs_ptr->average_intensity[0];
+#}
+
+#2]
 race:picture_decision_kernel
-race:calculate_input_average_intensity
-race:compute_luma_sad_between_center_and_target_frame
-race:compute_block_mean_compute_variance
 race:picture_manager_kernel
+#picture_manager_kernel() use encode_context_ptr: current_input_poc = encode_context_ptr->current_input_poc; after release
+#written in  picture_decision_kernel():encode_context_ptr->current_input_poc = pcs_ptr->picture_number;
+
+#3]
 race:packetization_kernel
+#Not synchronize access to variable:
+#encode_context_ptr->terminating_sequence_flag_received = EB_TRUE;
+#Between: picture_decision_kernel and packetization_kernel
+
+#4]
 race:signal_derivation_pre_analysis_oq
-race:compute_chroma_block_mean
+#dlf_kernel() read scs_ptr->seq_header.enable_restoration
+#cdef_kernel() read scs_ptr->seq_header.cdef_level
+#writed in resource_coordination_kernel():signal_derivation_pre_analysis_oq()
+
 
 #End of file

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2602,20 +2602,6 @@ EbErrorType denoise_estimate_film_grain(SequenceControlSet *     scs_ptr,
 }
 
 /************************************************
- * Set Picture Parameters based on input configuration
- ** Setting Number of regions per resolution
- ** Setting width and height for subpicture and when picture scan type is 1
- ************************************************/
-void set_picture_parameters_for_statistics_gathering(SequenceControlSet *scs_ptr) {
-    scs_ptr->picture_analysis_number_of_regions_per_width =
-        HIGHER_THAN_CLASS_1_REGION_SPLIT_PER_WIDTH;
-    scs_ptr->picture_analysis_number_of_regions_per_height =
-        HIGHER_THAN_CLASS_1_REGION_SPLIT_PER_HEIGHT;
-
-    return;
-}
-
-/************************************************
  * Picture Pre Processing Operations *
  *** A function that groups all of the Pre proceesing
  * operations performed on the input picture
@@ -4028,9 +4014,6 @@ void *picture_analysis_kernel(void *input_ptr) {
                                sizeof(uint8_t) * input_picture_ptr->width);
             }
 
-            // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
-            set_picture_parameters_for_statistics_gathering(scs_ptr);
-
             // Pre processing operations performed on the input picture
             picture_pre_processing_operations(pcs_ptr, scs_ptr, sb_total_count);
             if (input_picture_ptr->color_format >= EB_YUV422) {
@@ -4134,9 +4117,6 @@ void *picture_analysis_kernel(void *input_ptr) {
 
             // Padding for input pictures
             pad_input_pictures(scs_ptr, input_picture_ptr);
-
-            // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
-            set_picture_parameters_for_statistics_gathering(scs_ptr);
 
             // Pre processing operations performed on the input picture
             picture_pre_processing_operations(pcs_ptr, scs_ptr);

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -188,6 +188,15 @@ EbErrorType svt_sequence_control_set_ctor(SequenceControlSet *scs_ptr, EbPtr obj
     scs_ptr->lap_enabled = 0;
 #endif
 
+    // Set the block mean calculation prec
+    scs_ptr->block_mean_calc_prec = BLOCK_MEAN_PREC_SUB;
+
+    // Set Picture Parameters for statistics gathering
+    scs_ptr->picture_analysis_number_of_regions_per_width =
+        HIGHER_THAN_CLASS_1_REGION_SPLIT_PER_WIDTH;
+    scs_ptr->picture_analysis_number_of_regions_per_height =
+        HIGHER_THAN_CLASS_1_REGION_SPLIT_PER_HEIGHT;
+
     return EB_ErrorNone;
 }
 


### PR DESCRIPTION
* process_output_stream_buffer and process_output_stream_buffer
* set_picture_parameters_for_statistics_gathering() move to init loop
* resource_coordination_kernel() set scs_ptr->block_mean_calc_prec move to init loop
* resource_coordination_kernel() set scs_ptr->scd_mode move to begin
* rest_kernel() release pcs_ptr after all reference pointers are used

# Description
Fix part of Sanitizer issues.

# Issue
#1308

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@spawlows 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
