### PR TITLE
Fix a few issues with the stylecheck script

### DIFF
--- a/test/stylecheck.sh
+++ b/test/stylecheck.sh
@@ -8,13 +8,13 @@ if ! type git > /dev/null 2>&1; then
 fi
 
 echo "Checking for tabs" >&2
-git grep -InP --heading "\t" -- . ':!third_party/**/*' && ret=1
+git --no-pager grep -InP --heading "\t" -- . ':!third_party/**/*' && ret=1
 
 echo "Checking for carriage returns" >&2
-git grep -InP --heading "\r" -- . ':!third_party/**/*' && ret=1
+git --no-pager grep -InP --heading "\r" -- . ':!third_party/**/*' && ret=1
 
 echo "Checking for trailing spaces" >&2
-git grep -InP --heading " $" -- . ':!third_party/**/*' ':!*.patch' && ret=1
+git --no-pager grep -InP --heading " $" -- . ':!third_party/**/*' ':!*.patch' && ret=1
 
 echo "Checking EOF for newlines" >&2
 git fetch -q https://gitlab.com/AOMediaCodec/SVT-AV1.git master && FETCH_HEAD=FETCH_HEAD || FETCH_HEAD=master

--- a/test/stylecheck.sh
+++ b/test/stylecheck.sh
@@ -19,6 +19,10 @@ git --no-pager grep -InP --heading " $" -- . ':!third_party/**/*' ':!*.patch' &&
 echo "Checking EOF for newlines" >&2
 git fetch -q https://gitlab.com/AOMediaCodec/SVT-AV1.git master && FETCH_HEAD=FETCH_HEAD || FETCH_HEAD=master
 while read -r file; do
+    if ! test -f "$file"; then
+        echo "Ignoring folder or not found file: '$file'"
+        continue
+    fi
     if test -n "$(tail -c1 "$file")"; then
         echo "No newline at end of $file"
         ret=1

--- a/test/stylecheck.sh
+++ b/test/stylecheck.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if ! type git > /dev/null 2>&1; then
+    echo "ERROR: git not found, can't continue" >&2
+    exit 1
+fi
+
 echo "Checking for tabs" >&2
 git grep -InP --heading "\t" -- . ':!third_party/**/*' && ret=1
 
@@ -10,11 +15,6 @@ git grep -InP --heading "\r" -- . ':!third_party/**/*' && ret=1
 
 echo "Checking for trailing spaces" >&2
 git grep -InP --heading " $" -- . ':!third_party/**/*' ':!*.patch' && ret=1
-
-if ! type git > /dev/null 2>&1; then
-    echo "ERROR: git not found, can't continue" >&2
-    exit 1
-fi
 
 echo "Checking EOF for newlines" >&2
 git fetch -q https://gitlab.com/AOMediaCodec/SVT-AV1.git master && FETCH_HEAD=FETCH_HEAD || FETCH_HEAD=master


### PR DESCRIPTION
# Description
In interactive use (with a tty) git would use a pager for the grep output, causing the script to not work as expected locally.
Additionally the check for git was done after it was used, making it not very useful. For the EOF check, another test condition is added that will prevent a hard failure of the script when git diff would return a path to a folder or empty string.

# Issue

Might help with the failure mentioned at https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/1#note_451236568
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
