### PR TITLE
Further stylecheck fixes

### DIFF
--- a/test/stylecheck.sh
+++ b/test/stylecheck.sh
@@ -56,6 +56,6 @@ while read -r i; do
         ret=1
     fi
 done << EOF
-$(git rev-list HEAD ^FETCH_HEAD)
+$(git rev-list HEAD ^$FETCH_HEAD)
 EOF
 exit ${ret:-0}

--- a/test/stylecheck.sh
+++ b/test/stylecheck.sh
@@ -16,8 +16,15 @@ git --no-pager grep -InP --heading "\r" -- . ':!third_party/**/*' && ret=1
 echo "Checking for trailing spaces" >&2
 git --no-pager grep -InP --heading " $" -- . ':!third_party/**/*' ':!*.patch' && ret=1
 
-echo "Checking EOF for newlines" >&2
+
+# Test only "new" commits, that is, commits that are not upstream on
+# the master branch.
 git fetch -q https://gitlab.com/AOMediaCodec/SVT-AV1.git master && FETCH_HEAD=FETCH_HEAD || FETCH_HEAD=master
+if git diff --exit-code HEAD ^$FETCH_HEAD > /dev/null 2>&1; then
+    echo "No differences to upstream  master, skipping further tests"
+    exit 0
+fi
+
 while read -r file; do
     if ! test -f "$file"; then
         echo "Ignoring folder or not found file: '$file'"


### PR DESCRIPTION
# Description
The stylecheck script did some check in the diff against the upstream git master branch.
This would lead to failures when the script actually runs in the CI jobs on git master, as the
diffs would be empty in these cases, which the script was not handling properly.

# Issue
This should fix the Gitlab CI style check failures.
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
