### PR TITLE
EbAppConfig: Rewrite find_token to fix assertion

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1624,19 +1624,41 @@ static void parse_config_file(EbConfig *config, char *buffer, int32_t size) {
     return;
 }
 
-/******************************************
-* Find Token
-******************************************/
+/**
+ * @brief Find token and its argument
+ * @param argc      Argument count
+ * @param argv      Argument array
+ * @param token     The token to look for
+ * @param configStr Output buffer to write the argument to or NULL
+ * @return 0 if found, non-zero otherwise
+ *
+ * @note The configStr buffer must be at least
+ *       COMMAND_LINE_MAX_SIZE bytes big.
+ *       The argv must contain an additional NULL
+ *       element to terminate it, so that
+ *       argv[argc] == NULL.
+ */
 static int32_t find_token(int32_t argc, char *const argv[], char const *token, char *configStr) {
-    int32_t return_error = -1;
+    assert(argv[argc] == NULL);
 
-    while ((argc > 0) && (return_error != 0)) {
-        return_error = strcmp(argv[--argc], token);
-        if (return_error == 0 && configStr)
-            strcpy_s(configStr, COMMAND_LINE_MAX_SIZE, argv[argc + 1]);
+    if (argc == 0)
+        return -1;
+
+    for (int32_t i = argc - 1; i >= 0; i--) {
+        if (strcmp(argv[i], token) != 0)
+            continue;
+
+        // The argument matches the token.
+        // If given, try to copy its argument to configStr
+        if (configStr && argv[i + 1] != NULL) {
+            strcpy_s(configStr, COMMAND_LINE_MAX_SIZE, argv[i + 1]);
+        } else if (configStr) {
+            configStr[0] = '\0';
+        }
+
+        return 0;
     }
-
-    return return_error;
+    return -1;
 }
 
 /**********************************


### PR DESCRIPTION
# Description
The way find_token was written would lead to it unconditionally
using the next argument following the token. In cases where the
token is the last argument, this could lead to it passing NULL
to strcpy_s which is invalid, triggering an assertion on Windows
debug builds.

This was not reproducible on other platforms as the replacement
strcpy_s implementations does not seem to follow the Windows
implementation for that and only returns an error for these
cases, which is ignored here.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
