### PR TITLE
Fix UT Entropy_BitstreamWriter.write_symbol_no_update, value br.allow…

### DIFF
--- a/Source/Lib/Decoder/Codec/EbDecParseFrame.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseFrame.c
@@ -52,19 +52,6 @@ void svt_tile_init(TileInfo *cur_tile_info, FrameHeader *frame_header, int32_t t
     assert(cur_tile_info->mi_col_end > cur_tile_info->mi_col_start);
 }
 
-static int read_is_valid(const uint8_t *start, size_t len, const uint8_t *end) {
-    return len != 0 && len <= (size_t)(end - start);
-}
-
-EbErrorType init_svt_reader(SvtReader *r, const uint8_t *data, const uint8_t *data_end,
-                            const size_t read_size, uint8_t allow_update_cdf) {
-    if (read_is_valid(data, read_size, data_end) && !svt_reader_init(r, data, read_size))
-        r->allow_update_cdf = allow_update_cdf;
-    else
-        return EB_Corrupt_Frame;
-    return EB_ErrorNone;
-}
-
 void clear_above_context(ParseCtxt *parse_ctxt, int mi_col_start, int mi_col_end, int num_threads) {
     SeqHeader *seq_params = parse_ctxt->seq_header;
     int        num_planes = av1_num_planes(&seq_params->color_config);

--- a/Source/Lib/Decoder/Codec/EbDecParseFrame.h
+++ b/Source/Lib/Decoder/Codec/EbDecParseFrame.h
@@ -163,8 +163,18 @@ void parse_super_block(EbDecHandle *dec_handle, ParseCtxt *parse_ctxt, uint32_t 
 void svt_tile_init(TileInfo *cur_tile_info, FrameHeader *frame_header, int32_t tile_row,
                    int32_t tile_col);
 
-EbErrorType init_svt_reader(SvtReader *r, const uint8_t *data, const uint8_t *data_end,
-                            const size_t read_size, uint8_t allow_update_cdf);
+static int read_is_valid(const uint8_t *start, size_t len, const uint8_t *end) {
+    return len != 0 && len <= (size_t)(end - start);
+}
+
+static INLINE EbErrorType init_svt_reader(SvtReader *r, const uint8_t *data, const uint8_t *data_end,
+                            const size_t read_size, uint8_t allow_update_cdf) {
+    if (read_is_valid(data, read_size, data_end) && !svt_reader_init(r, data, read_size))
+        r->allow_update_cdf = allow_update_cdf;
+    else
+        return EB_Corrupt_Frame;
+    return EB_ErrorNone;
+}
 
 EbErrorType start_parse_tile(EbDecHandle *dec_handle_ptr, ParseCtxt *parse_ctxt,
                              TilesInfo *tiles_info, int tile_num, int is_mt);


### PR DESCRIPTION
# Description
There is two kernels: svt_reader_init()  and init_svt_reader().
init_svt_reader() call  svt_reader_init() and set br.allow_update_cdf 
In UT missing br.allow_update_cdf = 0;

# Issue
UT: [  FAILED  ] Entropy_BitstreamWriter.write_symbol_no_update

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@spawlows 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
