### PR TITLE
Fix assert when double call setup_common_rtcd_internal() and setup_rt…

### DIFF
--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -218,7 +218,7 @@ CPU_FLAGS get_cpu_flags_to_use() {
 
 #define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
     do {                                                                                          \
-        if (ptr != 0) {                                                                           \
+        if (check_pointer_was_set && ptr != 0) {                                                                           \
             printf("Error: %s:%i: Pointer \"%s\" is set before!\n", __FILE__, __LINE__, #ptr);    \
             assert(0);                                                                            \
         }                                                                                         \
@@ -230,7 +230,7 @@ CPU_FLAGS get_cpu_flags_to_use() {
         SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     } while (0)
 
-/* Macros SET_* use local variable CPU_FLAGS flags */
+/* Macros SET_* use local variable CPU_FLAGS flags and EbBool check_pointer_was_set */
 #define SET_ONLY_C(ptr, c)                                  SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 #define SET_SSE2(ptr, c, sse2)                              SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
 #define SET_SSE2_AVX2(ptr, c, sse2, avx2)                   SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
@@ -246,6 +246,11 @@ CPU_FLAGS get_cpu_flags_to_use() {
 
 void setup_common_rtcd_internal(CPU_FLAGS flags) {
 #ifdef ARCH_X86_64
+    /* Avoid check that pointer is set double, after first  setup. */
+    static EbBool first_call_setup = EB_TRUE;
+    EbBool check_pointer_was_set = first_call_setup;
+    first_call_setup = EB_FALSE;
+
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */
     flags &= get_cpu_flags_to_use();

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -50,7 +50,7 @@
 
 #define SET_FUNCTIONS(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512)     \
     do {                                                                                          \
-        if (ptr != 0) {                                                                           \
+        if (check_pointer_was_set && ptr != 0) {                                                                           \
             printf("Error: %s:%i: Pointer \"%s\" is set before!\n", __FILE__, __LINE__, #ptr);    \
             assert(0);                                                                            \
         }                                                                                         \
@@ -62,7 +62,7 @@
         SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     } while (0)
 
-/* Macros SET_* use local variable CPU_FLAGS flags */
+/* Macros SET_* use local variable CPU_FLAGS flags and EbBool check_pointer_was_set */
 #define SET_ONLY_C(ptr, c)                                  SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 #define SET_SSE2(ptr, c, sse2)                              SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, 0, 0)
 #define SET_SSE2_AVX2(ptr, c, sse2, avx2)                   SET_FUNCTIONS(ptr, c, 0, 0, sse2, 0, 0, 0, 0, 0, avx2, 0)
@@ -79,6 +79,11 @@
 void setup_rtcd_internal(CPU_FLAGS flags) {
 
 #ifdef ARCH_X86_64
+    /* Avoid check that pointer is set double, after first  setup. */
+    static EbBool first_call_setup = EB_TRUE;
+    EbBool check_pointer_was_set = first_call_setup;
+    first_call_setup = EB_FALSE;
+
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */
     flags &= get_cpu_flags_to_use();


### PR DESCRIPTION
…cd_internal() during initialization

# Description
setup_common_rtcd_internal() and setup_common_rtcd_internal() call multiple times in UT. 
Fix for case when init kernels run multiple times.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
