### PR TITLE
pkg-config: Fix SvtAv1Dec library name

### DIFF
--- a/Source/Lib/Decoder/pkg-config.pc.in
+++ b/Source/Lib/Decoder/pkg-config.pc.in
@@ -5,5 +5,5 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 Name: SvtAv1Dec
 Description: SVT (Scalable Video Technology) for AV1 decoder library
 Version: @DEC_VERSION_MAJOR@.@DEC_VERSION_MINOR@.@DEC_VERSION_PATCH@
-Libs: -L${libdir} -lSvtAv1dec @LIBS_PRIVATE@
+Libs: -L${libdir} -lSvtAv1Dec @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION


# Description
The library name to link with had a typo in the `.pc` file template.

# Issue
Fix #1525
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
