### PR TITLE
y4m: support y4m with header sizes up to 4096

### DIFF
--- a/Source/App/EncApp/EbAppInputy4m.h
+++ b/Source/App/EncApp/EbAppInputy4m.h
@@ -18,8 +18,8 @@
 
 int32_t read_y4m_header(EbConfig *cfg);
 
-int32_t read_and_skip_y4m_header(EbConfig *cfg);
+void read_and_skip_y4m_header(FILE *input_file);
 
-int32_t read_y4m_frame_delimiter(EbConfig *cfg);
+void read_y4m_frame_delimiter(FILE *input_file, FILE *error_log_file);
 
 EbBool check_if_y4m(EbConfig *cfg);

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -656,7 +656,8 @@ void read_input_frames(EbConfig *config, uint8_t is_16bit, EbBufferHeaderType *h
 
             header_ptr->n_filled_len = 0;
             /* if input is a y4m file, read next line which contains "FRAME" */
-            if (config->y4m_input == EB_TRUE) read_y4m_frame_delimiter(config);
+            if (config->y4m_input == EB_TRUE)
+                read_y4m_frame_delimiter(config->input_file, config->error_log_file);
             uint64_t luma_read_size = (uint64_t)input_padded_width * input_padded_height
                                       << is_16bit;
             uint8_t *eb_input_ptr = input_ptr->luma;
@@ -680,8 +681,8 @@ void read_input_frames(EbConfig *config, uint8_t is_16bit, EbBufferHeaderType *h
             if (read_size != header_ptr->n_filled_len) {
                 fseek(input_file, 0, SEEK_SET);
                 if (config->y4m_input == EB_TRUE) {
-                    read_and_skip_y4m_header(config);
-                    read_y4m_frame_delimiter(config);
+                    read_and_skip_y4m_header(config->input_file);
+                    read_y4m_frame_delimiter(config->input_file, config->error_log_file);
                 }
                 header_ptr->n_filled_len =
                     (uint32_t)fread(input_ptr->luma, 1, luma_read_size, input_file);


### PR DESCRIPTION
 # Description

increases the max length for 4096 since according to the ["spec"](https://linux.die.net/man/5/yuv4mpeg) the header contains an `unlimited number of TAGGED-FIELDs`

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

Fixes #1580

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
