### PR TITLE
build.sh: Fix broken build script

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -260,7 +260,7 @@ parse_options() {
                 ;;
             *) toolchain=$(
                 case ${url%/*} in
-                */*)
+                */*\)
                     [ -n "$prev_pwd" ] && cd "$prev_pwd"
                     cd "${url%/*}"
                     ;;


### PR DESCRIPTION
# Description

Fixes the build script always encountering the following error:

`./Build/linux/build.sh: line 269: syntax error near unexpected token `)'`


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
