### PR TITLE
Restructured First Pass

### DIFF
--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -127,6 +127,7 @@ extern "C" {
 #define TUNE_NEW_PRESETS                             1 // Preset tuning for M0-M7
 #define FIX_VALID_BLOCK_DERIVATION_OPT 1 // Initialize avail_blk_flag to false
 #define FIX_INTERPOLATION_SEARCH 1 // Fix initialization for interpolation search
+#define FIX_IRC_IDX 1 // Fix initial_rate_control_reorder_queue[] index error
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -118,19 +118,10 @@ extern "C" {
 #define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
 #define FIX_FIRST_PASS_HME        1 // Fix the hme/me based reference pruning level for the first pass
 #if 1
-#define FIRST_PASS_RESTRUCTURE 1
-#define LAP_ENABLED_VBR 1
-#define LAP_ENABLED_VBR_BUF 1
-#define LAP_ENABLED_VBR_DEBUG 1
-#define VBR_CODE_UPDATE 1
-#define FIRST_PASS_REF_FIXES 1
-#define LAP_LIMITED_STAT 0
-#define LAP_ENABLED_VBR_TUNE 1
-#define FIRST_PASS_ME_SETTING 1
-#else
-    #define OLD_SETTING_FIX 1
+#define FEATURE_FIRST_PASS_RESTRUCTURE 1 // Restructure the first pass and move it to PD.
+#define FEATURE_LAP_ENABLED_VBR        1 // Support for LAD enabled VBR
+#define TUNE_VBR_CODE_UPDATE           1 // Updated the 2 PASS VBR code based on the lastest aom
 #endif
-
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -117,6 +117,20 @@ extern "C" {
 #define FIX_ALLOW_SB128_2PASS_VBR 1 // To allow SB128x128 for 2pass VBR
 #define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
 #define FIX_FIRST_PASS_HME        1 // Fix the hme/me based reference pruning level for the first pass
+#if 1
+#define FIRST_PASS_RESTRUCTURE 1
+#define LAP_ENABLED_VBR 1
+#define LAP_ENABLED_VBR_BUF 1
+#define LAP_ENABLED_VBR_DEBUG 1
+#define VBR_CODE_UPDATE 1
+#define FIRST_PASS_REF_FIXES 1
+#define LAP_LIMITED_STAT 0
+#define LAP_ENABLED_VBR_TUNE 1
+#define FIRST_PASS_ME_SETTING 1
+#else
+    #define OLD_SETTING_FIX 1
+#endif
+
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -117,11 +117,10 @@ extern "C" {
 #define FIX_ALLOW_SB128_2PASS_VBR 1 // To allow SB128x128 for 2pass VBR
 #define FIX_2PASS_VBR_4L_SUPPORT  1 // Add 2pass VBR 4L support
 #define FIX_FIRST_PASS_HME        1 // Fix the hme/me based reference pruning level for the first pass
-#if 1
+
 #define FEATURE_FIRST_PASS_RESTRUCTURE 1 // Restructure the first pass and move it to PD.
 #define FEATURE_LAP_ENABLED_VBR        1 // Support for LAD enabled VBR
 #define TUNE_VBR_CODE_UPDATE           1 // Updated the 2 PASS VBR code based on the lastest aom
-#endif
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2318,7 +2318,11 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                               (sb_origin_x + blk_geom->origin_x) >> MI_SIZE_LOG2);
         }
 #if FEATURE_RE_ENCODE
-        if (use_input_stat(scs_ptr) &&
+#if LAP_ENABLED_VBR
+        if ((use_input_stat(scs_ptr) || scs_ptr->lap_enabled ) &&
+#else
+        if (use_input_stat(scs_ptr)  &&
+#endif
             blk_it == 0 && sb_origin_x == 0 && blk_geom->origin_x == 0 && sb_origin_y == 0 && blk_geom->origin_y == 0) {
             pcs_ptr->parent_pcs_ptr->pcs_total_rate = 0;
         }
@@ -3211,7 +3215,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                                         context_ptr->blk_geom->has_uv && uv_pass ? COMPONENT_ALL
                                                                                  : COMPONENT_LUMA);
                                 }
-
+#if !FIRST_PASS_RESTRUCTURE
                                 // CBF Tu decision
                                 if (use_output_stat(scs_ptr)) {
                                     context_ptr->md_context
@@ -3228,7 +3232,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                                         count_non_zero_coeffs[2] != 0 ? EB_TRUE : EB_FALSE;
                                 }
                                 else
-
+#endif
                                 av1_encode_txb_calc_cost(context_ptr,
                                                          count_non_zero_coeffs,
                                                          y_tu_full_distortion,

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2318,7 +2318,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                               (sb_origin_x + blk_geom->origin_x) >> MI_SIZE_LOG2);
         }
 #if FEATURE_RE_ENCODE
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         if ((use_input_stat(scs_ptr) || scs_ptr->lap_enabled ) &&
 #else
         if (use_input_stat(scs_ptr)  &&
@@ -3215,7 +3215,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                                         context_ptr->blk_geom->has_uv && uv_pass ? COMPONENT_ALL
                                                                                  : COMPONENT_LUMA);
                                 }
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                                 // CBF Tu decision
                                 if (use_output_stat(scs_ptr)) {
                                     context_ptr->md_context

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -4760,7 +4760,9 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
 
     results_ptr->leaf_count = 0;
     uint32_t blk_index = 0;
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
     int32_t force_blk_size = FORCED_BLK_SIZE;
+#endif
 #if FEATURE_PD0_CUT_DEPTH
     int32_t min_sq_size =
         (context_ptr->depth_refinement_ctrls.enabled && context_ptr->depth_refinement_ctrls.disallow_below_16x16)
@@ -5045,6 +5047,7 @@ void *mode_decision_kernel(void *input_ptr) {
         uint32_t sb_row_index_start = 0, sb_row_index_count = 0;
         context_ptr->tot_intra_coded_area       = 0;
 #if  FEATURE_FIRST_PASS_RESTRUCTURE
+        // Bypass encdec for the first pass
         if (use_output_stat(scs_ptr)) {
 
             svt_release_object(pcs_ptr->parent_pcs_ptr->me_data_wrapper_ptr);
@@ -5053,7 +5056,6 @@ void *mode_decision_kernel(void *input_ptr) {
             svt_get_empty_object(context_ptr->enc_dec_output_fifo_ptr, &enc_dec_results_wrapper_ptr);
             enc_dec_results_ptr = (EncDecResults *)enc_dec_results_wrapper_ptr->object_ptr;
             enc_dec_results_ptr->pcs_wrapper_ptr = enc_dec_tasks_ptr->pcs_wrapper_ptr;
-            //CHKN these are not needed for DLF
             enc_dec_results_ptr->completed_sb_row_index_start = 0;
             enc_dec_results_ptr->completed_sb_row_count =
                 ((pcs_ptr->parent_pcs_ptr->aligned_height + scs_ptr->sb_size_pix - 1) >> sb_size_log2);

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -5034,7 +5034,9 @@ void *mode_decision_kernel(void *input_ptr) {
         context_ptr->tile_group_index = enc_dec_tasks_ptr->tile_group_index;
         context_ptr->coded_sb_count   = 0;
         segments_ptr = pcs_ptr->enc_dec_segment_ctrl[context_ptr->tile_group_index];
+#if  !FEATURE_FIRST_PASS_RESTRUCTURE
         EbBool last_sb_flag           = EB_FALSE;
+#endif
         // SB Constants
         uint8_t sb_sz      = (uint8_t)scs_ptr->sb_size_pix;
         uint8_t sb_size_log2 = (uint8_t)svt_log2f(sb_sz);
@@ -5044,7 +5046,9 @@ void *mode_decision_kernel(void *input_ptr) {
         uint16_t tile_group_width_in_sb = pcs_ptr->parent_pcs_ptr
                                               ->tile_group_info[context_ptr->tile_group_index]
                                               .tile_group_width_in_sb;
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         uint32_t sb_row_index_start = 0, sb_row_index_count = 0;
+#endif
         context_ptr->tot_intra_coded_area       = 0;
 #if  FEATURE_FIRST_PASS_RESTRUCTURE
         // Bypass encdec for the first pass
@@ -5154,7 +5158,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     context_ptr->md_context->tile_index = sb_ptr->tile_info.tile_rs_index;
                     context_ptr->md_context->sb_origin_x = sb_origin_x;
                     context_ptr->md_context->sb_origin_y = sb_origin_y;
-
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     sb_row_index_start =
                         (x_sb_index + 1 == tile_group_width_in_sb && sb_row_index_count == 0)
                             ? y_sb_index
@@ -5162,6 +5166,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     sb_row_index_count = (x_sb_index + 1 == tile_group_width_in_sb)
                                              ? sb_row_index_count + 1
                                              : sb_row_index_count;
+#endif
                     mdc_ptr = context_ptr->md_context->mdc_sb_array;
                     context_ptr->sb_index = sb_index;
                     context_ptr->md_context->sb_class = NONE_CLASS;
@@ -5430,7 +5435,11 @@ void *mode_decision_kernel(void *input_ptr) {
                 pcs_ptr->txt_cnt[depth_delta][txs_idx] += context_ptr->md_context->txt_cnt[depth_delta][txs_idx];
 
         pcs_ptr->enc_dec_coded_sb_count += (uint32_t)context_ptr->coded_sb_count;
+#if FEATURE_FIRST_PASS_RESTRUCTURE
+        EbBool last_sb_flag = (pcs_ptr->sb_total_count_pix == pcs_ptr->enc_dec_coded_sb_count);
+#else
         last_sb_flag = (pcs_ptr->sb_total_count_pix == pcs_ptr->enc_dec_coded_sb_count);
+#endif
         svt_release_mutex(pcs_ptr->intra_mutex);
 
         if (last_sb_flag) {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -3744,7 +3744,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
     return return_error;
 }
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
 /******************************************************
 * Derive EncDec Settings for first pass
 Input   : encoder mode and pd pass
@@ -4769,7 +4769,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
 #endif
     while (blk_index < scs_ptr->max_block_cnt) {
         const BlockGeom *blk_geom = get_blk_geom_mds(blk_index);
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         if (use_output_stat(scs_ptr) && blk_geom->bheight >= FORCED_BLK_SIZE && blk_geom->bwidth >= FORCED_BLK_SIZE) {
             force_blk_size = FORCED_BLK_SIZE;
             if (blk_geom->bheight == FORCED_BLK_SIZE && blk_geom->bwidth == FORCED_BLK_SIZE &&
@@ -4836,7 +4836,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
                     results_ptr->leaf_data_array[results_ptr->leaf_count].tot_d1_blocks = tot_d1_blocks;
 
                     results_ptr->leaf_data_array[results_ptr->leaf_count].final_pred_depth_refinement = 0;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     if (use_output_stat(scs_ptr)) {
                         if (blk_geom->sq_size == force_blk_size)
                             results_ptr->leaf_data_array[results_ptr->leaf_count++].split_flag = EB_FALSE;
@@ -4849,7 +4849,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
                     else
                         results_ptr->leaf_data_array[results_ptr->leaf_count++].split_flag =
                         EB_FALSE;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     }
 #endif
                 }
@@ -4923,7 +4923,7 @@ static void recode_loop_decision_maker(PictureControlSet *pcs_ptr,
         // 2pass QPM with tpl_la
         if (scs_ptr->static_config.enable_adaptive_quantization == 2 &&
             !use_output_stat(scs_ptr) &&
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             (use_input_stat(scs_ptr) || scs_ptr->lap_enabled) &&
 #else
             use_input_stat(scs_ptr) &&
@@ -5044,7 +5044,7 @@ void *mode_decision_kernel(void *input_ptr) {
                                               .tile_group_width_in_sb;
         uint32_t sb_row_index_start = 0, sb_row_index_count = 0;
         context_ptr->tot_intra_coded_area       = 0;
-#if  FIRST_PASS_RESTRUCTURE
+#if  FEATURE_FIRST_PASS_RESTRUCTURE
         if (use_output_stat(scs_ptr)) {
 
             svt_release_object(pcs_ptr->parent_pcs_ptr->me_data_wrapper_ptr);
@@ -5136,7 +5136,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     sb_index = (uint16_t)((y_sb_index + tile_group_y_sb_start) * pic_width_in_sb +
                                           x_sb_index + tile_group_x_sb_start);
 #endif
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     if (use_output_stat(scs_ptr) && sb_index == 0)
                         setup_firstpass_data(pcs_ptr->parent_pcs_ptr);
 #endif
@@ -5346,7 +5346,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     }
                     // [PD_PASS_2] Signal(s) derivation
                     context_ptr->md_context->pd_pass = PD_PASS_2;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     if (use_output_stat(scs_ptr))
                         first_pass_signal_derivation_enc_dec_kernel(pcs_ptr, context_ptr->md_context);
                     else
@@ -5392,7 +5392,7 @@ void *mode_decision_kernel(void *input_ptr) {
                                     context_ptr);
 #else
                     // Encode Pass
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                     if(!use_output_stat(scs_ptr))
 #endif
                     av1_encode_decode(
@@ -5435,7 +5435,7 @@ void *mode_decision_kernel(void *input_ptr) {
 #if FEATURE_RE_ENCODE
             EbBool do_recode = EB_FALSE;
             scs_ptr->encode_context_ptr->recode_loop = scs_ptr->static_config.recode_loop;
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             if ((use_input_stat(scs_ptr) || scs_ptr->lap_enabled) &&
 #else
             if (use_input_stat(scs_ptr) &&
@@ -5505,7 +5505,7 @@ void *mode_decision_kernel(void *input_ptr) {
             pcs_ptr->parent_pcs_ptr->av1x->rdmult =
                 context_ptr->pic_full_lambda[(context_ptr->bit_depth == EB_10BIT) ? EB_10_BIT_MD
                                                                                   : EB_8_BIT_MD];
-#if  !FIRST_PASS_RESTRUCTURE
+#if  !FEATURE_FIRST_PASS_RESTRUCTURE
             if (use_output_stat(scs_ptr)) {
                 first_pass_frame_end(pcs_ptr->parent_pcs_ptr, pcs_ptr->parent_pcs_ptr->ts_duration);
                 if(pcs_ptr->parent_pcs_ptr->end_of_sequence_flag)
@@ -5528,7 +5528,7 @@ void *mode_decision_kernel(void *input_ptr) {
             }
 #endif
         }
-#if  FIRST_PASS_RESTRUCTURE
+#if  FEATURE_FIRST_PASS_RESTRUCTURE
         }
 #endif
         // Release Mode Decision Results

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1516,7 +1516,11 @@ void *initial_rate_control_kernel(void *input_ptr) {
                         PictureParentControlSet* pcs =
                             (PictureParentControlSet*)(encode_context_ptr
                                                            ->initial_rate_control_reorder_queue
+#if FIX_IRC_IDX
+                                                               [queue_entry_index_temp2]
+#else
                                                                [queue_entry_index_temp]
+#endif
                                                                ->parent_pcs_wrapper_ptr)->object_ptr;
                         if (pcs->is_next_frame_intra)
                             break;

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1464,7 +1464,11 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 // Determine offset from the Head Ptr
                 determine_picture_offset_in_queue(
                     encode_context_ptr, pcs_ptr, in_results_ptr);
-#if !FEATURE_LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
+            if (scs_ptr->static_config.rate_control_mode && !use_input_stat(scs_ptr) && !scs_ptr->lap_enabled)
+                    // Getting the Histogram Queue Data
+                    get_histogram_queue_data(scs_ptr, encode_context_ptr, pcs_ptr);
+#else
             if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                 ; //skip 2pass VBR
             else
@@ -1603,7 +1607,14 @@ void *initial_rate_control_kernel(void *input_ptr) {
                             pcs_ptr->end_of_sequence_region = EB_TRUE;
                         else
                             pcs_ptr->end_of_sequence_region = EB_FALSE;
-#if !FEATURE_LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
+                        if (scs_ptr->static_config.rate_control_mode && !use_input_stat(scs_ptr) && !scs_ptr->lap_enabled)
+                            // Determine offset from the Head Ptr for HLRC histogram queue and set the life count
+                            if (scs_ptr->static_config.look_ahead_distance != 0)
+                                // Update Histogram Queue Entry Life count
+                                update_histogram_queue_entry(
+                                    scs_ptr, encode_context_ptr, pcs_ptr, frames_in_sw);
+#else
                         if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                             ; //skip 2pass VBR
                         else

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1464,7 +1464,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 // Determine offset from the Head Ptr
                 determine_picture_offset_in_queue(
                     encode_context_ptr, pcs_ptr, in_results_ptr);
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
             if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                 ; //skip 2pass VBR
             else
@@ -1603,7 +1603,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                             pcs_ptr->end_of_sequence_region = EB_TRUE;
                         else
                             pcs_ptr->end_of_sequence_region = EB_FALSE;
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
                         if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                             ; //skip 2pass VBR
                         else

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1464,7 +1464,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 // Determine offset from the Head Ptr
                 determine_picture_offset_in_queue(
                     encode_context_ptr, pcs_ptr, in_results_ptr);
-
+#if !LAP_ENABLED_VBR
             if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                 ; //skip 2pass VBR
             else
@@ -1472,7 +1472,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 // Getting the Histogram Queue Data
                 get_histogram_queue_data(scs_ptr, encode_context_ptr, pcs_ptr);
             }
-
+#endif
             for (uint8_t temporal_layer_index = 0; temporal_layer_index < EB_MAX_TEMPORAL_LAYERS;
                  temporal_layer_index++)
                 pcs_ptr->frames_in_interval[temporal_layer_index] = 0;
@@ -1603,7 +1603,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                             pcs_ptr->end_of_sequence_region = EB_TRUE;
                         else
                             pcs_ptr->end_of_sequence_region = EB_FALSE;
-
+#if !LAP_ENABLED_VBR
                         if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                             ; //skip 2pass VBR
                         else
@@ -1615,6 +1615,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                     scs_ptr, encode_context_ptr, pcs_ptr, frames_in_sw);
                             }
                         }
+#endif
                         // BACKGROUND ENHANCEMENT Part II
                         if (!pcs_ptr->end_of_sequence_flag &&
                             scs_ptr->static_config.look_ahead_distance != 0) {

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -4474,7 +4474,11 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
     MeSbResults *me_results =
         pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[context_ptr->me_sb_addr];
     EbBool       allow_bipred =
+#if !FIRST_PASS_RESTRUCTURE
         (use_output_stat(scs_ptr) || context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)
+#else
+        (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)
+#endif
         ? EB_FALSE : EB_TRUE;
     uint32_t mi_row = context_ptr->blk_origin_y >> MI_SIZE_LOG2;
     uint32_t mi_col = context_ptr->blk_origin_x >> MI_SIZE_LOG2;

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -4474,7 +4474,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
     MeSbResults *me_results =
         pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[context_ptr->me_sb_addr];
     EbBool       allow_bipred =
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         (use_output_stat(scs_ptr) || context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)
 #else
         (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
@@ -47,6 +47,9 @@ typedef enum EbMeType {
     ME_MCTF = 1,
     ME_TPL = 2,
     ME_OPEN_LOOP = 3
+#if FIRST_PASS_RESTRUCTURE
+    ,ME_FIRST_PASS = 4
+#endif
 } EbMeType;
 #endif
 typedef enum EbMeTierZeroPu {

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationContext.h
@@ -47,7 +47,7 @@ typedef enum EbMeType {
     ME_MCTF = 1,
     ME_TPL = 2,
     ME_OPEN_LOOP = 3
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
     ,ME_FIRST_PASS = 4
 #endif
 } EbMeType;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -1264,35 +1264,35 @@ void *motion_estimation_kernel(void *input_ptr) {
                 }
             }
 #endif
-#if !FEATURE_LAP_ENABLED_VBR
-            // Calculate the ME Distortion and OIS Historgrams
 
-            svt_block_on_mutex(pcs_ptr->rc_distortion_histogram_mutex);
-
-
+#if FEATURE_LAP_ENABLED_VBR
+            if (scs_ptr->static_config.rate_control_mode && !use_input_stat(scs_ptr) && !scs_ptr->lap_enabled) {
+#endif
+                // Calculate the ME Distortion and OIS Historgrams
+                svt_block_on_mutex(pcs_ptr->rc_distortion_histogram_mutex);
 
 #if !FEATURE_INL_ME
-            if (scs_ptr->static_config.rate_control_mode
-                && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
-                ) {
-                if (pcs_ptr->slice_type != I_SLICE) {
-                    for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
-                         ++y_sb_index)
-                        for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
-                             ++x_sb_index) {
+                if (scs_ptr->static_config.rate_control_mode
+                    && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
+                    ) {
+                    if (pcs_ptr->slice_type != I_SLICE) {
+                        for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
+                            ++y_sb_index)
+                            for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
+                                ++x_sb_index) {
                             uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
                             uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
-                            uint32_t sb_width    = (pcs_ptr->aligned_width - sb_origin_x) <
-                                    BLOCK_SIZE_64
+                            uint32_t sb_width = (pcs_ptr->aligned_width - sb_origin_x) <
+                                BLOCK_SIZE_64
                                 ? pcs_ptr->aligned_width - sb_origin_x
                                 : BLOCK_SIZE_64;
                             uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
-                                    BLOCK_SIZE_64
+                                BLOCK_SIZE_64
                                 ? pcs_ptr->aligned_height - sb_origin_y
                                 : BLOCK_SIZE_64;
 
-                            uint32_t sb_index                           = (uint16_t)(x_sb_index +
-                                                           y_sb_index * pic_width_in_sb);
+                            uint32_t sb_index = (uint16_t)(x_sb_index +
+                                y_sb_index * pic_width_in_sb);
                             pcs_ptr->inter_sad_interval_index[sb_index] = 0;
                             pcs_ptr->intra_sad_interval_index[sb_index] = 0;
 
@@ -1321,13 +1321,13 @@ void *motion_estimation_kernel(void *input_ptr) {
                                 uint32_t intra_sad_interval_index =
                                     pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
                                 intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
-                                                                      2);
+                                    2);
                                 if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
                                     uint32_t sad_interval_index_temp = intra_sad_interval_index -
                                         ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
 
                                     intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
-                                                                1) +
+                                        1) +
                                         (sad_interval_index_temp >> 3);
                                 }
                                 if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
@@ -1341,126 +1341,129 @@ void *motion_estimation_kernel(void *input_ptr) {
                                 ++pcs_ptr->full_sb_count;
                             }
                         }
-                } else
-                    for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
-                         ++y_sb_index)
-                        for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
-                             ++x_sb_index) {
-                            uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
-                            uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
-                            uint32_t sb_width    = (pcs_ptr->aligned_width - sb_origin_x) <
-                                    BLOCK_SIZE_64
-                                ? pcs_ptr->aligned_width - sb_origin_x
-                                : BLOCK_SIZE_64;
-                            uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
-                                    BLOCK_SIZE_64
-                                ? pcs_ptr->aligned_height - sb_origin_y
-                                : BLOCK_SIZE_64;
+                    }
+                    else
+                        for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
+                            ++y_sb_index)
+                            for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
+                                ++x_sb_index) {
+                        uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
+                        uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
+                        uint32_t sb_width = (pcs_ptr->aligned_width - sb_origin_x) <
+                            BLOCK_SIZE_64
+                            ? pcs_ptr->aligned_width - sb_origin_x
+                            : BLOCK_SIZE_64;
+                        uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
+                            BLOCK_SIZE_64
+                            ? pcs_ptr->aligned_height - sb_origin_y
+                            : BLOCK_SIZE_64;
 
-                            uint32_t sb_index = (uint16_t)(x_sb_index +
-                                                           y_sb_index * pic_width_in_sb);
+                        uint32_t sb_index = (uint16_t)(x_sb_index +
+                            y_sb_index * pic_width_in_sb);
 
-                            pcs_ptr->inter_sad_interval_index[sb_index] = 0;
-                            pcs_ptr->intra_sad_interval_index[sb_index] = 0;
+                        pcs_ptr->inter_sad_interval_index[sb_index] = 0;
+                        pcs_ptr->intra_sad_interval_index[sb_index] = 0;
 
-                            if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
-                                uint32_t intra_sad_interval_index =
-                                    pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
-                                intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
-                                                                      2);
-                                if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
-                                    uint32_t sad_interval_index_temp = intra_sad_interval_index -
-                                        ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
+                        if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
+                            uint32_t intra_sad_interval_index =
+                                pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
+                            intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
+                                2);
+                            if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
+                                uint32_t sad_interval_index_temp = intra_sad_interval_index -
+                                    ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
 
-                                    intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
-                                                                1) +
-                                        (sad_interval_index_temp >> 3);
-                                }
-                                if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
-                                    intra_sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
-
-                                pcs_ptr->intra_sad_interval_index[sb_index] =
-                                    intra_sad_interval_index;
-
-                                pcs_ptr->ois_distortion_histogram[intra_sad_interval_index]++;
-
-                                ++pcs_ptr->full_sb_count;
+                                intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
+                                    1) +
+                                    (sad_interval_index_temp >> 3);
                             }
+                            if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
+                                intra_sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
+
+                            pcs_ptr->intra_sad_interval_index[sb_index] =
+                                intra_sad_interval_index;
+
+                            pcs_ptr->ois_distortion_histogram[intra_sad_interval_index]++;
+
+                            ++pcs_ptr->full_sb_count;
                         }
-            }
+                    }
+                }
 #else
-            if (scs_ptr->static_config.rate_control_mode
-                && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
-                ) {
+                if (scs_ptr->static_config.rate_control_mode
+                    && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
+                    ) {
                     for (uint32_t y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index;
-                         ++y_sb_index)
+                        ++y_sb_index)
                         for (uint32_t x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index;
-                             ++x_sb_index) {
-                            uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
-                            uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
-                            uint32_t sb_width    = (pcs_ptr->aligned_width - sb_origin_x) <
-                                    BLOCK_SIZE_64
-                                ? pcs_ptr->aligned_width - sb_origin_x
-                                : BLOCK_SIZE_64;
-                            uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
-                                    BLOCK_SIZE_64
-                                ? pcs_ptr->aligned_height - sb_origin_y
-                                : BLOCK_SIZE_64;
+                            ++x_sb_index) {
+                        uint32_t sb_origin_x = x_sb_index * scs_ptr->sb_sz;
+                        uint32_t sb_origin_y = y_sb_index * scs_ptr->sb_sz;
+                        uint32_t sb_width = (pcs_ptr->aligned_width - sb_origin_x) <
+                            BLOCK_SIZE_64
+                            ? pcs_ptr->aligned_width - sb_origin_x
+                            : BLOCK_SIZE_64;
+                        uint32_t sb_height = (pcs_ptr->aligned_height - sb_origin_y) <
+                            BLOCK_SIZE_64
+                            ? pcs_ptr->aligned_height - sb_origin_y
+                            : BLOCK_SIZE_64;
 
-                            uint32_t sb_index = (uint16_t)(x_sb_index +
-                                                           y_sb_index * pic_width_in_sb);
-                            pcs_ptr->inter_sad_interval_index[sb_index] = 0;
-                            pcs_ptr->intra_sad_interval_index[sb_index] = 0;
+                        uint32_t sb_index = (uint16_t)(x_sb_index +
+                            y_sb_index * pic_width_in_sb);
+                        pcs_ptr->inter_sad_interval_index[sb_index] = 0;
+                        pcs_ptr->intra_sad_interval_index[sb_index] = 0;
 
-                            if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
-                                if (pcs_ptr->slice_type != I_SLICE && !scs_ptr->in_loop_me) {
-                                    uint16_t sad_interval_index = (uint16_t)(
-                                            pcs_ptr->rc_me_distortion[sb_index] >>
-                                            (12 - SAD_PRECISION_INTERVAL)); //change 12 to 2*log2(64)
+                        if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
+                            if (pcs_ptr->slice_type != I_SLICE && !scs_ptr->in_loop_me) {
+                                uint16_t sad_interval_index = (uint16_t)(
+                                    pcs_ptr->rc_me_distortion[sb_index] >>
+                                    (12 - SAD_PRECISION_INTERVAL)); //change 12 to 2*log2(64)
 
-                                    sad_interval_index = (uint16_t)(sad_interval_index >> 2);
-                                    if (sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
-                                        uint16_t sad_interval_index_temp = sad_interval_index -
-                                            ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
-
-                                        sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) - 1) +
-                                            (sad_interval_index_temp >> 3);
-                                    }
-                                    if (sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
-                                        sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
-
-                                    pcs_ptr->inter_sad_interval_index[sb_index] = sad_interval_index;
-
-                                    pcs_ptr->me_distortion_histogram[sad_interval_index]++;
-                                }
-
-                                uint32_t intra_sad_interval_index =
-                                    pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
-                                intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
-                                                                      2);
-                                if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
-                                    uint32_t sad_interval_index_temp = intra_sad_interval_index -
+                                sad_interval_index = (uint16_t)(sad_interval_index >> 2);
+                                if (sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
+                                    uint16_t sad_interval_index_temp = sad_interval_index -
                                         ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
 
-                                    intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
-                                                                1) +
+                                    sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) - 1) +
                                         (sad_interval_index_temp >> 3);
                                 }
-                                if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
-                                    intra_sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
+                                if (sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
+                                    sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
 
-                                pcs_ptr->intra_sad_interval_index[sb_index] =
-                                    intra_sad_interval_index;
+                                pcs_ptr->inter_sad_interval_index[sb_index] = sad_interval_index;
 
-                                pcs_ptr->ois_distortion_histogram[intra_sad_interval_index]++;
-
-                                ++pcs_ptr->full_sb_count;
+                                pcs_ptr->me_distortion_histogram[sad_interval_index]++;
                             }
+
+                            uint32_t intra_sad_interval_index =
+                                pcs_ptr->variance[sb_index][ME_TIER_ZERO_PU_64x64] >> 4;
+                            intra_sad_interval_index = (uint16_t)(intra_sad_interval_index >>
+                                2);
+                            if (intra_sad_interval_index > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {
+                                uint32_t sad_interval_index_temp = intra_sad_interval_index -
+                                    ((NUMBER_OF_SAD_INTERVALS >> 1) - 1);
+
+                                intra_sad_interval_index = ((NUMBER_OF_SAD_INTERVALS >> 1) -
+                                    1) +
+                                    (sad_interval_index_temp >> 3);
+                            }
+                            if (intra_sad_interval_index >= NUMBER_OF_SAD_INTERVALS - 1)
+                                intra_sad_interval_index = NUMBER_OF_SAD_INTERVALS - 1;
+
+                            pcs_ptr->intra_sad_interval_index[sb_index] =
+                                intra_sad_interval_index;
+
+                            pcs_ptr->ois_distortion_histogram[intra_sad_interval_index]++;
+
+                            ++pcs_ptr->full_sb_count;
                         }
+                    }
                 }
 #endif
 
-            svt_release_mutex(pcs_ptr->rc_distortion_histogram_mutex);
+                svt_release_mutex(pcs_ptr->rc_distortion_histogram_mutex);
+#if FEATURE_LAP_ENABLED_VBR
+            }
 #endif
 #if FEATURE_FIRST_PASS_RESTRUCTURE
             }

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -32,7 +32,7 @@
 #include "EbPictureDemuxResults.h"
 #include "EbRateControlTasks.h"
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
 #include "firstpass.h"
 #endif
 /* --32x32-
@@ -131,7 +131,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
                 me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 500;
             }
             else {
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                 if (use_output_stat(scs_ptr) || (scs_ptr->lap_enabled && !pcs_ptr->first_pass_done)) {
 #else
                 if (use_output_stat(scs_ptr)) {
@@ -169,7 +169,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
     }
 #endif
     else {
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         if (use_output_stat(scs_ptr) || (scs_ptr->lap_enabled && !pcs_ptr->first_pass_done)) {
 #else
         if (use_output_stat(scs_ptr)) {
@@ -197,7 +197,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
             me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 164;
         }
     if (!pcs_ptr->sc_content_detected)
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         if (use_output_stat(scs_ptr) || (scs_ptr->lap_enabled && !pcs_ptr->first_pass_done)) {
 #else
         if (use_output_stat(scs_ptr)) {
@@ -257,7 +257,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
         me_context_ptr->hme_level2_search_area_in_height_array[1] = 16;
 #endif
     if (!pcs_ptr->sc_content_detected)
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         if (use_output_stat(scs_ptr) || (scs_ptr->lap_enabled && !pcs_ptr->first_pass_done)) {
 #else
         if (use_output_stat(scs_ptr)) {
@@ -562,7 +562,7 @@ EbErrorType signal_tpl_me_kernel(SequenceControlSet *       scs_ptr,
     return return_error;
 };
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
 void open_loop_first_pass(struct PictureParentControlSet *ppcs_ptr,
                                  MotionEstimationContext_t *me_context_ptr, int32_t segment_index);
 
@@ -920,7 +920,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 
         context_ptr->me_context_ptr->me_alt_ref = in_results_ptr->task_type == 1;
 #else
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
         context_ptr->me_context_ptr->me_type =
             in_results_ptr->task_type == 1 ? ME_MCTF :
             in_results_ptr->task_type == 0 ? ME_OPEN_LOOP : ME_FIRST_PASS;
@@ -995,7 +995,7 @@ void *motion_estimation_kernel(void *input_ptr) {
                 y_segment_index, picture_height_in_sb, pcs_ptr->me_segments_row_count);
             uint32_t y_sb_end_index = SEGMENT_END_IDX(
                 y_segment_index, picture_height_in_sb, pcs_ptr->me_segments_row_count);
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
             EbBool skip_me = EB_FALSE;
             if (use_output_stat(scs_ptr))
                 skip_me = EB_TRUE;
@@ -1247,7 +1247,7 @@ void *motion_estimation_kernel(void *input_ptr) {
                     y_sb_start_index,
                     y_sb_end_index);
 #endif
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
             // ZZ SSDs Computation
             // 1 lookahead frame is needed to get valid (0,0) SAD
             if (use_output_stat(scs_ptr) && scs_ptr->static_config.look_ahead_distance != 0) {
@@ -1263,7 +1263,7 @@ void *motion_estimation_kernel(void *input_ptr) {
                 }
             }
 #endif
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
             // Calculate the ME Distortion and OIS Historgrams
 
             svt_block_on_mutex(pcs_ptr->rc_distortion_histogram_mutex);
@@ -1461,7 +1461,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 
             svt_release_mutex(pcs_ptr->rc_distortion_histogram_mutex);
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
             }
 #endif
             // Get Empty Results Object
@@ -1478,7 +1478,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 
             // Post the Full Results Object
             svt_post_full_object(out_results_wrapper_ptr);
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
         } else if (in_results_ptr->task_type == 1) {
 #else
         } else {
@@ -1498,7 +1498,7 @@ void *motion_estimation_kernel(void *input_ptr) {
             // Release the Input Results
             svt_release_object(in_results_wrapper_ptr);
         }
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
         else {
             // ME Kernel Signal(s) derivation
             first_pass_signal_derivation_me_kernel(scs_ptr, pcs_ptr, context_ptr);
@@ -1777,7 +1777,7 @@ void *inloop_me_kernel(void *input_ptr) {
                 skip_me = ppcs_ptr->tpl_me_done;
 #endif
             }
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
             if(use_output_stat(scs_ptr))
                 skip_me = EB_TRUE;
 #endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -999,6 +999,7 @@ void *motion_estimation_kernel(void *input_ptr) {
             EbBool skip_me = EB_FALSE;
             if (use_output_stat(scs_ptr))
                 skip_me = EB_TRUE;
+            // skip me for the first pass. ME is already performed
             if (!skip_me) {
 #endif
             // *** MOTION ESTIMATION CODE ***

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -85,7 +85,7 @@ EbErrorType packetization_context_ctor(EbThreadContext *  thread_context_ptr,
 
     return EB_ErrorNone;
 }
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
 void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
 #if FIX_OPTIMIZE_BUILD_QUANTIZER
     Dequants *const dequants = pcs_ptr->hbd_mode_decision ?
@@ -725,7 +725,7 @@ void *packetization_kernel(void *input_ptr) {
         rate_control_tasks_ptr->task_type       = RC_PACKETIZATION_FEEDBACK_RESULT;
 
         if(use_input_stat(scs_ptr) ||
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             scs_ptr->lap_enabled ||
 #endif
 #if FEATURE_PA_ME
@@ -782,7 +782,7 @@ void *packetization_kernel(void *input_ptr) {
         // Send the number of bytes per frame to RC
         pcs_ptr->parent_pcs_ptr->total_num_bits = output_stream_ptr->n_filled_len << 3;
         queue_entry_ptr->total_num_bits         = pcs_ptr->parent_pcs_ptr->total_num_bits;
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
         // update the rate tables used in RC based on the encoded bits of each sb
         update_rc_rate_tables(pcs_ptr, scs_ptr);
 #endif
@@ -835,7 +835,7 @@ void *packetization_kernel(void *input_ptr) {
         // Post Rate Control Taks
         svt_post_full_object(rate_control_tasks_wrapper_ptr);
         if (use_input_stat(scs_ptr) ||
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             scs_ptr->lap_enabled ||
 #endif
 #if FEATURE_PA_ME

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -85,7 +85,7 @@ EbErrorType packetization_context_ctor(EbThreadContext *  thread_context_ptr,
 
     return EB_ErrorNone;
 }
-
+#if !LAP_ENABLED_VBR
 void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
 #if FIX_OPTIMIZE_BUILD_QUANTIZER
     Dequants *const dequants = pcs_ptr->hbd_mode_decision ?
@@ -328,7 +328,7 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         svt_release_mutex(encode_context_ptr->rate_table_update_mutex);
     }
 }
-
+#endif
 static inline int get_reorder_queue_pos(const EncodeContext *encode_context_ptr, int delta) {
     return (encode_context_ptr->packetization_reorder_queue_head_index + delta) % PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
 }
@@ -725,6 +725,9 @@ void *packetization_kernel(void *input_ptr) {
         rate_control_tasks_ptr->task_type       = RC_PACKETIZATION_FEEDBACK_RESULT;
 
         if(use_input_stat(scs_ptr) ||
+#if LAP_ENABLED_VBR
+            scs_ptr->lap_enabled ||
+#endif
 #if FEATURE_PA_ME
             (scs_ptr->enable_dec_order) ||
 #endif
@@ -779,8 +782,10 @@ void *packetization_kernel(void *input_ptr) {
         // Send the number of bytes per frame to RC
         pcs_ptr->parent_pcs_ptr->total_num_bits = output_stream_ptr->n_filled_len << 3;
         queue_entry_ptr->total_num_bits         = pcs_ptr->parent_pcs_ptr->total_num_bits;
+#if !LAP_ENABLED_VBR
         // update the rate tables used in RC based on the encoded bits of each sb
         update_rc_rate_tables(pcs_ptr, scs_ptr);
+#endif
         queue_entry_ptr->frame_type = frm_hdr->frame_type;
         queue_entry_ptr->poc        = pcs_ptr->picture_number;
         svt_memcpy(&queue_entry_ptr->av1_ref_signal,
@@ -830,6 +835,9 @@ void *packetization_kernel(void *input_ptr) {
         // Post Rate Control Taks
         svt_post_full_object(rate_control_tasks_wrapper_ptr);
         if (use_input_stat(scs_ptr) ||
+#if LAP_ENABLED_VBR
+            scs_ptr->lap_enabled ||
+#endif
 #if FEATURE_PA_ME
             (scs_ptr->enable_dec_order) ||
 #endif

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -85,7 +85,6 @@ EbErrorType packetization_context_ctor(EbThreadContext *  thread_context_ptr,
 
     return EB_ErrorNone;
 }
-#if !FEATURE_LAP_ENABLED_VBR
 void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
 #if FIX_OPTIMIZE_BUILD_QUANTIZER
     Dequants *const dequants = pcs_ptr->hbd_mode_decision ?
@@ -328,7 +327,6 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         svt_release_mutex(encode_context_ptr->rate_table_update_mutex);
     }
 }
-#endif
 static inline int get_reorder_queue_pos(const EncodeContext *encode_context_ptr, int delta) {
     return (encode_context_ptr->packetization_reorder_queue_head_index + delta) % PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
 }
@@ -782,10 +780,11 @@ void *packetization_kernel(void *input_ptr) {
         // Send the number of bytes per frame to RC
         pcs_ptr->parent_pcs_ptr->total_num_bits = output_stream_ptr->n_filled_len << 3;
         queue_entry_ptr->total_num_bits         = pcs_ptr->parent_pcs_ptr->total_num_bits;
-#if !FEATURE_LAP_ENABLED_VBR
-        // update the rate tables used in RC based on the encoded bits of each sb
-        update_rc_rate_tables(pcs_ptr, scs_ptr);
+#if FEATURE_LAP_ENABLED_VBR
+        if (scs_ptr->static_config.rate_control_mode && !use_input_stat(scs_ptr) && !scs_ptr->lap_enabled)
 #endif
+            // update the rate tables used in RC based on the encoded bits of each sb
+            update_rc_rate_tables(pcs_ptr, scs_ptr);
         queue_entry_ptr->frame_type = frm_hdr->frame_type;
         queue_entry_ptr->poc        = pcs_ptr->picture_number;
         svt_memcpy(&queue_entry_ptr->av1_ref_signal,

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -4233,6 +4233,16 @@ void *picture_analysis_kernel(void *input_ptr) {
                             (EbPictureBufferDesc *)pa_ref_obj_->quarter_filtered_picture_ptr,
                             (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_filtered_picture_ptr);
                 }
+#if FIRST_PASS_REF_FIXES
+                if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+                    pcs_ptr->ds_pics.quarter_picture_ptr = pa_ref_obj_->quarter_filtered_picture_ptr;
+                    pcs_ptr->ds_pics.sixteenth_picture_ptr = pa_ref_obj_->sixteenth_filtered_picture_ptr;
+                }
+                else {
+                    pcs_ptr->ds_pics.quarter_picture_ptr = pa_ref_obj_->quarter_decimated_picture_ptr;
+                    pcs_ptr->ds_pics.sixteenth_picture_ptr = pa_ref_obj_->sixteenth_decimated_picture_ptr;
+                }
+#endif
                 // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
                 gathering_picture_statistics(
                         scs_ptr,

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -4233,7 +4233,7 @@ void *picture_analysis_kernel(void *input_ptr) {
                             (EbPictureBufferDesc *)pa_ref_obj_->quarter_filtered_picture_ptr,
                             (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_filtered_picture_ptr);
                 }
-#if FIRST_PASS_REF_FIXES
+#if FEATURE_FIRST_PASS_RESTRUCTURE
                 if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
                     pcs_ptr->ds_pics.quarter_picture_ptr = pa_ref_obj_->quarter_filtered_picture_ptr;
                     pcs_ptr->ds_pics.sixteenth_picture_ptr = pa_ref_obj_->sixteenth_filtered_picture_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1201,7 +1201,7 @@ static void picture_parent_control_set_dctor(EbPtr ptr) {
   //  EB_DESTROY_SEMAPHORE(obj->pame_done_semaphore);
     EB_DESTROY_MUTEX(obj->pame_done.mutex);
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
     EB_DESTROY_SEMAPHORE(obj->first_pass_done_semaphore);
     EB_DESTROY_MUTEX(obj->first_pass_mutex);
 #endif
@@ -1346,7 +1346,7 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
 #if FEATURE_PA_ME
     EB_CREATE_MUTEX(object_ptr->pame_done.mutex);
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
     EB_CREATE_SEMAPHORE(object_ptr->first_pass_done_semaphore, 0, 1);
     EB_CREATE_MUTEX(object_ptr->first_pass_mutex);
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1201,6 +1201,10 @@ static void picture_parent_control_set_dctor(EbPtr ptr) {
   //  EB_DESTROY_SEMAPHORE(obj->pame_done_semaphore);
     EB_DESTROY_MUTEX(obj->pame_done.mutex);
 #endif
+#if FIRST_PASS_RESTRUCTURE
+    EB_DESTROY_SEMAPHORE(obj->first_pass_done_semaphore);
+    EB_DESTROY_MUTEX(obj->first_pass_mutex);
+#endif
     if(obj->frame_superres_enabled){
         svt_pcs_sb_structs_dctor(obj);
         EB_DELETE(obj->enhanced_picture_ptr);
@@ -1341,6 +1345,10 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
 
 #if FEATURE_PA_ME
     EB_CREATE_MUTEX(object_ptr->pame_done.mutex);
+#endif
+#if FIRST_PASS_RESTRUCTURE
+    EB_CREATE_SEMAPHORE(object_ptr->first_pass_done_semaphore, 0, 1);
+    EB_CREATE_MUTEX(object_ptr->first_pass_mutex);
 #endif
     object_ptr->av1_cm->interp_filter = SWITCHABLE;
 

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -978,6 +978,17 @@ typedef struct PictureParentControlSet {
     int low_cr_seen;
     uint64_t pcs_total_rate;
 #endif
+#if FIRST_PASS_RESTRUCTURE
+    int16_t     first_pass_seg_total_count;
+    uint8_t     first_pass_seg_column_count;
+    uint8_t     first_pass_seg_row_count;
+    uint16_t    first_pass_seg_acc;
+    EbHandle    first_pass_done_semaphore;
+    EbHandle    first_pass_mutex;
+    struct PictureParentControlSet *first_pass_ref_ppcs_ptr[2];
+    uint8_t     first_pass_ref_count;
+    uint8_t     first_pass_done;
+#endif
 } PictureParentControlSet;
 
 typedef struct PictureControlSetInitData {

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -978,7 +978,7 @@ typedef struct PictureParentControlSet {
     int low_cr_seen;
     uint64_t pcs_total_rate;
 #endif
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
     int16_t     first_pass_seg_total_count;
     uint8_t     first_pass_seg_column_count;
     uint8_t     first_pass_seg_row_count;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -4010,7 +4010,6 @@ void process_first_pass_frame(
     pcs_ptr->first_pass_seg_total_count = (uint16_t)(pcs_ptr->first_pass_seg_column_count  * pcs_ptr->first_pass_seg_row_count);
     pcs_ptr->first_pass_seg_acc = 0;
     first_pass_signal_derivation_multi_processes(scs_ptr, pcs_ptr, context_ptr);
-    // anaghdin: do we always need this if single thread is used?
     if (pcs_ptr->me_data_wrapper_ptr == NULL) {
         EbObjectWrapper               *me_wrapper;
         svt_get_empty_object(context_ptr->me_fifo_ptr, &me_wrapper);
@@ -5009,9 +5008,11 @@ void* picture_decision_kernel(void *input_ptr)
                             first_pass_pcs_ptr->first_pass_done = 1;
 #endif
                             int32_t temp_entry_index = QUEUE_GET_PREVIOUS_SPOT(entry_index);
-                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[0] = first_pass_queue_entry->picture_number > 0 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
+                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[0] = first_pass_queue_entry->picture_number > 0 ?
+                                (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
                             temp_entry_index = QUEUE_GET_PREVIOUS_SPOT(temp_entry_index);
-                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[1] = first_pass_queue_entry->picture_number > 1 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
+                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[1] = first_pass_queue_entry->picture_number > 1 ?
+                                (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
                             first_pass_pcs_ptr->first_pass_ref_count = first_pass_queue_entry->picture_number > 1 ? 2 : first_pass_queue_entry->picture_number > 0 ? 1 : 0;
 
                             process_first_pass_frame(scs_ptr, first_pass_pcs_ptr, context_ptr);
@@ -5022,7 +5023,6 @@ void* picture_decision_kernel(void *input_ptr)
                     }
                 }
             }
-
 #endif
 
 #if FEATURE_NEW_DELAY

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -4000,8 +4000,6 @@ EbBool is_delayed_intra(PictureParentControlSet *pcs) {
 */
 void process_first_pass_frame(
     SequenceControlSet      *scs_ptr, PictureParentControlSet *pcs_ptr, PictureDecisionContext  *context_ptr) {
-
-     // Start Filtering in ME processes
     int16_t seg_idx;
 
     // Initialize Segments
@@ -4021,7 +4019,6 @@ void process_first_pass_frame(
 
         EbObjectWrapper               *out_results_wrapper_ptr;
         PictureDecisionResults        *out_results_ptr;
-
         svt_get_empty_object(
             context_ptr->picture_decision_results_output_fifo_ptr,
             &out_results_wrapper_ptr);
@@ -4033,12 +4030,10 @@ void process_first_pass_frame(
     }
 
     svt_block_on_semaphore(pcs_ptr->first_pass_done_semaphore);
-
     svt_release_object(pcs_ptr->me_data_wrapper_ptr);
     pcs_ptr->me_data_wrapper_ptr = (EbObjectWrapper *)NULL;
 }
 #endif
-
 /*
   Performs Motion Compensated Temporal Filtering in ME process
 */

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -32,7 +32,6 @@
 #include "common_dsp_rtcd.h"
 #include "EbResize.h"
 #include "EbMalloc.h"
-
 /************************************************
  * Defines
  ************************************************/
@@ -3995,6 +3994,51 @@ EbBool is_delayed_intra(PictureParentControlSet *pcs) {
     else
         return 0;
 }
+#if FIRST_PASS_RESTRUCTURE
+/*
+  Performs first pass in ME process
+*/
+void process_first_pass_frame(
+    SequenceControlSet      *scs_ptr, PictureParentControlSet *pcs_ptr, PictureDecisionContext  *context_ptr) {
+
+     // Start Filtering in ME processes
+    int16_t seg_idx;
+
+    // Initialize Segments
+    pcs_ptr->first_pass_seg_column_count = (uint8_t)(scs_ptr->me_segment_column_count_array[0]);
+    pcs_ptr->first_pass_seg_row_count = (uint8_t)(scs_ptr->me_segment_row_count_array[0]);
+    pcs_ptr->first_pass_seg_total_count = (uint16_t)(pcs_ptr->first_pass_seg_column_count  * pcs_ptr->first_pass_seg_row_count);
+    pcs_ptr->first_pass_seg_acc = 0;
+    first_pass_signal_derivation_multi_processes(scs_ptr, pcs_ptr, context_ptr);
+    // anaghdin: do we always need this if single thread is used?
+    if (pcs_ptr->me_data_wrapper_ptr == NULL) {
+        EbObjectWrapper               *me_wrapper;
+        svt_get_empty_object(context_ptr->me_fifo_ptr, &me_wrapper);
+        pcs_ptr->me_data_wrapper_ptr = me_wrapper;
+        pcs_ptr->pa_me_data = (MotionEstimationData *)me_wrapper->object_ptr;
+    }
+
+    for (seg_idx = 0; seg_idx < pcs_ptr->first_pass_seg_total_count; ++seg_idx) {
+
+        EbObjectWrapper               *out_results_wrapper_ptr;
+        PictureDecisionResults        *out_results_ptr;
+
+        svt_get_empty_object(
+            context_ptr->picture_decision_results_output_fifo_ptr,
+            &out_results_wrapper_ptr);
+        out_results_ptr = (PictureDecisionResults*)out_results_wrapper_ptr->object_ptr;
+        out_results_ptr->pcs_wrapper_ptr = pcs_ptr->p_pcs_wrapper_ptr;
+        out_results_ptr->segment_index = seg_idx;
+        out_results_ptr->task_type = 2;
+        svt_post_full_object(out_results_wrapper_ptr);
+    }
+
+    svt_block_on_semaphore(pcs_ptr->first_pass_done_semaphore);
+
+    svt_release_object(pcs_ptr->me_data_wrapper_ptr);
+    pcs_ptr->me_data_wrapper_ptr = (EbObjectWrapper *)NULL;
+}
+#endif
 
 /*
   Performs Motion Compensated Temporal Filtering in ME process
@@ -4928,6 +4972,9 @@ void* picture_decision_kernel(void *input_ptr)
             }
 
             pcs_ptr->pic_decision_reorder_queue_idx = queue_entry_index;
+#if FIRST_PASS_RESTRUCTURE
+            pcs_ptr->first_pass_done = 0;
+#endif
         }
         // Process the head of the Picture Decision Reordering Queue (Entry N)
         // P.S. The Picture Decision Reordering Queue should be parsed in the display order to be able to construct a pred structure
@@ -4941,6 +4988,46 @@ void* picture_decision_kernel(void *input_ptr)
                 frame_passthrough = EB_FALSE;
             window_avail = EB_TRUE;
             previous_entry_index = QUEUE_GET_PREVIOUS_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index);
+
+#if FIRST_PASS_RESTRUCTURE
+#if LAP_ENABLED_VBR
+            if (use_output_stat(scs_ptr) || scs_ptr->lap_enabled) {
+#else
+            if (use_output_stat(scs_ptr)) {
+#endif
+                for (window_index = 0; window_index < scs_ptr->scd_delay; window_index++) {
+                    entry_index = QUEUE_GET_NEXT_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index, window_index);
+                    PictureDecisionReorderEntry   *first_pass_queue_entry = encode_context_ptr->picture_decision_reorder_queue[entry_index];
+                    if (first_pass_queue_entry->parent_pcs_wrapper_ptr == NULL) {
+                        break;
+                    }
+                    else {
+
+                        PictureParentControlSet *first_pass_pcs_ptr = (PictureParentControlSet*)first_pass_queue_entry->parent_pcs_wrapper_ptr->object_ptr;
+                        if (!first_pass_pcs_ptr->first_pass_done) {
+#if 0//LAP_ENABLED_VBR_DEBUG
+                            SVT_LOG("First Pass: POC:%lld\n", first_pass_queue_entry->picture_number);
+#endif
+#if !LAP_ENABLED_VBR
+                            first_pass_pcs_ptr->first_pass_done = 1;
+#endif
+                            int32_t temp_entry_index = QUEUE_GET_PREVIOUS_SPOT(entry_index);
+                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[0] = first_pass_queue_entry->picture_number > 0 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
+                            temp_entry_index = QUEUE_GET_PREVIOUS_SPOT(temp_entry_index);
+                            first_pass_pcs_ptr->first_pass_ref_ppcs_ptr[1] = first_pass_queue_entry->picture_number > 1 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[temp_entry_index]->parent_pcs_wrapper_ptr->object_ptr : NULL;
+                            first_pass_pcs_ptr->first_pass_ref_count = first_pass_queue_entry->picture_number > 1 ? 2 : first_pass_queue_entry->picture_number > 0 ? 1 : 0;
+
+                            process_first_pass_frame(scs_ptr, first_pass_pcs_ptr, context_ptr);
+#if LAP_ENABLED_VBR
+                            first_pass_pcs_ptr->first_pass_done = 1;
+#endif
+                        }
+                    }
+                }
+            }
+
+#endif
+
 #if FEATURE_NEW_DELAY
             pcs_ptr = (PictureParentControlSet*)queue_entry_ptr->parent_pcs_wrapper_ptr->object_ptr;
             memset(pcs_ptr->pd_window, 0, PD_WINDOW_SIZE * sizeof(PictureParentControlSet*));

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3994,7 +3994,7 @@ EbBool is_delayed_intra(PictureParentControlSet *pcs) {
     else
         return 0;
 }
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
 /*
   Performs first pass in ME process
 */
@@ -4972,7 +4972,7 @@ void* picture_decision_kernel(void *input_ptr)
             }
 
             pcs_ptr->pic_decision_reorder_queue_idx = queue_entry_index;
-#if FIRST_PASS_RESTRUCTURE
+#if FEATURE_FIRST_PASS_RESTRUCTURE
             pcs_ptr->first_pass_done = 0;
 #endif
         }
@@ -4989,8 +4989,8 @@ void* picture_decision_kernel(void *input_ptr)
             window_avail = EB_TRUE;
             previous_entry_index = QUEUE_GET_PREVIOUS_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index);
 
-#if FIRST_PASS_RESTRUCTURE
-#if LAP_ENABLED_VBR
+#if FEATURE_FIRST_PASS_RESTRUCTURE
+#if FEATURE_LAP_ENABLED_VBR
             if (use_output_stat(scs_ptr) || scs_ptr->lap_enabled) {
 #else
             if (use_output_stat(scs_ptr)) {
@@ -5005,10 +5005,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                         PictureParentControlSet *first_pass_pcs_ptr = (PictureParentControlSet*)first_pass_queue_entry->parent_pcs_wrapper_ptr->object_ptr;
                         if (!first_pass_pcs_ptr->first_pass_done) {
-#if 0//LAP_ENABLED_VBR_DEBUG
-                            SVT_LOG("First Pass: POC:%lld\n", first_pass_queue_entry->picture_number);
-#endif
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
                             first_pass_pcs_ptr->first_pass_done = 1;
 #endif
                             int32_t temp_entry_index = QUEUE_GET_PREVIOUS_SPOT(entry_index);
@@ -5018,7 +5015,7 @@ void* picture_decision_kernel(void *input_ptr)
                             first_pass_pcs_ptr->first_pass_ref_count = first_pass_queue_entry->picture_number > 1 ? 2 : first_pass_queue_entry->picture_number > 0 ? 1 : 0;
 
                             process_first_pass_frame(scs_ptr, first_pass_pcs_ptr, context_ptr);
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                             first_pass_pcs_ptr->first_pass_done = 1;
 #endif
                         }

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -1008,7 +1008,11 @@ void *picture_manager_kernel(void *input_ptr) {
                     availability_flag = EB_TRUE;
                     if (entry_pcs_ptr->decode_order != decode_order &&
 #if FEATURE_PA_ME
+#if LAP_ENABLED_VBR
+                    ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr) ||scs_ptr->lap_enabled))
+#else
                         ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr)))
+#endif
 #else
                         use_input_stat(scs_ptr))
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -1009,7 +1009,7 @@ void *picture_manager_kernel(void *input_ptr) {
                     if (entry_pcs_ptr->decode_order != decode_order &&
 #if FEATURE_PA_ME
 #if FEATURE_LAP_ENABLED_VBR
-                    ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr) ||scs_ptr->lap_enabled))
+                    (scs_ptr->enable_dec_order || use_input_stat(scs_ptr) || scs_ptr->lap_enabled ))
 #else
                         ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr)))
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -1008,7 +1008,7 @@ void *picture_manager_kernel(void *input_ptr) {
                     availability_flag = EB_TRUE;
                     if (entry_pcs_ptr->decode_order != decode_order &&
 #if FEATURE_PA_ME
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                     ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr) ||scs_ptr->lap_enabled))
 #else
                         ((scs_ptr->enable_dec_order) || use_input_stat(scs_ptr)))

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5250,7 +5250,7 @@ void tx_type_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr
         }
 
         //LUMA-ONLY
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         if (use_output_stat(scs_ptr))
             y_txb_coeff_bits_txt[tx_type] = 0;
         else
@@ -8906,7 +8906,7 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
 
     context_ptr->md_local_blk_unit[blk_ptr->mds_idx].avail_blk_flag = EB_TRUE;
 }
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
  void first_pass_md_encode_block(PictureControlSet *pcs_ptr,
     ModeDecisionContext *context_ptr, EbPictureBufferDesc *input_picture_ptr,
     ModeDecisionCandidateBuffer *bestcandidate_buffers[5]);
@@ -9263,7 +9263,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
     uint32_t             d1_block_itr      = 0;
     uint32_t             d1_first_block    = 1;
     EbPictureBufferDesc *input_picture_ptr = pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#if FIX_10BIT && !FIRST_PASS_RESTRUCTURE
+#if FIX_10BIT && !FEATURE_FIRST_PASS_RESTRUCTURE
     if (context_ptr->hbd_mode_decision || (use_output_stat(scs_ptr) && pcs_ptr->parent_pcs_ptr->scs_ptr->encoder_bit_depth > EB_8BIT)) {
 #else
     if (context_ptr->hbd_mode_decision) {
@@ -9440,7 +9440,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 
         uint8_t  redundant_blk_avail = 0;
         uint16_t redundant_blk_mds;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         if (!use_output_stat(scs_ptr))
 #endif
         {
@@ -9608,7 +9608,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                 !zero_sq_coeff_skip_action &&
                 !skip_next_depth &&
                 !skip_nsq) {
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
                 if (use_output_stat(scs_ptr))
                     first_pass_md_encode_block(pcs_ptr,
                         context_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4926,10 +4926,10 @@ void tx_type_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr
     EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision
         ? pcs_ptr->input_frame16bit
         : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
     SequenceControlSet *scs_ptr;
     scs_ptr = (SequenceControlSet*)pcs_ptr->scs_wrapper_ptr->object_ptr;
-
+#endif
     int32_t seg_qp = pcs_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled
         ? pcs_ptr->parent_pcs_ptr->frm_hdr.segmentation_params
               .feature_data[context_ptr->blk_ptr->segment_id][SEG_LVL_ALT_Q]

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5250,9 +5250,11 @@ void tx_type_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr
         }
 
         //LUMA-ONLY
+#if !FIRST_PASS_RESTRUCTURE
         if (use_output_stat(scs_ptr))
             y_txb_coeff_bits_txt[tx_type] = 0;
         else
+#endif
         av1_txb_estimate_coeff_bits(
             context_ptr,
             0, //allow_update_cdf,
@@ -8904,10 +8906,11 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
 
     context_ptr->md_local_blk_unit[blk_ptr->mds_idx].avail_blk_flag = EB_TRUE;
 }
-
+#if !FIRST_PASS_RESTRUCTURE
  void first_pass_md_encode_block(PictureControlSet *pcs_ptr,
     ModeDecisionContext *context_ptr, EbPictureBufferDesc *input_picture_ptr,
     ModeDecisionCandidateBuffer *bestcandidate_buffers[5]);
+#endif
 /*
  * Determine if the evaluation of nsq blocks (HA, HB, VA, VB, H4, V4) can be skipped
  * based on the relative cost of the SQ, H, and V blocks.  The scaling factor sq_weight
@@ -9260,7 +9263,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
     uint32_t             d1_block_itr      = 0;
     uint32_t             d1_first_block    = 1;
     EbPictureBufferDesc *input_picture_ptr = pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#if FIX_10BIT
+#if FIX_10BIT && !FIRST_PASS_RESTRUCTURE
     if (context_ptr->hbd_mode_decision || (use_output_stat(scs_ptr) && pcs_ptr->parent_pcs_ptr->scs_ptr->encoder_bit_depth > EB_8BIT)) {
 #else
     if (context_ptr->hbd_mode_decision) {
@@ -9437,7 +9440,10 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 
         uint8_t  redundant_blk_avail = 0;
         uint16_t redundant_blk_mds;
-        if (!use_output_stat(scs_ptr)) {
+#if !FIRST_PASS_RESTRUCTURE
+        if (!use_output_stat(scs_ptr))
+#endif
+        {
         // Reset settings, in case they were over-written by previous block
 #if FEATURE_REMOVE_CIRCULAR
             signal_derivation_enc_dec_kernel_oq(scs_ptr, pcs_ptr, context_ptr);
@@ -9602,12 +9608,14 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                 !zero_sq_coeff_skip_action &&
                 !skip_next_depth &&
                 !skip_nsq) {
+#if !FIRST_PASS_RESTRUCTURE
                 if (use_output_stat(scs_ptr))
                     first_pass_md_encode_block(pcs_ptr,
                         context_ptr,
                         input_picture_ptr,
                         bestcandidate_buffers);
                 else
+#endif
                 md_encode_block(pcs_ptr, context_ptr, input_picture_ptr, bestcandidate_buffers);
             } else if (sq_weight_based_nsq_skip || skip_next_depth || zero_sq_coeff_skip_action) {
                 if (context_ptr->blk_geom->shape != PART_N)

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -7196,7 +7196,7 @@ static int rc_pick_q_and_bounds(PictureControlSet *pcs_ptr) {
             rc->this_frame_target);
 
         //printf("\n After poc%d boost=%d, q=%d, bottom_index=%d top_index=%d, base_frame_target=%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, q, active_best_quality, active_worst_quality, rc->this_frame_target);
-#endif 
+#endif
     //  printf("\nrc_pick_q_and_bounds return poc%d boost=%d, q=%d, bottom_index=%d top_index=%d, isintra=%d base_frame_target=%d, buffer_level=%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, q, active_best_quality, active_worst_quality, frame_is_intra_only(pcs_ptr->parent_pcs_ptr), rc->base_frame_target, rc->buffer_level);
 
     return q;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -8336,8 +8336,6 @@ void *rate_control_kernel(void *input_ptr) {
                         ? context_ptr->rate_control_param_queue[PARALLEL_GOP_MAX_NUMBER - 1]
                         : context_ptr->rate_control_param_queue[interval_index_temp - 1];
             }
-#if FEATURE_LAP_ENABLED_VBR //anaghdin
-#endif
             if (scs_ptr->static_config.rate_control_mode == 0
 #if !ENABLE_TPL_ZERO_LAD
                 &&

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -6593,7 +6593,7 @@ static void av1_rc_init(SequenceControlSet *scs_ptr) {
       // encoded in the second pass is a guess. However, the sum duration is not.
       // It is calculated based on the actual durations of all frames from the
       // first pass.
-      av1_new_framerate(scs_ptr, frame_rate);
+      svt_av1_new_framerate(scs_ptr, frame_rate);
   }
 #endif
 }

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -6585,7 +6585,7 @@ static void av1_rc_init(SequenceControlSet *scs_ptr) {
   // Set absolute upper and lower quality limits
   rc->worst_quality = rc_cfg->worst_allowed_q;
   rc->best_quality  = rc_cfg->best_allowed_q;
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
   if (scs_ptr->lap_enabled) {
       double frame_rate = (double)scs_ptr->static_config.frame_rate_numerator / (double)scs_ptr->static_config.frame_rate_denominator;
       // Each frame can have a different duration, as the frame rate in the source
@@ -6622,7 +6622,7 @@ void process_tpl_stats_frame_kf_gfu_boost(PictureControlSet *pcs_ptr) {
 
     if (scs_ptr->lap_enabled) {
         double min_boost_factor = sqrt(rc->baseline_gf_interval);
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
 #if TUNE_TPL
         // The new tpl only looks at pictures in tpl group, which is fewer than before,
         // As a results, we defined a factor to adjust r0
@@ -6636,7 +6636,7 @@ void process_tpl_stats_frame_kf_gfu_boost(PictureControlSet *pcs_ptr) {
                 factor = 1.5;
             else
                 factor = 1;
-#if LAP_ENABLED_VBR_TUNE
+#if FEATURE_LAP_ENABLED_VBR
             if (pcs_ptr->parent_pcs_ptr->pd_window_count == scs_ptr->scd_delay)
                 div_factor = factor;
             else if (pcs_ptr->parent_pcs_ptr->pd_window_count <= 1)
@@ -7145,23 +7145,6 @@ static int rc_pick_q_and_bounds(PictureControlSet *pcs_ptr) {
     }
 
     adjust_active_best_and_worst_quality_org(pcs_ptr, rc, &active_worst_quality, &active_best_quality);
-#if 1 //LAP_ENABLED_VBR_DEBUG
-    if(pcs_ptr->temporal_layer_index == 0)
-        printf(
-            "\n Before poc%d boost=%d, r0:%.2f FtoK=%d  q=%d, bottom_index=%d "
-            "top_index=%d\tbase_frame_target=%d\trc->this_frame_target%d\n",
-            pcs_ptr->picture_number,
-            frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost,
-            pcs_ptr->parent_pcs_ptr->r0,
-            rc->frames_to_key,
-            active_best_quality,
-            active_best_quality,
-            active_worst_quality,
-            rc->base_frame_target,
-            rc->this_frame_target);
-
-        //printf("\n Before poc%d boost=%d, q=%d, bottom_index=%d top_index=%d\tbase_frame_target=%d\trc->this_frame_target%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, active_best_quality, active_best_quality, active_worst_quality, rc->base_frame_target, rc->this_frame_target);
-#endif
     q = get_q(pcs_ptr, active_worst_quality, active_best_quality);
     // Special case when we are targeting the max allowed rate.
     if (rc->this_frame_target >= rc->max_frame_bandwidth &&
@@ -7179,25 +7162,6 @@ static int rc_pick_q_and_bounds(PictureControlSet *pcs_ptr) {
     assert(q <= rc->worst_quality && q >= rc->best_quality);
 
     if (gf_group->update_type[pcs_ptr->parent_pcs_ptr->gf_group_index] == ARF_UPDATE) rc->arf_q = q;
-#if 1 //LAP_ENABLED_VBR_DEBUG
-    if (pcs_ptr->temporal_layer_index == 0)
-        //printf("\n After poc%d boost=%d, q=%d, bottom_index=%d top_index=%d\tbase_frame_target=%d\trc->this_frame_target:%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, q, active_best_quality, active_worst_quality, rc->base_frame_target, rc->this_frame_target);
-        printf(
-            "\n After poc%d boost=%d r0:%.2f FtoK=%d  q=%d, bottom_index=%d "
-            "top_index=%d\tbase_frame_target=%d\trc->this_frame_target:%d\n",
-            pcs_ptr->picture_number,
-            frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost,
-            pcs_ptr->parent_pcs_ptr->r0,
-            rc->frames_to_key,
-            q,
-            active_best_quality,
-            active_worst_quality,
-            rc->base_frame_target,
-            rc->this_frame_target);
-
-        //printf("\n After poc%d boost=%d, q=%d, bottom_index=%d top_index=%d, base_frame_target=%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, q, active_best_quality, active_worst_quality, rc->this_frame_target);
-#endif
-    //  printf("\nrc_pick_q_and_bounds return poc%d boost=%d, q=%d, bottom_index=%d top_index=%d, isintra=%d base_frame_target=%d, buffer_level=%d\n", pcs_ptr->picture_number, frame_is_intra_only(pcs_ptr->parent_pcs_ptr) ? rc->kf_boost : rc->gfu_boost, q, active_best_quality, active_worst_quality, frame_is_intra_only(pcs_ptr->parent_pcs_ptr), rc->base_frame_target, rc->buffer_level);
 
     return q;
 }
@@ -8035,7 +7999,7 @@ void *rate_control_kernel(void *input_ptr) {
                     pcs_ptr->parent_pcs_ptr->sad_me +=
                         pcs_ptr->parent_pcs_ptr->rc_me_distortion[sb_addr];
                 }
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             if (use_input_stat(scs_ptr) || scs_ptr->lap_enabled) {
 #else
             if (use_input_stat(scs_ptr)) {
@@ -8174,7 +8138,7 @@ void *rate_control_kernel(void *input_ptr) {
                 // ***Rate Control***
                 if (scs_ptr->static_config.rate_control_mode == 1) {
                     if (use_input_stat(scs_ptr)
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                         || scs_ptr->lap_enabled
 #endif
 #if !ENABLE_TPL_ZERO_LAD
@@ -8273,7 +8237,7 @@ void *rate_control_kernel(void *input_ptr) {
             // 2pass QPM with tpl_la
             if (scs_ptr->static_config.enable_adaptive_quantization == 2 &&
                 !use_output_stat(scs_ptr) &&
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                 (use_input_stat(scs_ptr) || scs_ptr->lap_enabled) &&
 #else
                 use_input_stat(scs_ptr) &&
@@ -8305,7 +8269,7 @@ void *rate_control_kernel(void *input_ptr) {
                     pcs_ptr->parent_pcs_ptr->average_qp += pcs_ptr->picture_qp;
                 }
             }
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
             if(use_input_stat(scs_ptr) || scs_ptr->lap_enabled)
 #else
             if (use_input_stat(scs_ptr))
@@ -8372,7 +8336,7 @@ void *rate_control_kernel(void *input_ptr) {
                         ? context_ptr->rate_control_param_queue[PARALLEL_GOP_MAX_NUMBER - 1]
                         : context_ptr->rate_control_param_queue[interval_index_temp - 1];
             }
-#if LAP_ENABLED_VBR //anaghdin
+#if FEATURE_LAP_ENABLED_VBR //anaghdin
 #endif
             if (scs_ptr->static_config.rate_control_mode == 0
 #if !ENABLE_TPL_ZERO_LAD
@@ -8392,7 +8356,7 @@ void *rate_control_kernel(void *input_ptr) {
                     (int64_t)parentpicture_control_set_ptr->total_num_bits -
                     (int64_t)context_ptr->high_level_rate_control_ptr->channel_bit_rate_per_frame;
 
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                 if (use_input_stat(scs_ptr) || scs_ptr->lap_enabled
 #else
                 if (use_input_stat(scs_ptr)
@@ -8406,7 +8370,7 @@ void *rate_control_kernel(void *input_ptr) {
                 } else
                 high_level_rc_feed_back_picture(parentpicture_control_set_ptr, scs_ptr);
                 if (scs_ptr->static_config.rate_control_mode == 1)
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                     if (use_input_stat(scs_ptr) || scs_ptr->lap_enabled
 #else
                     if (use_input_stat(scs_ptr)

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -1310,7 +1310,7 @@ uint32_t get_compound_mode_rate(uint8_t md_pass, ModeDecisionCandidate *candidat
 int is_interintra_wedge_used(BlockSize sb_type);
 int svt_is_interintra_allowed(uint8_t enable_inter_intra, BlockSize sb_type, PredictionMode mode,
                               const MvReferenceFrame ref_frame[2]);
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
 /* two_pass_cost_update
  * This function adds some biases for distortion and rate.
  * The function is used in the first pass only and for the purpose of data collection */
@@ -1667,7 +1667,7 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion += chromasad_;
 
         rate = luma_rate + chroma_rate;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
@@ -1685,7 +1685,7 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion = luma_sad + chromasad_;
         if (blk_geom->has_uv == 0 && chromasad_ != 0) SVT_LOG("av1_inter_fast_cost: Chroma error");
         rate = luma_rate + chroma_rate;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
         if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
@@ -1970,7 +1970,7 @@ EbErrorType av1_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
 
     rate = luma_rate + chroma_rate + coeff_rate;
     if (candidate_buffer_ptr->candidate_ptr->block_has_coeff) rate += tx_size_bits;
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
     if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr) &&
         candidate_buffer_ptr->candidate_ptr->type != INTRA_MODE) {
         two_pass_cost_update_64bit(
@@ -2119,7 +2119,7 @@ EbErrorType av1_merge_skip_full_cost(PictureControlSet *pcs_ptr, ModeDecisionCon
     skip_distortion = skip_luma_sse + skip_chroma_sse;
     skip_rate       = skip_mode_rate;
     skip_cost       = RDCOST(lambda, skip_rate, skip_distortion);
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
     if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
         MvReferenceFrame ref_type[2];
         av1_set_ref_frame(ref_type, candidate_buffer_ptr->candidate_ptr->ref_frame_type);

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -1310,7 +1310,7 @@ uint32_t get_compound_mode_rate(uint8_t md_pass, ModeDecisionCandidate *candidat
 int is_interintra_wedge_used(BlockSize sb_type);
 int svt_is_interintra_allowed(uint8_t enable_inter_intra, BlockSize sb_type, PredictionMode mode,
                               const MvReferenceFrame ref_frame[2]);
-
+#if !FIRST_PASS_RESTRUCTURE
 /* two_pass_cost_update
  * This function adds some biases for distortion and rate.
  * The function is used in the first pass only and for the purpose of data collection */
@@ -1354,7 +1354,7 @@ void two_pass_cost_update_64bit(PictureControlSet *pcs_ptr, ModeDecisionCandidat
         *distortion += (*distortion) * 2;
     }
 }
-
+#endif
 uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr, uint32_t qp,
                              uint64_t luma_distortion, uint64_t chroma_distortion, uint64_t lambda,
 #if !FIX_REMOVE_UNUSED_CODE
@@ -1667,9 +1667,11 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion += chromasad_;
 
         rate = luma_rate + chroma_rate;
+#if !FIRST_PASS_RESTRUCTURE
         if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
+#endif
         if (candidate_ptr->merge_flag) {
             uint64_t skip_mode_rate =
                 candidate_ptr->md_rate_estimation_ptr->skip_mode_fac_bits[skip_mode_ctx][1];
@@ -1683,9 +1685,11 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion = luma_sad + chromasad_;
         if (blk_geom->has_uv == 0 && chromasad_ != 0) SVT_LOG("av1_inter_fast_cost: Chroma error");
         rate = luma_rate + chroma_rate;
+#if !FIRST_PASS_RESTRUCTURE
         if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
+#endif
         // Assign fast cost
         if (candidate_ptr->merge_flag) {
             uint64_t skip_mode_rate =
@@ -1966,11 +1970,13 @@ EbErrorType av1_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
 
     rate = luma_rate + chroma_rate + coeff_rate;
     if (candidate_buffer_ptr->candidate_ptr->block_has_coeff) rate += tx_size_bits;
+#if !FIRST_PASS_RESTRUCTURE
     if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr) &&
         candidate_buffer_ptr->candidate_ptr->type != INTRA_MODE) {
         two_pass_cost_update_64bit(
             pcs_ptr, candidate_buffer_ptr->candidate_ptr, &rate, &total_distortion);
     }
+#endif
     // Assign full cost
     *(candidate_buffer_ptr->full_cost_ptr) = RDCOST(lambda, rate, total_distortion);
     candidate_buffer_ptr->candidate_ptr->total_rate = rate;
@@ -2113,6 +2119,7 @@ EbErrorType av1_merge_skip_full_cost(PictureControlSet *pcs_ptr, ModeDecisionCon
     skip_distortion = skip_luma_sse + skip_chroma_sse;
     skip_rate       = skip_mode_rate;
     skip_cost       = RDCOST(lambda, skip_rate, skip_distortion);
+#if !FIRST_PASS_RESTRUCTURE
     if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
         MvReferenceFrame ref_type[2];
         av1_set_ref_frame(ref_type, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
@@ -2132,6 +2139,7 @@ EbErrorType av1_merge_skip_full_cost(PictureControlSet *pcs_ptr, ModeDecisionCon
             merge_cost += merge_cost * 2;
         }
     }
+#endif
     // Assigne full cost
     *candidate_buffer_ptr->full_cost_ptr       = (skip_cost <= merge_cost) ? skip_cost : merge_cost;
     *candidate_buffer_ptr->full_cost_merge_ptr = merge_cost;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -684,7 +684,11 @@ static void setup_two_pass(SequenceControlSet *scs_ptr) {
             svt_av1_init_second_pass(scs_ptr);
         }
     }
-
+#if LAP_ENABLED_VBR
+    else if (scs_ptr->lap_enabled){
+        svt_av1_init_single_pass_lap(scs_ptr);
+    }
+#endif
 }
 
 extern EbErrorType first_pass_signal_derivation_pre_analysis(SequenceControlSet *     scs_ptr,
@@ -1021,7 +1025,11 @@ void *resource_coordination_kernel(void *input_ptr) {
             if (pcs_ptr->picture_number == 0) {
                 if (use_input_stat(scs_ptr))
                     read_stat(scs_ptr);
+#if LAP_ENABLED_VBR
+                if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr) || scs_ptr->lap_enabled)
+#else
                 if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr))
+#endif
                     setup_two_pass(scs_ptr);
             }
             pcs_ptr->ts_duration = (int64_t)10000000*(1<<16) / scs_ptr->frame_rate;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -684,7 +684,7 @@ static void setup_two_pass(SequenceControlSet *scs_ptr) {
             svt_av1_init_second_pass(scs_ptr);
         }
     }
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
     else if (scs_ptr->lap_enabled){
         svt_av1_init_single_pass_lap(scs_ptr);
     }
@@ -1025,7 +1025,7 @@ void *resource_coordination_kernel(void *input_ptr) {
             if (pcs_ptr->picture_number == 0) {
                 if (use_input_stat(scs_ptr))
                     read_stat(scs_ptr);
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
                 if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr) || scs_ptr->lap_enabled)
 #else
                 if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr))

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -685,9 +685,8 @@ static void setup_two_pass(SequenceControlSet *scs_ptr) {
         }
     }
 #if FEATURE_LAP_ENABLED_VBR
-    else if (scs_ptr->lap_enabled){
+    else if (scs_ptr->lap_enabled)
         svt_av1_init_single_pass_lap(scs_ptr);
-    }
 #endif
 }
 

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -184,11 +184,10 @@ EbErrorType svt_sequence_control_set_ctor(SequenceControlSet *scs_ptr, EbPtr obj
 
     scs_ptr->film_grain_random_seed = 7391;
     scs_ptr->reference_count        = 4;
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
     scs_ptr->lap_enabled = 0;
 #endif
 
-    scs_ptr->lap_enabled = 0;
     return EB_ErrorNone;
 }
 
@@ -311,7 +310,7 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
     dst->enable_pic_mgr_dec_order = src->enable_pic_mgr_dec_order;
     dst->enable_dec_order = src->enable_dec_order;
 #endif
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
     dst->lap_enabled                    = src->lap_enabled;
 #endif
     return EB_ErrorNone;

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -184,6 +184,9 @@ EbErrorType svt_sequence_control_set_ctor(SequenceControlSet *scs_ptr, EbPtr obj
 
     scs_ptr->film_grain_random_seed = 7391;
     scs_ptr->reference_count        = 4;
+#if !LAP_ENABLED_VBR
+    scs_ptr->lap_enabled = 0;
+#endif
 
     scs_ptr->lap_enabled = 0;
     return EB_ErrorNone;
@@ -307,6 +310,9 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
 #if FEATURE_PA_ME
     dst->enable_pic_mgr_dec_order = src->enable_pic_mgr_dec_order;
     dst->enable_dec_order = src->enable_dec_order;
+#endif
+#if LAP_ENABLED_VBR
+    dst->lap_enabled                    = src->lap_enabled;
 #endif
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -26,14 +26,24 @@
 #include "EbPictureDecisionProcess.h"
 #include "EbModeDecisionConfigurationProcess.h"
 #include "mv.h"
+#if FIRST_PASS_RESTRUCTURE
+#ifdef ARCH_X86_64
+#include <xmmintrin.h>
+#endif
+#include "EbMotionEstimation.h"
+//#include "EbMotionEstimationProcess.h"
+#undef _MM_HINT_T2
+#define _MM_HINT_T2 1
+#endif
 
+#if !FIRST_PASS_RESTRUCTURE
 #define INCRMENT_CAND_TOTAL_COUNT(cnt)                                                     \
     MULTI_LINE_MACRO_BEGIN cnt++;                                                          \
     if (cnt >= MODE_DECISION_CANDIDATE_MAX_COUNT_Y)                                          \
         SVT_LOG(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n", cnt); \
     MULTI_LINE_MACRO_END
-
-#define OUTPUT_FPF 0
+#endif
+#define OUTPUT_FPF 1
 
 #define INTRA_MODE_PENALTY 1024
 #define NEW_MV_MODE_PENALTY 32
@@ -45,7 +55,39 @@
 #define STATS_CAPABILITY_INIT 100
 //1.5 times larger than request.
 #define STATS_CAPABILITY_GROW(s) (s * 3 /2)
+#if LAP_ENABLED_VBR_BUF
+static EbErrorType realloc_stats_out(SequenceControlSet *scs_ptr, FirstPassStatsOut* out, uint64_t frame_number) {
+    if (frame_number < out->size)
+        return EB_ErrorNone;
 
+    if ((int64_t)frame_number >= (int64_t)out->capability - 1) {
+        size_t capability = (int64_t)frame_number >= (int64_t)STATS_CAPABILITY_INIT - 1 ?
+            STATS_CAPABILITY_GROW(frame_number) : STATS_CAPABILITY_INIT;
+        if (scs_ptr->lap_enabled) {
+            //store the data points before re-allocation
+            uint64_t stats_in_start_offset = 0;
+            uint64_t stats_in_offset = 0;
+            uint64_t stats_in_end_offset = 0;
+            if (frame_number) {
+                stats_in_start_offset = scs_ptr->twopass.stats_buf_ctx->stats_in_start - out->stat;
+                stats_in_offset = scs_ptr->twopass.stats_in - out->stat;
+                stats_in_end_offset = scs_ptr->twopass.stats_buf_ctx->stats_in_end - out->stat;
+            }
+            EB_REALLOC_ARRAY(out->stat, capability);
+            // restore the pointers after re-allocation is done
+            scs_ptr->twopass.stats_buf_ctx->stats_in_start = out->stat + stats_in_start_offset;
+            scs_ptr->twopass.stats_in = out->stat + stats_in_offset;
+            scs_ptr->twopass.stats_buf_ctx->stats_in_end = out->stat + stats_in_end_offset;
+        }
+        else {
+            EB_REALLOC_ARRAY(out->stat, capability);
+        }
+        out->capability = capability;
+    }
+    out->size = frame_number + 1;
+    return EB_ErrorNone;
+    }
+#else
 static EbErrorType realloc_stats_out(FirstPassStatsOut* out, uint64_t frame_number) {
     if (frame_number < out->size)
         return EB_ErrorNone;
@@ -58,17 +100,23 @@ static EbErrorType realloc_stats_out(FirstPassStatsOut* out, uint64_t frame_numb
     out->size = frame_number + 1;
     return EB_ErrorNone;
 }
+#endif
 
 static AOM_INLINE void output_stats(SequenceControlSet *scs_ptr, FIRSTPASS_STATS *stats,
                                     uint64_t frame_number) {
     FirstPassStatsOut* stats_out = &scs_ptr->encode_context_ptr->stats_out;
     svt_block_on_mutex(scs_ptr->encode_context_ptr->stat_file_mutex);
+#if LAP_ENABLED_VBR_BUF
+    if (realloc_stats_out(scs_ptr, stats_out, frame_number) != EB_ErrorNone) {
+#else
     if (realloc_stats_out(stats_out, frame_number) != EB_ErrorNone) {
+#endif
         SVT_ERROR("realloc_stats_out request %d entries failed failed\n", frame_number);
     } else {
         stats_out->stat[frame_number] = *stats;
     }
-// TEMP debug code
+
+    // TEMP debug code
 #if OUTPUT_FPF
     {
         FILE *fpfile;
@@ -321,9 +369,13 @@ static void update_firstpass_stats(PictureParentControlSet *pcs_ptr,
     if (twopass->stats_buf_ctx->total_stats != NULL) {
         svt_av1_accumulate_stats(twopass->stats_buf_ctx->total_stats, &fps);
     }
+#if 0//LAP_ENABLED_VBR_DEBUG
+    SVT_LOG("stats_in_end++: %.0f\n", twopass->stats_buf_ctx->stats_in_end->frame);
+#endif
     /*In the case of two pass, first pass uses it as a circular buffer,
    * when LAP is enabled it is used as a linear buffer*/
     twopass->stats_buf_ctx->stats_in_end++;
+
     if ((use_output_stat(scs_ptr)) &&
         (twopass->stats_buf_ctx->stats_in_end >= twopass->stats_buf_ctx->stats_in_buf_end)) {
         twopass->stats_buf_ctx->stats_in_end = twopass->stats_buf_ctx->stats_in_start;
@@ -467,6 +519,7 @@ extern EbErrorType first_pass_signal_derivation_pre_analysis(SequenceControlSet 
 
     return return_error;
 }
+#if !FIRST_PASS_RESTRUCTURE
 extern EbErrorType av1_intra_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                        struct ModeDecisionCandidateBuffer *candidate_buffer_ptr,
                                        BlkStruct *blk_ptr, uint64_t *y_distortion,
@@ -576,7 +629,9 @@ extern void first_pass_loop_core(PictureControlSet *pcs_ptr,
     //ALL PLANE
     *(candidate_buffer->full_cost_ptr) = 0;
 }
+#endif
 #define LOW_MOTION_ERROR_THRESH 25
+#if !FIRST_PASS_RESTRUCTURE
 /***************************************************************************
 * Computes and returns the intra pred error of a block.
 * intra pred error: sum of squared error of the intra predicted residual.
@@ -741,7 +796,6 @@ static int firstpass_inter_prediction(
 
     int motion_error = 0;
     // TODO(pengchong): Replace the hard-coded threshold
-    // anaghdin: to add support
     if (1) //(raw_motion_error > LOW_MOTION_ERROR_THRESH)
     {
         uint32_t                      cand_index = 1;
@@ -1674,7 +1728,7 @@ extern void first_pass_md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionC
 #endif
     context_ptr->md_local_blk_unit[blk_ptr->mds_idx].avail_blk_flag = EB_TRUE;
 }
-
+#endif
 #if FEATURE_OPT_TF
 void set_tf_controls(PictureParentControlSet *pcs_ptr, uint8_t tf_level);
 #else
@@ -1839,6 +1893,7 @@ EbErrorType first_pass_signal_derivation_multi_processes(SequenceControlSet *   
 #endif
     return return_error;
 }
+#if !FIRST_PASS_RESTRUCTURE
 #if TUNE_TX_TYPE_LEVELS
 void set_txt_controls(ModeDecisionContext *mdctxt, uint8_t txt_level);
 #else
@@ -2161,6 +2216,7 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
 
     return return_error;
 }
+#endif
 /******************************************************
 * Derive Mode Decision Config Settings for first pass
 Input   : encoder mode and tune
@@ -2277,7 +2333,7 @@ EbErrorType first_pass_signal_derivation_me_kernel(
 #endif
 
     // Set hme/me based reference pruning level (0-4)
-#if FIX_FIRST_PASS_HME
+#if 0 // FIX_FIRST_PASS_HME //anaghdin
     if (scs_ptr->static_config.enc_mode <= ENC_MR)
         set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
     else if (scs_ptr->static_config.enc_mode <= ENC_M3)
@@ -2293,3 +2349,569 @@ EbErrorType first_pass_signal_derivation_me_kernel(
 
     return return_error;
 };
+
+#if FIRST_PASS_RESTRUCTURE
+/***************************************************************************
+* Computes and returns the intra pred error of a block using src.
+* intra pred error: sum of squared error of the intra predicted residual.
+* Modifies:
+*   stats->intra_skip_count
+*   stats->image_data_start_row
+*   stats->intra_factor
+*   stats->brightness_factor
+*   stats->intra_error
+*   stats->frame_avg_wavelet_energy
+* Returns:
+*   this_intra_error.
+***************************************************************************/
+static int open_loop_firstpass_intra_prediction(uint32_t blk_origin_x, uint32_t blk_origin_y,
+                                                uint8_t bwidth, uint8_t bheight,
+                                                EbPictureBufferDesc *input_picture_ptr,
+                                                uint32_t             input_origin_index,
+                                                FRAME_STATS *const   stats) {
+    int32_t        mb_row = blk_origin_y >> 4;
+    int32_t        mb_col = blk_origin_x >> 4;
+    const int       use_dc_pred = (mb_col || mb_row) && (!mb_col || !mb_row);
+
+    uint32_t sub_blk_origin_x, sub_blk_origin_y;
+    uint8_t *above_row;
+    uint8_t *left_col;
+
+    DECLARE_ALIGNED(16, uint8_t, left_data[MAX_TX_SIZE * 2 + 32]);
+    DECLARE_ALIGNED(16, uint8_t, above_data[MAX_TX_SIZE * 2 + 32]);
+    DECLARE_ALIGNED(32, uint8_t, predictor8[256 * 2]);
+    uint8_t *predictor = predictor8;
+
+    uint8_t sub_blk_rows = use_dc_pred ? (bheight == FORCED_BLK_SIZE && bwidth == FORCED_BLK_SIZE) ? 1 : bheight / 8
+        : bheight / 4;
+    uint8_t sub_blk_cols = use_dc_pred ? (bheight == FORCED_BLK_SIZE && bwidth == FORCED_BLK_SIZE) ? 1 : bwidth / 8
+        : bwidth / 4;
+
+    for (uint32_t sub_blk_index_y = 0; sub_blk_index_y < sub_blk_rows; ++sub_blk_index_y) {
+        for (uint32_t sub_blk_index_x = 0; sub_blk_index_x < sub_blk_cols; ++sub_blk_index_x) {
+            TxSize tx_size = use_dc_pred ? ((bheight == FORCED_BLK_SIZE && bwidth == FORCED_BLK_SIZE) ? TX_16X16 : TX_8X8) : TX_4X4;
+            sub_blk_origin_x = blk_origin_x + sub_blk_index_x * bwidth / sub_blk_cols;
+            sub_blk_origin_y = blk_origin_y + sub_blk_index_y* bheight/ sub_blk_rows;
+            above_row = above_data + 16;
+            left_col = left_data + 16;
+
+            // Fill Neighbor Arrays
+            update_neighbor_samples_array_open_loop_mb(above_row - 1, left_col - 1,
+                input_picture_ptr, input_picture_ptr->stride_y, sub_blk_origin_x, sub_blk_origin_y, bwidth / sub_blk_cols, bheight / sub_blk_rows);
+            // PRED
+            predictor = &predictor8[(sub_blk_origin_x - blk_origin_x) + (sub_blk_origin_y - blk_origin_y)*FORCED_BLK_SIZE];
+            intra_prediction_open_loop_mb(0, DC_PRED, sub_blk_origin_x, sub_blk_origin_y, tx_size, above_row, left_col, predictor, FORCED_BLK_SIZE);
+        }
+    }
+
+    EbSpatialFullDistType spatial_full_dist_type_fun = svt_spatial_full_distortion_kernel;
+    int this_intra_error =
+        (uint32_t)(spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
+            input_origin_index,
+            input_picture_ptr->stride_y,
+            predictor8,
+            0,
+            FORCED_BLK_SIZE,
+            bwidth,
+            bheight));
+
+    if (this_intra_error < UL_INTRA_THRESH) {
+        ++stats->intra_skip_count;
+    }
+    else if ((mb_col > 0) && (stats->image_data_start_row == INVALID_ROW)) {
+        stats->image_data_start_row = mb_row;
+    }
+    // aom_clear_system_state();
+    double log_intra = log1p((double)this_intra_error);
+    if (log_intra < 10.0)
+        stats->intra_factor += 1.0 + ((10.0 - log_intra) * 0.05);
+    else
+        stats->intra_factor += 1.0;
+
+    int level_sample = input_picture_ptr->buffer_y[input_origin_index];
+
+    if ((level_sample < DARK_THRESH) && (log_intra < 9.0))
+        stats->brightness_factor += 1.0 + (0.01 * (DARK_THRESH - level_sample));
+    else
+        stats->brightness_factor += 1.0;
+    // Intrapenalty below deals with situations where the intra and inter
+    // error scores are very low (e.g. a plain black frame).
+    // We do not have special cases in first pass for 0,0 and nearest etc so
+    // all inter modes carry an overhead cost estimate for the mv.
+    // When the error score is very low this causes us to pick all or lots of
+    // INTRA modes and throw lots of key frames.
+    // This penalty adds a cost matching that of a 0,0 mv to the intra case.
+    this_intra_error += INTRA_MODE_PENALTY;
+
+    const int stride = input_picture_ptr->stride_y;
+    uint8_t *buf = &(input_picture_ptr->buffer_y)[input_origin_index];
+    for (int r8 = 0; r8 < 2; ++r8) {
+        for (int c8 = 0; c8 < 2; ++c8) {
+            stats->frame_avg_wavelet_energy +=
+                svt_av1_haar_ac_sad_8x8_uint8_input(buf + c8 * 8 + r8 * 8 * stride, stride, 0);
+        }
+    }
+
+    // Accumulate the intra error.
+    stats->intra_error += (int64_t)this_intra_error;
+    return this_intra_error;
+}
+/***************************************************************************
+* Computes and returns the inter prediction error from the src last frame.
+* Computes inter prediction errors from the golden and updates stats accordingly.
+* Modifies:
+*    stats: many member params in it.
+*  Returns:
+*    this_inter_error
+***************************************************************************/
+static int open_loop_firstpass_inter_prediction(
+    PictureParentControlSet *ppcs_ptr, uint32_t me_sb_addr, uint32_t blk_origin_x,
+    uint32_t blk_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *input_picture_ptr,
+    uint32_t input_origin_index, const int this_intra_error, MV *last_mv,
+    int raw_motion_err, FRAME_STATS *stats) {
+    int32_t        mb_row = blk_origin_y >> 4;
+    int32_t        mb_col = blk_origin_x >> 4;
+    const uint32_t mb_cols =
+        (ppcs_ptr->scs_ptr->seq_header.max_frame_width + FORCED_BLK_SIZE - 1) / FORCED_BLK_SIZE;
+    const uint32_t mb_rows =
+        (ppcs_ptr->scs_ptr->seq_header.max_frame_height + FORCED_BLK_SIZE - 1) / FORCED_BLK_SIZE;
+    int this_inter_error = this_intra_error;
+    FULLPEL_MV mv = kZeroFullMv;
+    EbSpatialFullDistType spatial_full_dist_type_fun = svt_spatial_full_distortion_kernel;
+
+    int motion_error = 0;
+    // TODO(pengchong): Replace the hard-coded threshold
+    if (raw_motion_err > LOW_MOTION_ERROR_THRESH)
+    {
+        uint32_t    me_mb_offset = 0;
+        BlockGeom   blk_geom;
+        const MeSbResults *me_results = ppcs_ptr->pa_me_data->me_results[me_sb_addr];
+        uint32_t me_sb_size = ppcs_ptr->scs_ptr->sb_sz;
+        blk_geom.origin_x = blk_origin_x - (blk_origin_x / me_sb_size)*me_sb_size;
+        blk_geom.origin_y = blk_origin_y - (blk_origin_y / me_sb_size)*me_sb_size;
+        blk_geom.bwidth = FORCED_BLK_SIZE;
+        blk_geom.bheight = FORCED_BLK_SIZE;
+        me_mb_offset = get_me_info_index(ppcs_ptr->max_number_of_pus_per_sb, &blk_geom, 0, 0);
+        uint8_t list_index = 0;
+        uint8_t ref_pic_index = 0;
+        mv.col = me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].x_mv >> 2;
+        mv.row = me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].y_mv >> 2;
+
+        EbPictureBufferDesc *last_input_picture_ptr = ppcs_ptr->first_pass_ref_count ? ppcs_ptr->first_pass_ref_ppcs_ptr[0]->enhanced_picture_ptr : NULL;
+        int32_t ref_origin_index = last_input_picture_ptr->origin_x + (blk_origin_x + mv.col) +
+            (blk_origin_y + mv.row + last_input_picture_ptr->origin_y) *
+                last_input_picture_ptr->stride_y;
+
+        motion_error =
+            (uint32_t)(spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
+                input_origin_index,
+                input_picture_ptr->stride_y,
+                last_input_picture_ptr->buffer_y,
+                ref_origin_index,
+                last_input_picture_ptr->stride_y,
+                bwidth,
+                bheight));
+
+        // Assume 0,0 motion with no mv overhead.
+        if (mv.col != 0 && mv.row != 0) {
+            motion_error +=
+                NEW_MV_MODE_PENALTY;
+        }
+        // Motion search in 2nd reference frame.
+        int gf_motion_error = motion_error;
+        if (ppcs_ptr->first_pass_ref_count > 1 && me_results->total_me_candidate_index[me_mb_offset] > 1) {
+            // To convert full-pel MV
+            list_index = 0;
+            ref_pic_index = 1;
+            FULLPEL_MV gf_mv;
+            gf_mv.col =  me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].x_mv >> 2;
+            gf_mv.row =  me_results->me_mv_array[me_mb_offset * MAX_PA_ME_MV + (list_index ? 4 : 0) + ref_pic_index].y_mv >> 2;
+            EbPictureBufferDesc *golden_input_picture_ptr = ppcs_ptr->first_pass_ref_ppcs_ptr[1]->enhanced_picture_ptr;
+            ref_origin_index = golden_input_picture_ptr->origin_x + (blk_origin_x + gf_mv.col) +
+                (blk_origin_y + gf_mv.row + golden_input_picture_ptr->origin_y) *
+                golden_input_picture_ptr->stride_y;
+
+            gf_motion_error =
+                (uint32_t)(spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
+                    input_origin_index,
+                    input_picture_ptr->stride_y,
+                    golden_input_picture_ptr->buffer_y,
+                    ref_origin_index,
+                    golden_input_picture_ptr->stride_y,
+                    bwidth,
+                    bheight));
+
+            // Assume 0,0 motion with no mv overhead.
+            if (gf_mv.col != 0 && gf_mv.row != 0) {
+                gf_motion_error +=
+                    NEW_MV_MODE_PENALTY;
+            }
+        }
+
+        if (gf_motion_error < motion_error && gf_motion_error < this_intra_error) {
+            ++stats->second_ref_count;
+#if FIRST_PASS_ME_SETTING
+            motion_error = gf_motion_error;
+#endif
+        }
+        // In accumulating a score for the 2nd reference frame take the
+        // best of the motion predicted score and the intra coded error
+        // (just as will be done for) accumulation of "coded_error" for
+        // the last frame.
+        if (ppcs_ptr->first_pass_ref_count > 1 &&  (gf_motion_error < motion_error * 3)) {
+            stats->sr_coded_error += AOMMIN(gf_motion_error, this_intra_error);
+        }
+        else {
+            stats->sr_coded_error += motion_error;
+        }
+
+        // Motion search in 3rd reference frame.
+        int alt_motion_error = motion_error;
+        if (alt_motion_error < motion_error && alt_motion_error < gf_motion_error &&
+            alt_motion_error < this_intra_error) {
+            ++stats->third_ref_count;
+        }
+        // In accumulating a score for the 3rd reference frame take the
+        // best of the motion predicted score and the intra coded error
+        // (just as will be done for) accumulation of "coded_error" for
+        // the last frame.
+        // alt_ref_frame is not supported yet
+        if (0 /*alt_ref_frame != NULL*/) {
+            stats->tr_coded_error += AOMMIN(alt_motion_error, this_intra_error);
+        }
+        else {
+            stats->tr_coded_error += motion_error;
+        }
+    }
+    else {
+        stats->sr_coded_error += motion_error;
+        stats->tr_coded_error += motion_error;
+    }
+
+    // Start by assuming that intra mode is best.
+    if (motion_error <= this_intra_error) {
+#ifdef ARCH_X86_64
+        aom_clear_system_state();
+#endif
+        // Keep a count of cases where the inter and intra were very close
+        // and very low. This helps with scene cut detection for example in
+        // cropped clips with black bars at the sides or top and bottom.
+        if (((this_intra_error - INTRA_MODE_PENALTY) * 9 <= motion_error * 10) &&
+            (this_intra_error < (2 * INTRA_MODE_PENALTY))) {
+            stats->neutral_count += 1.0;
+            // Also track cases where the intra is not much worse than the inter
+            // and use this in limiting the GF/arf group length.
+        }
+        else if ((this_intra_error > NCOUNT_INTRA_THRESH) &&
+            (this_intra_error < (NCOUNT_INTRA_FACTOR * motion_error))) {
+            stats->neutral_count +=
+                (double)motion_error / DOUBLE_DIVIDE_CHECK((double)this_intra_error);
+        }
+        const MV best_mv = get_mv_from_fullmv(&mv);
+        this_inter_error = motion_error;
+        stats->sum_mvr += best_mv.row;
+        stats->sum_mvr_abs += abs(best_mv.row);
+        stats->sum_mvc += best_mv.col;
+        stats->sum_mvc_abs += abs(best_mv.col);
+        stats->sum_mvrs += best_mv.row * best_mv.row;
+        stats->sum_mvcs += best_mv.col * best_mv.col;
+        ++stats->inter_count;
+        accumulate_mv_stats(best_mv, mv, mb_row, mb_col, mb_rows, mb_cols, last_mv, stats);
+    }
+
+    return this_inter_error;
+}
+/***************************************************************************
+* Perform the processing for first pass.
+* For each 16x16 blocks performs DC and ME results from LAST frame and store
+* the required data.
+***************************************************************************/
+static EbErrorType first_pass_frame(PictureParentControlSet *  ppcs_ptr) {
+    EbPictureBufferDesc *input_picture_ptr = ppcs_ptr->enhanced_picture_ptr;
+    EbPictureBufferDesc *last_input_picture_ptr = ppcs_ptr->first_pass_ref_count ? ppcs_ptr->first_pass_ref_ppcs_ptr[0]->enhanced_picture_ptr : NULL;
+
+    const uint32_t blk_cols = (uint32_t)(input_picture_ptr->width + FORCED_BLK_SIZE - 1) /
+        FORCED_BLK_SIZE;
+    const uint32_t blk_rows = (uint32_t)(input_picture_ptr->height + FORCED_BLK_SIZE - 1) /
+        FORCED_BLK_SIZE;
+
+    uint32_t me_sb_size = ppcs_ptr->scs_ptr->sb_sz;
+    uint32_t me_pic_width_in_sb =
+        (ppcs_ptr->aligned_width + me_sb_size - 1) / me_sb_size;
+    uint32_t me_sb_x, me_sb_y, me_sb_addr;
+
+    uint32_t blk_width, blk_height, blk_origin_x, blk_origin_y;
+    MV first_top_mv = kZeroMv;
+    MV last_mv;
+    uint32_t input_origin_index;
+
+    EbSpatialFullDistType spatial_full_dist_type_fun = svt_spatial_full_distortion_kernel;
+
+    for (uint32_t blk_index_y = 0; blk_index_y < blk_rows; ++blk_index_y) {
+        for (uint32_t blk_index_x = 0; blk_index_x < blk_cols; ++blk_index_x) {
+
+            blk_origin_x = blk_index_x * FORCED_BLK_SIZE;
+            blk_origin_y = blk_index_y * FORCED_BLK_SIZE;
+            me_sb_x = blk_origin_x / me_sb_size;
+            me_sb_y = blk_origin_y / me_sb_size;
+            me_sb_addr = me_sb_x + me_sb_y * me_pic_width_in_sb;
+
+            blk_width =
+                (ppcs_ptr->aligned_width - blk_origin_x) < FORCED_BLK_SIZE
+                ? ppcs_ptr->aligned_width - blk_origin_x
+                : FORCED_BLK_SIZE;
+            blk_height =
+                (ppcs_ptr->aligned_height - blk_origin_y) < FORCED_BLK_SIZE
+                ? ppcs_ptr->aligned_height - blk_origin_y
+                : FORCED_BLK_SIZE;
+    
+            input_origin_index = (input_picture_ptr->origin_y + blk_origin_y) *
+                input_picture_ptr->stride_y +
+                (input_picture_ptr->origin_x + blk_origin_x);
+
+            FRAME_STATS *mb_stats =
+                ppcs_ptr->firstpass_data.mb_stats + blk_index_y * blk_cols + blk_index_x;
+
+            int this_intra_error = open_loop_firstpass_intra_prediction(blk_origin_x,
+                                                                   blk_origin_y,
+                                                                   blk_width,
+                                                                   blk_height,
+                                                                   input_picture_ptr,
+                                                                   input_origin_index,
+                                                                   mb_stats);
+            int this_inter_error = this_intra_error;
+
+            if (blk_origin_x == 0)
+                last_mv = first_top_mv;
+
+            if (ppcs_ptr->first_pass_ref_count) {
+                ppcs_ptr->firstpass_data.raw_motion_err_list[blk_index_y * blk_cols + blk_index_x]
+                    = (uint32_t)(spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
+                        input_origin_index,
+                        input_picture_ptr->stride_y,
+                        last_input_picture_ptr->buffer_y,
+                        input_origin_index,
+                        input_picture_ptr->stride_y,
+                        blk_width,
+                        blk_height));
+
+                this_inter_error = open_loop_firstpass_inter_prediction(
+                    ppcs_ptr,
+                    me_sb_addr,
+                    blk_origin_x,
+                    blk_origin_y,
+                    blk_width,
+                    blk_height,
+                    input_picture_ptr,
+                    input_origin_index,
+                    this_intra_error,
+                    &last_mv,
+                    ppcs_ptr->firstpass_data.raw_motion_err_list[blk_index_y * blk_cols + blk_index_x],
+                    mb_stats);
+
+                if (blk_origin_x == 0)
+                    first_top_mv = last_mv;
+
+                mb_stats->coded_error += this_inter_error;
+            }
+            else {
+                mb_stats->sr_coded_error += this_intra_error;
+                mb_stats->tr_coded_error += this_intra_error;
+                mb_stats->coded_error += this_intra_error;
+            }
+        }
+    }
+
+    return EB_ErrorNone;
+}
+/***************************************************************************
+* Prepare the me context for performing first pass me.
+***************************************************************************/
+static void first_pass_setup_me_context(MotionEstimationContext_t *context_ptr,
+                                        PictureParentControlSet *  ppcs_ptr,
+                                        EbPictureBufferDesc *input_picture_ptr, int blk_row,
+                                        int blk_col, uint32_t ss_x, uint32_t ss_y) {
+    // setup the references
+    context_ptr->me_context_ptr->num_of_list_to_search       = 0;
+    context_ptr->me_context_ptr->num_of_ref_pic_to_search[0] = 0;
+    context_ptr->me_context_ptr->num_of_ref_pic_to_search[1] = 0;
+    context_ptr->me_context_ptr->temporal_layer_index        = 0;
+    context_ptr->me_context_ptr->is_used_as_reference_flag   = 1;
+
+    if (ppcs_ptr->first_pass_ref_count) {
+        context_ptr->me_context_ptr->me_ds_ref_array[0][0] =
+            ppcs_ptr->first_pass_ref_ppcs_ptr[0]->ds_pics;
+        context_ptr->me_context_ptr->num_of_ref_pic_to_search[0]++;
+    }
+    if (ppcs_ptr->first_pass_ref_count > 1) {
+        context_ptr->me_context_ptr->me_ds_ref_array[0][1] =
+            ppcs_ptr->first_pass_ref_ppcs_ptr[1]->ds_pics;
+        context_ptr->me_context_ptr->num_of_ref_pic_to_search[0]++;
+    }
+
+    context_ptr->me_context_ptr->me_type = ME_FIRST_PASS;
+#if FIRST_PASS_REF_FIXES
+    // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+    EbPictureBufferDesc *quarter_pic_ptr = ppcs_ptr->ds_pics.quarter_picture_ptr;
+
+    EbPictureBufferDesc *sixteenth_pic_ptr = ppcs_ptr->ds_pics.sixteenth_picture_ptr;
+#else
+    // set the buffers with the original, quarter and sixteenth pixels version of the source frame
+    EbDownScaledObject *src_ds_object = (EbDownScaledObject *)
+                                            ppcs_ptr->down_scaled_picture_wrapper_ptr->object_ptr;
+
+    // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+    EbPictureBufferDesc *quarter_pic_ptr = src_ds_object->quarter_picture_ptr;
+
+    EbPictureBufferDesc *sixteenth_pic_ptr = src_ds_object->sixteenth_picture_ptr;
+#endif
+    // Parts from MotionEstimationKernel()
+    uint32_t sb_origin_x = (uint32_t)(blk_col * BLOCK_SIZE_64);
+    uint32_t sb_origin_y = (uint32_t)(blk_row * BLOCK_SIZE_64);
+
+    uint32_t sb_width  = (input_picture_ptr->width - sb_origin_x) < BLOCK_SIZE_64
+         ? input_picture_ptr->width - sb_origin_x
+         : BLOCK_SIZE_64;
+    uint32_t sb_height = (input_picture_ptr->height - sb_origin_y) < BLOCK_SIZE_64
+        ? input_picture_ptr->height - sb_origin_y
+        : BLOCK_SIZE_64;
+    // Load the SB from the input to the intermediate SB buffer
+    int buffer_index = (input_picture_ptr->origin_y + sb_origin_y) * input_picture_ptr->stride_y +
+        input_picture_ptr->origin_x + sb_origin_x;
+
+    // set search method
+    context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
+
+    uint8_t *src_ptr = &(input_picture_ptr->buffer_y[buffer_index]);
+#ifdef ARCH_X86_64
+    //_MM_HINT_T0     //_MM_HINT_T1    //_MM_HINT_T2    //_MM_HINT_NTA
+    uint32_t i;
+    for (i = 0; i < sb_height; i++) {
+        char const *p = (char const *)(src_ptr + i * input_picture_ptr->stride_y);
+        _mm_prefetch(p, _MM_HINT_T2);
+    }
+#endif
+    context_ptr->me_context_ptr->sb_src_ptr    = &(input_picture_ptr->buffer_y[buffer_index]);
+    context_ptr->me_context_ptr->sb_src_stride = input_picture_ptr->stride_y;
+
+    // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
+    buffer_index = (quarter_pic_ptr->origin_y + (sb_origin_y >> ss_y)) * quarter_pic_ptr->stride_y +
+        quarter_pic_ptr->origin_x + (sb_origin_x >> ss_x);
+
+    for (uint32_t sb_row = 0; sb_row < (sb_height >> ss_y); sb_row++) {
+        EB_MEMCPY((&(context_ptr->me_context_ptr->quarter_sb_buffer
+                         [sb_row * context_ptr->me_context_ptr->quarter_sb_buffer_stride])),
+                  (&(quarter_pic_ptr->buffer_y[buffer_index + sb_row * quarter_pic_ptr->stride_y])),
+                  (sb_width >> ss_x) * sizeof(uint8_t));
+    }
+
+    // Load the 1/16 decimated SB from the 1/16 decimated input to the 1/16 intermediate SB buffer
+    buffer_index = (sixteenth_pic_ptr->origin_y + (sb_origin_y >> 2)) *
+            sixteenth_pic_ptr->stride_y +
+        sixteenth_pic_ptr->origin_x + (sb_origin_x >> 2);
+
+    uint8_t *frame_ptr = &(sixteenth_pic_ptr->buffer_y[buffer_index]);
+    uint8_t *local_ptr = context_ptr->me_context_ptr->sixteenth_sb_buffer;
+
+    if (context_ptr->me_context_ptr->hme_search_method == FULL_SAD_SEARCH) {
+        for (uint32_t sb_row = 0; sb_row < (sb_height >> 2); sb_row += 1) {
+            EB_MEMCPY(local_ptr, frame_ptr, (sb_width >> 2) * sizeof(uint8_t));
+            local_ptr += 16;
+            frame_ptr += sixteenth_pic_ptr->stride_y;
+        }
+    } else {
+        for (uint32_t sb_row = 0; sb_row < (sb_height >> 2); sb_row += 2) {
+            EB_MEMCPY(local_ptr, frame_ptr, (sb_width >> 2) * sizeof(uint8_t));
+            local_ptr += 16;
+            frame_ptr += sixteenth_pic_ptr->stride_y << 1;
+        }
+    }
+  
+}
+/***************************************************************************
+* Perform the motion estimation for first pass.
+***************************************************************************/
+static EbErrorType first_pass_me(PictureParentControlSet *  ppcs_ptr,
+                                    MotionEstimationContext_t *me_context_ptr,
+                                    int32_t segment_index) {
+    EbPictureBufferDesc *input_picture_ptr = ppcs_ptr->enhanced_picture_ptr;
+
+
+    uint32_t blk_cols = (uint32_t)(input_picture_ptr->width + BLOCK_SIZE_64 - 1) /
+        BLOCK_SIZE_64;
+    uint32_t blk_rows = (uint32_t)(input_picture_ptr->height + BLOCK_SIZE_64 - 1) /
+        BLOCK_SIZE_64;
+    uint32_t ss_x   = ppcs_ptr->scs_ptr->subsampling_x;
+    uint32_t ss_y   = ppcs_ptr->scs_ptr->subsampling_y;
+
+    MeContext *context_ptr = me_context_ptr->me_context_ptr;
+
+    uint32_t x_seg_idx;
+    uint32_t y_seg_idx;
+    uint32_t picture_width_in_b64  = blk_cols;
+    uint32_t picture_height_in_b64 = blk_rows;
+    SEGMENT_CONVERT_IDX_TO_XY(
+        segment_index, x_seg_idx, y_seg_idx, ppcs_ptr->first_pass_seg_column_count);
+    uint32_t x_b64_start_idx = SEGMENT_START_IDX(
+        x_seg_idx, picture_width_in_b64, ppcs_ptr->first_pass_seg_column_count);
+    uint32_t x_b64_end_idx = SEGMENT_END_IDX(
+        x_seg_idx, picture_width_in_b64, ppcs_ptr->first_pass_seg_column_count);
+    uint32_t y_b64_start_idx = SEGMENT_START_IDX(
+        y_seg_idx, picture_height_in_b64, ppcs_ptr->first_pass_seg_row_count);
+    uint32_t y_b64_end_idx = SEGMENT_END_IDX(
+        y_seg_idx, picture_height_in_b64, ppcs_ptr->first_pass_seg_row_count);
+
+    for (uint32_t blk_row = y_b64_start_idx; blk_row < y_b64_end_idx; blk_row++) {
+        for (uint32_t blk_col = x_b64_start_idx; blk_col < x_b64_end_idx; blk_col++) {
+            // Initialize ME context
+            first_pass_setup_me_context(
+                me_context_ptr, ppcs_ptr, input_picture_ptr, blk_row, blk_col, ss_x, ss_y);
+            // Perform ME - context_ptr will store the outputs (MVs, buffers, etc)
+            // Block-based MC using open-loop HME + refinement
+            motion_estimate_sb(ppcs_ptr, // source picture control set -> references come from here
+                               (uint32_t)blk_row * blk_cols + blk_col,
+                               (uint32_t)blk_col * BLOCK_SIZE_64, // x block
+                               (uint32_t)blk_row * BLOCK_SIZE_64, // y block
+                               context_ptr,
+                               input_picture_ptr); // source picture
+
+        }
+    }
+    return EB_ErrorNone;
+}
+
+/************************************************************************************
+* Performs the first pass based on open loop data.
+* Source frames are used for Intra and Inter prediction.
+* ME is done per segment but the remaining parts performed per frame.
+************************************************************************************/
+void open_loop_first_pass(PictureParentControlSet *ppcs_ptr,
+                                 MotionEstimationContext_t *me_context_ptr, int32_t segment_index) {
+
+    me_context_ptr->me_context_ptr->min_frame_size = MIN(ppcs_ptr->aligned_height,
+                                                         ppcs_ptr->aligned_width);
+    // Perform the me for the first pass for each segment
+    if (ppcs_ptr->first_pass_ref_count)
+        first_pass_me(ppcs_ptr, me_context_ptr, segment_index);
+    
+    svt_block_on_mutex(ppcs_ptr->first_pass_mutex);
+    ppcs_ptr->first_pass_seg_acc++;
+    if (ppcs_ptr->first_pass_seg_acc == ppcs_ptr->first_pass_seg_total_count) {
+        setup_firstpass_data(ppcs_ptr);
+        // Perform the processing of the frame for each frame after me is done for all blocks
+        first_pass_frame(ppcs_ptr);
+
+        first_pass_frame_end(ppcs_ptr, ppcs_ptr->ts_duration);
+#if LAP_ENABLED_VBR
+        if (ppcs_ptr->end_of_sequence_flag && !ppcs_ptr->scs_ptr->lap_enabled)
+#else
+        if (ppcs_ptr->end_of_sequence_flag)
+#endif
+            svt_av1_end_first_pass(ppcs_ptr);
+        // Signal that the first pass is done
+        svt_post_semaphore(ppcs_ptr->first_pass_done_semaphore);
+    }
+
+    svt_release_mutex(ppcs_ptr->first_pass_mutex);
+}
+#endif

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -2333,7 +2333,7 @@ EbErrorType first_pass_signal_derivation_me_kernel(
 #endif
 
     // Set hme/me based reference pruning level (0-4)
-#if 0 // FIX_FIRST_PASS_HME //anaghdin
+#if FIX_FIRST_PASS_HME && !FIRST_PASS_ME_SETTING
     if (scs_ptr->static_config.enc_mode <= ENC_MR)
         set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
     else if (scs_ptr->static_config.enc_mode <= ENC_M3)
@@ -2664,7 +2664,7 @@ static EbErrorType first_pass_frame(PictureParentControlSet *  ppcs_ptr) {
                 (ppcs_ptr->aligned_height - blk_origin_y) < FORCED_BLK_SIZE
                 ? ppcs_ptr->aligned_height - blk_origin_y
                 : FORCED_BLK_SIZE;
-    
+
             input_origin_index = (input_picture_ptr->origin_y + blk_origin_y) *
                 input_picture_ptr->stride_y +
                 (input_picture_ptr->origin_x + blk_origin_x);
@@ -2826,7 +2826,7 @@ static void first_pass_setup_me_context(MotionEstimationContext_t *context_ptr,
             frame_ptr += sixteenth_pic_ptr->stride_y << 1;
         }
     }
-  
+
 }
 /***************************************************************************
 * Perform the motion estimation for first pass.
@@ -2893,7 +2893,7 @@ void open_loop_first_pass(PictureParentControlSet *ppcs_ptr,
     // Perform the me for the first pass for each segment
     if (ppcs_ptr->first_pass_ref_count)
         first_pass_me(ppcs_ptr, me_context_ptr, segment_index);
-    
+
     svt_block_on_mutex(ppcs_ptr->first_pass_mutex);
     ppcs_ptr->first_pass_seg_acc++;
     if (ppcs_ptr->first_pass_seg_acc == ppcs_ptr->first_pass_seg_total_count) {

--- a/Source/Lib/Encoder/Codec/firstpass.h
+++ b/Source/Lib/Encoder/Codec/firstpass.h
@@ -326,6 +326,7 @@ struct TileDataEnc;
 void svt_av1_twopass_zero_stats(FIRSTPASS_STATS *section);
 void svt_av1_accumulate_stats(FIRSTPASS_STATS *section,
                           const FIRSTPASS_STATS *frame);
+#if !FIRST_PASS_RESTRUCTURE
 struct PictureParentControlSet;
 extern void svt_av1_end_first_pass(struct PictureParentControlSet *pcs_ptr);
 extern void first_pass_frame_end(struct PictureParentControlSet *pcs_ptr, const int64_t ts_duration);
@@ -335,6 +336,7 @@ void accumulate_mv_stats(const MV best_mv, const FULLPEL_MV mv,
     const int mb_row, const int mb_col,
     const int mb_rows, const int mb_cols,
     MV *last_mv, FRAME_STATS *stats);
+#endif
 /*!\endcond */
 
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/Codec/firstpass.h
+++ b/Source/Lib/Encoder/Codec/firstpass.h
@@ -326,7 +326,7 @@ struct TileDataEnc;
 void svt_av1_twopass_zero_stats(FIRSTPASS_STATS *section);
 void svt_av1_accumulate_stats(FIRSTPASS_STATS *section,
                           const FIRSTPASS_STATS *frame);
-#if !FIRST_PASS_RESTRUCTURE
+#if !FEATURE_FIRST_PASS_RESTRUCTURE
 struct PictureParentControlSet;
 extern void svt_av1_end_first_pass(struct PictureParentControlSet *pcs_ptr);
 extern void first_pass_frame_end(struct PictureParentControlSet *pcs_ptr, const int64_t ts_duration);

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -2622,7 +2622,7 @@ void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
   // encoded in the second pass is a guess. However, the sum duration is not.
   // It is calculated based on the actual durations of all frames from the
   // first pass.
-#if FEATURE_LAP_ENABLED_VBR 
+#if FEATURE_LAP_ENABLED_VBR
   svt_av1_new_framerate(scs_ptr, frame_rate);
 #else
   av1_new_framerate(scs_ptr, frame_rate);

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -8,7 +8,15 @@
  * Media Patent License 1.0 was not distributed with this source code in the
  * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
  */
-
+#if VBR_CODE_UPDATE
+ /*!\defgroup gf_group_algo Golden Frame Group
+  * \ingroup high_level_algo
+  * Algorithms regarding determining the length of GF groups and defining GF
+  * group structures.
+  * @{
+  */
+  /*! @} - end defgroup gf_group_algo */
+#endif
 #include <stdint.h>
 
 #include "EbDefinitions.h"
@@ -18,7 +26,9 @@
 #include "firstpass.h"
 #include "EbSequenceControlSet.h"
 #include "EbEntropyCoding.h"
-
+#if LAP_ENABLED_VBR_DEBUG
+#include "EbLog.h"
+#endif
 //#define INT_MAX 0x7fffffff
 
 #define DEFAULT_KF_BOOST 2300
@@ -82,6 +92,24 @@ static int input_stats(TWO_PASS *p, FIRSTPASS_STATS *fps) {
   ++p->stats_in;
   return 1;
 }
+#if LAP_ENABLED_VBR
+static int input_stats_lap(TWO_PASS *p, FIRSTPASS_STATS *fps) {
+    if (p->stats_in >= p->stats_buf_ctx->stats_in_end) return EOF;
+
+    *fps = *p->stats_in; //anaghdin check
+    ///* Move old stats[0] out to accommodate for next frame stats  */
+    //memmove(p->frame_stats_arr[0], p->frame_stats_arr[1],
+    //    (p->stats_buf_ctx->stats_in_end - p->stats_in - 1) *
+    //    sizeof(FIRSTPASS_STATS));
+
+    //p->stats_buf_ctx->stats_in_end--;
+    ++p->stats_in;
+#if 0//LAP_ENABLED_VBR_DEBUG
+    SVT_LOG("stats_in_end--:  %.0f\t%.0f\n", p->stats_in->frame, (p->stats_buf_ctx->stats_in_end-1)->frame);
+#endif
+    return 1;
+}
+#endif
 
 // Read frame stats at an offset from the current position.
 static const FIRSTPASS_STATS *read_frame_stats(const TWO_PASS *p, int offset) {
@@ -191,7 +219,32 @@ static int find_qindex_by_rate_with_correction(
 
 // Bits Per MB at different Q (Multiplied by 512)
 #define BPER_MB_NORMBITS 9
-
+#if VBR_CODE_UPDATE
+/*!\brief Choose a target maximum Q for a group of frames
+ *
+ * \ingroup rate_control
+ *
+ * This function is used to estimate a suitable maximum Q for a
+ * group of frames. Inititally it is called to get a crude estimate
+ * for the whole clip. It is then called for each ARF/GF group to get
+ * a revised estimate for that group.
+ *
+ * \param[in]    cpi                 Top-level encoder structure
+ * \param[in]    av_frame_err        The average per frame coded error score
+ *                                   for frames making up this section/group.
+ * \param[in]    inactive_zone       Used to mask off /ignore part of the
+ *                                   frame. The most common use case is where
+ *                                   a wide format video (e.g. 16:9) is
+ *                                   letter-boxed into a more square format.
+ *                                   Here we want to ignore the bands at the
+ *                                   top and bottom.
+ * \param[in]    av_target_bandwidth The target bits per frame
+ * \param[in]    group_weight_factor A correction factor allowing the algorithm
+ *                                   to correct for errors over time.
+ *
+ * \return The maximum Q for frames in the group.
+ */
+#endif
 static int get_twopass_worst_quality(PictureParentControlSet *pcs_ptr, const double section_err,
                                      double inactive_zone,
                                      int section_target_bandwidth,
@@ -497,7 +550,11 @@ static double calc_kf_frame_boost(const RATE_CONTROL *rc,
   // Update the accumulator for second ref error difference.
   // This is intended to give an indication of how much the coded error is
   // increasing over time.
+#if VBR_CODE_UPDATE //anaghdin added
+  *sr_accumulator += AOMMAX(0.0, (this_frame->sr_coded_error - this_frame->coded_error));
+#else
   *sr_accumulator += (this_frame->sr_coded_error - this_frame->coded_error);
+#endif
   *sr_accumulator = AOMMAX(0.0, *sr_accumulator);
 
   // Q correction and scaling
@@ -643,8 +700,21 @@ static int calculate_section_intra_ratio(const FIRSTPASS_STATS *begin,
 
   return (int)(intra_error / DOUBLE_DIVIDE_CHECK(coded_error));
 }
-
+#if VBR_CODE_UPDATE
 // Calculate the total bits to allocate in this GF/ARF group.
+/*!\brief Calculates the bit target for this GF/ARF group
+ *
+ * \ingroup rate_control
+ *
+ * Calculates the total bits to allocate in this GF/ARF group.
+ *
+ * \param[in]    cpi              Top-level encoder structure
+ * \param[in]    gf_group_err     Cumulative coded error score for the
+ *                                frames making up this group.
+ *
+ * \return The target total number of bits for this GF/ARF group.
+ */
+#endif
 static int64_t calculate_total_gf_group_bits(PictureParentControlSet *pcs_ptr,
                                              double gf_group_err) {
   SequenceControlSet *scs_ptr = pcs_ptr->scs_ptr;
@@ -653,12 +723,12 @@ static int64_t calculate_total_gf_group_bits(PictureParentControlSet *pcs_ptr,
   TWO_PASS *const twopass = &scs_ptr->twopass;
   const int max_bits = frame_max_bits(rc, encode_context_ptr);
   int64_t total_group_bits;
-
+#if !VBR_CODE_UPDATE
   if (scs_ptr->lap_enabled) {
     total_group_bits = rc->avg_frame_bandwidth * rc->baseline_gf_interval;
     return total_group_bits;
   }
-
+#endif
   // Calculate the bits to be allocated to the group as a whole.
   if ((twopass->kf_group_bits > 0) && (twopass->kf_group_error_left > 0)) {
     total_group_bits = (int64_t)(twopass->kf_group_bits *
@@ -825,7 +895,16 @@ static void impose_gf_length(PictureParentControlSet *pcs_ptr, int max_intervals
     EncodeContext *     encode_context_ptr = scs_ptr->encode_context_ptr;
     RATE_CONTROL *const rc                 = &encode_context_ptr->rc;
     int                 i                  = 0;
+#if LAP_ENABLED_VBR_TUNE
+    max_intervals = scs_ptr->lap_enabled
+        ? scs_ptr->static_config.hierarchical_levels != pcs_ptr->hierarchical_levels ? 2 : 1
+        : max_intervals;
+    if (scs_ptr->lap_enabled && scs_ptr->static_config.hierarchical_levels != pcs_ptr->hierarchical_levels)
+        rc->frames_to_key = (int)(scs_ptr->twopass.stats_buf_ctx->total_stats->count -
+            pcs_ptr->picture_number + (1<< pcs_ptr->hierarchical_levels));
+#else
     max_intervals                          = scs_ptr->lap_enabled ? 1 : max_intervals;
+#endif
     int cut_pos[MAX_NUM_GF_INTERVALS + 1]  = {0};
     int count_cuts                         = 1;
     int cur_last;
@@ -846,8 +925,14 @@ static void impose_gf_length(PictureParentControlSet *pcs_ptr, int max_intervals
         // To cut based on PD decisions, only supports 5L for now
 #if FIX_2PASS_VBR_4L_SUPPORT
         cut_here =
+#if LAP_ENABLED_VBR_TUNE
+        ((i % gf_interval == 0) || 
+         ((((rc->frames_to_key - cut_pos[count_cuts - 1]) < gf_interval) || (scs_ptr->lap_enabled && scs_ptr->static_config.hierarchical_levels != pcs_ptr->hierarchical_levels)) && (i % (gf_interval >> 1) == 0)))
+            ? 1 : 0;
+#else
             ((i % gf_interval == 0) || ((rc->frames_to_key - cut_pos[count_cuts - 1]) < gf_interval && (i % (gf_interval>>1) == 0)))
                 ? 1 : 0;
+#endif
 #else
         cut_here =
             ((i % 16 == 0) || ((rc->frames_to_key - cut_pos[count_cuts - 1]) < 16 && (i % 8 == 0)))
@@ -1094,6 +1179,23 @@ static void av1_gop_bit_allocation(RATE_CONTROL *const rc,
 int frame_is_kf_gf_arf(PictureParentControlSet *ppcs_ptr);
 // Analyse and define a gf/arf group.
 #define MAX_GF_BOOST 5400
+#if VBR_CODE_UPDATE
+/*!\brief Define a GF group.
+ *
+ * \ingroup gf_group_algo
+ * This function defines the structure of a GF group, along with various
+ * parameters regarding bit-allocation and quality setup.
+ *
+ * \param[in]    cpi             Top-level encoder structure
+ * \param[in]    this_frame      First pass statistics structure
+ * \param[in]    frame_params    Structure with frame parameters
+ * \param[in]    max_gop_length  Maximum length of the GF group
+ * \param[in]    is_final_pass   Whether this is the final pass for the
+ *                               GF group, or a trial (non-zero)
+ *
+ * \return Nothing is returned. Instead, encode_context_ptr->gf_group is changed.
+ */
+#endif
 static void define_gf_group(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS *this_frame,
                             const EncodeFrameParams *const frame_params,
                             int max_gop_length, int is_final_pass) {
@@ -1293,7 +1395,14 @@ static void define_gf_group(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS *t
 
   // Reset the file position.
   reset_fpf_position(twopass, start_pos);
-
+#if VBR_CODE_UPDATE
+  if (scs_ptr->lap_enabled) {
+      // Since we don't have enough stats to know the actual error of the
+      // gf group, we assume error of each frame to be equal to 1 and set
+      // the error of the group as baseline_gf_interval.
+      gf_stats.gf_group_err = rc->baseline_gf_interval;
+  }
+#endif
   // Calculate the bits to be allocated to the gf/arf group as a whole
   gf_group_bits = calculate_total_gf_group_bits(pcs_ptr, gf_stats.gf_group_err);
   rc->gf_group_bits = gf_group_bits;
@@ -1580,7 +1689,20 @@ static int get_projected_kf_boost(RATE_CONTROL *const rc) {
       (int)rint((tpl_factor * rc->kf_boost) / tpl_factor_num_stats);
   return projected_kf_boost;
 }
-
+#if VBR_CODE_UPDATE
+/*!\brief Determine the location of the next key frame
+ *
+ * \ingroup gf_group_algo
+ * This function decides the placement of the next key frame when a
+ * scenecut is detected or the maximum key frame distance is reached.
+ *
+ * \param[in]    this_frame       Pointer to first pass stats
+ * \param[out]   kf_group_err     The total error in the KF group
+ * \param[in]    num_frames_to_detect_scenecut Maximum lookahead frames.
+ *
+ * \return       Number of frames to the next key.
+ */
+#endif
 static int define_kf_interval(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS *this_frame,
                               double *kf_group_err,
                               int num_frames_to_detect_scenecut) {
@@ -1616,6 +1738,9 @@ static int define_kf_interval(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS 
   for (j = 0; j < FRAMES_TO_CHECK_DECAY; ++j) recent_loop_decay[j] = 1.0;
 
   while (twopass->stats_in < twopass->stats_buf_ctx->stats_in_end &&
+#if  LAP_LIMITED_STAT
+      num_stats_used_for_kf_boost < 23 &&
+#endif
          frames_to_key < num_frames_to_detect_scenecut) {
     int i = 0;
     // Accumulate total number of stats available till next key frame
@@ -1694,7 +1819,24 @@ static int define_kf_interval(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS 
 
   return frames_to_key;
 }
+#if LAP_ENABLED_VBR
+static int64_t get_kf_group_bits(PictureParentControlSet *pcs_ptr, double kf_group_err/*,
+                                 double kf_group_avg_error*/) {
+    SequenceControlSet *scs_ptr = pcs_ptr->scs_ptr;
+    EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
+    RATE_CONTROL *const rc = &encode_context_ptr->rc;
+    TWO_PASS *const twopass = &scs_ptr->twopass;
+    int64_t kf_group_bits;
 
+    if (scs_ptr->lap_enabled)
+        kf_group_bits = (int64_t)rc->frames_to_key * rc->avg_frame_bandwidth;
+    else
+        kf_group_bits = (int64_t)(twopass->bits_left *
+            (kf_group_err / twopass->modified_error_left));
+
+    return kf_group_bits;
+}
+#else
 static int64_t get_kf_group_bits(PictureParentControlSet *pcs_ptr, double kf_group_err/*,
                                  double kf_group_avg_error*/) {
   SequenceControlSet *scs_ptr = pcs_ptr->scs_ptr;
@@ -1710,7 +1852,7 @@ static int64_t get_kf_group_bits(PictureParentControlSet *pcs_ptr, double kf_gro
 
   return kf_group_bits;
 }
-
+#endif
 static int calc_avg_stats(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS *avg_frame_stat) {
   SequenceControlSet *scs_ptr = pcs_ptr->scs_ptr;
   EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
@@ -1812,6 +1954,9 @@ static double get_kf_boost_score(PictureParentControlSet *pcs_ptr, double kf_raw
   }
   return boost_score;
 }
+#if VBR_CODE_UPDATE
+#define MAX_KF_BITS_INTERVAL_SINGLE_PASS 5
+#endif
 // This function imposes the key frames based on the intra refresh period
 //anaghdin only works for key frames, and scene change is not detected for now
 static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STATS *this_frame) {
@@ -1856,7 +2001,12 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
     double kf_group_err = 0.0;
     double sr_accumulator = 0.0;
     //double kf_group_avg_error = 0.0;
+#if VBR_CODE_UPDATE
+    int frames_to_key, frames_to_key_clipped = INT_MAX;
+    int64_t kf_group_bits_clipped = INT64_MAX;
+#else
     int frames_to_key;
+#endif
     // Is this a forced key frame by interval.
     rc->this_key_frame_forced = rc->next_key_frame_forced;
 
@@ -1873,7 +2023,7 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
         rc->frames_to_key = AOMMIN(kf_cfg->key_freq_max, frames_to_key);
     else
         rc->frames_to_key = kf_cfg->key_freq_max;
-
+    //anaghdin
     //if (scs_ptr->lap_enabled) correct_frames_to_key(cpi);
 
     // If there is a max kf interval set by the user we must obey it.
@@ -1938,7 +2088,23 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
         twopass->kf_group_bits = 0;
     }
     twopass->kf_group_bits = AOMMAX(0, twopass->kf_group_bits);
+#if VBR_CODE_UPDATE
+    if (scs_ptr->lap_enabled) {
+        // In the case of single pass based on LAP, frames to  key may have an
+        // inaccurate value, and hence should be clipped to an appropriate
+        // interval.
+        frames_to_key_clipped =
+            (int)(MAX_KF_BITS_INTERVAL_SINGLE_PASS * scs_ptr->double_frame_rate);
 
+        // This variable calculates the bits allocated to kf_group with a clipped
+        // frames_to_key.
+        if (rc->frames_to_key > frames_to_key_clipped) {
+            kf_group_bits_clipped =
+                (int64_t)((double)twopass->kf_group_bits * frames_to_key_clipped /
+                    rc->frames_to_key);
+        }
+    }
+#endif
     // Reset the first pass file position.
     reset_fpf_position(twopass, start_position);
 
@@ -1985,9 +2151,17 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
     }
 
     // Work out how many bits to allocate for the key frame itself.
+#if VBR_CODE_UPDATE
+  // In case of LAP enabled for VBR, if the frames_to_key value is
+  // very high, we calculate the bits based on a clipped value of
+  // frames_to_key.
+    kf_bits = calculate_boost_bits(
+        AOMMIN(rc->frames_to_key, frames_to_key_clipped) - 1, rc->kf_boost,
+        AOMMIN(twopass->kf_group_bits, kf_group_bits_clipped));
+#else
     kf_bits = calculate_boost_bits((rc->frames_to_key - 1), rc->kf_boost,
         twopass->kf_group_bits);
-
+#endif
     twopass->kf_group_bits -= kf_bits;
 
     // Save the bits to spend on the key frame.
@@ -1995,7 +2169,17 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
     gf_group->update_type[0] = KF_UPDATE;
 
     // Note the total error score of the kf group minus the key frame itself.
+#if VBR_CODE_UPDATE
+    if (scs_ptr->lap_enabled)
+        // As we don't have enough stats to know the actual error of the group,
+        // we assume the complexity of each frame to be equal to 1, and set the
+        // error as the number of frames in the group(minus the keyframe).
+        twopass->kf_group_error_left = (int)(rc->frames_to_key - 1);
+    else
+        twopass->kf_group_error_left = (int)(kf_group_err - kf_mod_err);
+#else
     twopass->kf_group_error_left = (int)(kf_group_err - kf_mod_err);
+#endif
 
     // Adjust the count of total modified error left.
     // The count of bits left is adjusted elsewhere based on real coded frame
@@ -2073,7 +2257,9 @@ static void process_first_pass_stats(PictureParentControlSet *pcs_ptr,
 
   int err = 0;
   if (scs_ptr->lap_enabled) {
-    //err = input_stats_lap(twopass, this_frame);
+#if LAP_ENABLED_VBR
+    err = input_stats_lap(twopass, this_frame);
+#endif
   } else {
     err = input_stats(twopass, this_frame);
   }
@@ -2314,12 +2500,85 @@ static void av1_rc_update_framerate(SequenceControlSet *scs_ptr/*, int width, in
 }
 
 // from aom encoder.c
+#if LAP_ENABLED_VBR
+void av1_new_framerate(SequenceControlSet *scs_ptr, double framerate) {
+#else
 static void av1_new_framerate(SequenceControlSet *scs_ptr, double framerate) {
+#endif
   //cpi->framerate = framerate < 0.1 ? 30 : framerate;
   scs_ptr->double_frame_rate = framerate < 0.1 ? 30 : framerate;
   av1_rc_update_framerate(scs_ptr/*, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height*/);
 }
+#if LAP_ENABLED_VBR
+void set_rc_param(SequenceControlSet *scs_ptr) {
+    EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
+    FrameInfo *frame_info = &encode_context_ptr->frame_info;
 
+    const int is_vbr = scs_ptr->static_config.rate_control_mode == 1;
+    frame_info->frame_width = scs_ptr->seq_header.max_frame_width;
+    frame_info->frame_height = scs_ptr->seq_header.max_frame_height;
+    frame_info->mb_cols = (scs_ptr->seq_header.max_frame_width + 16 - 1) / 16;
+    frame_info->mb_rows = (scs_ptr->seq_header.max_frame_height + 16 - 1) / 16;
+    frame_info->num_mbs = frame_info->mb_cols * frame_info->mb_rows;
+    frame_info->bit_depth = scs_ptr->static_config.encoder_bit_depth;
+    // input config  from options
+    encode_context_ptr->two_pass_cfg.vbrmin_section = scs_ptr->static_config.vbr_min_section_pct;
+    encode_context_ptr->two_pass_cfg.vbrmax_section = scs_ptr->static_config.vbr_max_section_pct;
+    encode_context_ptr->two_pass_cfg.vbrbias = scs_ptr->static_config.vbr_bias_pct;
+    encode_context_ptr->rc_cfg.mode = scs_ptr->static_config.rate_control_mode == 1 ? AOM_VBR : AOM_Q;
+    encode_context_ptr->rc_cfg.best_allowed_q = (int32_t)quantizer_to_qindex[scs_ptr->static_config.min_qp_allowed];
+    encode_context_ptr->rc_cfg.worst_allowed_q = (int32_t)quantizer_to_qindex[scs_ptr->static_config.max_qp_allowed];
+    encode_context_ptr->rc_cfg.over_shoot_pct = scs_ptr->static_config.over_shoot_pct;
+    encode_context_ptr->rc_cfg.under_shoot_pct = scs_ptr->static_config.under_shoot_pct;
+    encode_context_ptr->rc_cfg.cq_level = quantizer_to_qindex[scs_ptr->static_config.qp];
+    encode_context_ptr->rc_cfg.maximum_buffer_size_ms = is_vbr ? 240000 : 6000;//cfg->rc_buf_sz;
+    encode_context_ptr->rc_cfg.starting_buffer_level_ms = is_vbr ? 60000 : 4000;//cfg->rc_buf_initial_sz;
+    encode_context_ptr->rc_cfg.optimal_buffer_level_ms = is_vbr ? 60000 : 5000;//cfg->rc_buf_optimal_sz;
+    encode_context_ptr->gf_cfg.lag_in_frames = 25;//hack scs_ptr->static_config.look_ahead_distance + 1;
+    encode_context_ptr->gf_cfg.gf_min_pyr_height = scs_ptr->static_config.hierarchical_levels;
+    encode_context_ptr->gf_cfg.gf_max_pyr_height = scs_ptr->static_config.hierarchical_levels;
+    encode_context_ptr->gf_cfg.min_gf_interval = 1 << scs_ptr->static_config.hierarchical_levels;
+    encode_context_ptr->gf_cfg.max_gf_interval = 1 << scs_ptr->static_config.hierarchical_levels;
+    encode_context_ptr->gf_cfg.enable_auto_arf = 1;
+    encode_context_ptr->kf_cfg.sframe_dist = 0; // not supported yet
+    encode_context_ptr->kf_cfg.sframe_mode = 0; // not supported yet
+    encode_context_ptr->kf_cfg.auto_key = 0;
+    encode_context_ptr->kf_cfg.key_freq_max = scs_ptr->intra_period_length + 1;
+}
+
+void svt_av1_init_single_pass_lap(SequenceControlSet *scs_ptr) {
+    TWO_PASS *const twopass = &scs_ptr->twopass;
+    EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
+    if (!twopass->stats_buf_ctx->stats_in_end) return;
+
+    set_rc_param(scs_ptr);
+
+    // This variable monitors how far behind the second ref update is lagging.
+    twopass->sr_update_lag = 1;
+
+    twopass->bits_left = 0;
+    twopass->modified_error_min = 0.0;
+    twopass->modified_error_max = 0.0;
+    twopass->modified_error_left = 0.0;
+
+    // Reset the vbr bits off target counters
+    encode_context_ptr->rc.vbr_bits_off_target = 0;
+    encode_context_ptr->rc.vbr_bits_off_target_fast = 0;
+
+    encode_context_ptr->rc.rate_error_estimate = 0;
+
+    // Static sequence monitor variables.
+    twopass->kf_zeromotion_pct = 100;
+    twopass->last_kfgroup_zeromotion_pct = 100;
+
+    // Initialize bits per macro_block estimate correction factor.
+    twopass->bpm_factor = 1.0;
+    // Initialize actual and target bits counters for ARF groups so that
+    // at the start we have a neutral bpm adjustment.
+    twopass->rolling_arf_group_target_bits = 1;
+    twopass->rolling_arf_group_actual_bits = 1;
+}
+#endif
 void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
   TWO_PASS *const twopass = &scs_ptr->twopass;
   EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
@@ -2329,7 +2588,9 @@ void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
   FIRSTPASS_STATS *stats;
 
   if (!twopass->stats_buf_ctx->stats_in_end) return;
-
+#if LAP_ENABLED_VBR
+  set_rc_param(scs_ptr);
+#else
   {
       const int is_vbr = scs_ptr->static_config.rate_control_mode == 1;
       frame_info->frame_width  = scs_ptr->seq_header.max_frame_width;
@@ -2362,7 +2623,7 @@ void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
       encode_context_ptr->kf_cfg.auto_key      = 0;
       encode_context_ptr->kf_cfg.key_freq_max  = scs_ptr->intra_period_length + 1;
   }
-
+#endif
   stats = twopass->stats_buf_ctx->total_stats;
 
   *stats = *twopass->stats_buf_ctx->stats_in_end;

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -2488,7 +2488,7 @@ static void av1_rc_update_framerate(SequenceControlSet *scs_ptr/*, int width, in
 
 // from aom encoder.c
 #if FEATURE_LAP_ENABLED_VBR
-void av1_new_framerate(SequenceControlSet *scs_ptr, double framerate) {
+void svt_av1_new_framerate(SequenceControlSet *scs_ptr, double framerate) {
 #else
 static void av1_new_framerate(SequenceControlSet *scs_ptr, double framerate) {
 #endif
@@ -2622,7 +2622,11 @@ void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
   // encoded in the second pass is a guess. However, the sum duration is not.
   // It is calculated based on the actual durations of all frames from the
   // first pass.
+#if FEATURE_LAP_ENABLED_VBR 
+  svt_av1_new_framerate(scs_ptr, frame_rate);
+#else
   av1_new_framerate(scs_ptr, frame_rate);
+#endif
   twopass->bits_left =
       (int64_t)(stats->duration * (int64_t)scs_ptr->static_config.target_bit_rate / 10000000.0);
 

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -926,7 +926,7 @@ static void impose_gf_length(PictureParentControlSet *pcs_ptr, int max_intervals
 #if FIX_2PASS_VBR_4L_SUPPORT
         cut_here =
 #if LAP_ENABLED_VBR_TUNE
-        ((i % gf_interval == 0) || 
+        ((i % gf_interval == 0) ||
          ((((rc->frames_to_key - cut_pos[count_cuts - 1]) < gf_interval) || (scs_ptr->lap_enabled && scs_ptr->static_config.hierarchical_levels != pcs_ptr->hierarchical_levels)) && (i % (gf_interval >> 1) == 0)))
             ? 1 : 0;
 #else

--- a/Source/Lib/Encoder/Codec/pass2_strategy.h
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.h
@@ -57,7 +57,7 @@ typedef struct {
 void svt_av1_init_second_pass(struct SequenceControlSet *scs_ptr);
 #if FEATURE_LAP_ENABLED_VBR
 void svt_av1_init_single_pass_lap(struct SequenceControlSet *scs_ptr);
-void av1_new_framerate(struct SequenceControlSet *scs_ptr, double framerate);
+void svt_av1_new_framerate(struct SequenceControlSet *scs_ptr, double framerate);
 #else
 void av1_init_single_pass_lap(AV1_COMP *cpi);
 #endif

--- a/Source/Lib/Encoder/Codec/pass2_strategy.h
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.h
@@ -55,7 +55,7 @@ typedef struct {
 } GF_FRAME_STATS;
 
 void svt_av1_init_second_pass(struct SequenceControlSet *scs_ptr);
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
 void svt_av1_init_single_pass_lap(struct SequenceControlSet *scs_ptr);
 void av1_new_framerate(struct SequenceControlSet *scs_ptr, double framerate);
 #else

--- a/Source/Lib/Encoder/Codec/pass2_strategy.h
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.h
@@ -55,8 +55,12 @@ typedef struct {
 } GF_FRAME_STATS;
 
 void svt_av1_init_second_pass(struct SequenceControlSet *scs_ptr);
-
+#if LAP_ENABLED_VBR
+void svt_av1_init_single_pass_lap(struct SequenceControlSet *scs_ptr);
+void av1_new_framerate(struct SequenceControlSet *scs_ptr, double framerate);
+#else
 void av1_init_single_pass_lap(AV1_COMP *cpi);
+#endif
 
 void svt_av1_get_second_pass_params(struct PictureParentControlSet *pcs_ptr);
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2272,7 +2272,11 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     }
 #if FEATURE_RE_ENCODE
     if (scs_ptr->static_config.recode_loop > 0 &&
+#if LAP_ENABLED_VBR
+        (scs_ptr->static_config.rate_control_mode != 1)) {
+#else
         (!use_input_stat(scs_ptr) || scs_ptr->static_config.rate_control_mode != 1)) {
+#endif
         // Only allow re-encoding for 2pass VBR, otherwise force recode_loop to DISALLOW_RECODE or 0
         scs_ptr->static_config.recode_loop = DISALLOW_RECODE;
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2612,7 +2612,7 @@ void copy_api_from_app(
     scs_ptr->static_config.enable_tpl_la = ((EbSvtAv1EncConfiguration*)config_struct)->enable_tpl_la;
 #if FEATURE_LAP_ENABLED_VBR
     if (scs_ptr->static_config.rate_control_mode && !scs_ptr->lap_enabled && scs_ptr->static_config.enable_tpl_la) {
-        SVT_LOG("SVT [Warning]: force enable_tpl_la to be 0. Not supported for 1 PASS RC \n", );
+        SVT_LOG("SVT [Warning]: force enable_tpl_la to be 0. Not supported for 1 PASS RC \n");
         scs_ptr->static_config.enable_tpl_la = 0;
     }
 #endif

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2624,7 +2624,7 @@ void copy_api_from_app(
         scs_ptr->static_config.look_ahead_distance != (uint32_t)TPL_LAD &&
         scs_ptr->static_config.rate_control_mode == 0) {
 #endif
-    
+
         SVT_LOG("SVT [Warning]: force look_ahead_distance to be %d from %d for perf/quality tradeoff when enable_tpl_la=1\n", (uint32_t)TPL_LAD, scs_ptr->static_config.look_ahead_distance);
         scs_ptr->static_config.look_ahead_distance = TPL_LAD;
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2272,7 +2272,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     }
 #if FEATURE_RE_ENCODE
     if (scs_ptr->static_config.recode_loop > 0 &&
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         (scs_ptr->static_config.rate_control_mode != 1)) {
 #else
         (!use_input_stat(scs_ptr) || scs_ptr->static_config.rate_control_mode != 1)) {
@@ -2293,7 +2293,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     else
         scs_ptr->static_config.super_block_size = (scs_ptr->static_config.enc_mode <= ENC_M4) ? 128 : 64;
 #if FIX_ALLOW_SB128_2PASS_VBR
-#if !LAP_ENABLED_VBR
+#if !FEATURE_LAP_ENABLED_VBR
     scs_ptr->static_config.super_block_size = (scs_ptr->static_config.rate_control_mode > 0 && !use_input_stat(scs_ptr))
                                               ? 64
                                               : scs_ptr->static_config.super_block_size;
@@ -2379,7 +2379,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     if (scs_ptr->static_config.encoder_bit_depth < 10)
         scs_ptr->static_config.enable_hbd_mode_decision = 0;
 
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
     if (scs_ptr->static_config.rate_control_mode && !use_output_stat(scs_ptr) && !use_input_stat(scs_ptr))
         scs_ptr->lap_enabled = 1;
     else
@@ -2609,20 +2609,20 @@ void copy_api_from_app(
     // Get Default Intra Period if not specified
     if (scs_ptr->static_config.intra_period_length == -2)
         scs_ptr->intra_period_length = scs_ptr->static_config.intra_period_length = compute_default_intra_period(scs_ptr);
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
     else if (scs_ptr->static_config.intra_period_length == -1 && (use_input_stat(scs_ptr) || use_output_stat(scs_ptr) || scs_ptr->lap_enabled))
 #else
     else if (scs_ptr->static_config.intra_period_length == -1 && (use_input_stat(scs_ptr) || use_output_stat(scs_ptr)))
 #endif
 
         scs_ptr->intra_period_length = (MAX_NUM_GF_INTERVALS-1)* (1 << (scs_ptr->static_config.hierarchical_levels));
-    if (scs_ptr->static_config.look_ahead_distance == (uint32_t)~0) //LAP_ENABLED_VBR anaghdin check these functions
+    if (scs_ptr->static_config.look_ahead_distance == (uint32_t)~0) //FEATURE_LAP_ENABLED_VBR anaghdin check these functions
         scs_ptr->static_config.look_ahead_distance = compute_default_look_ahead(&scs_ptr->static_config);
     else
         scs_ptr->static_config.look_ahead_distance = cap_look_ahead_distance(&scs_ptr->static_config);
     if (scs_ptr->static_config.enable_tpl_la &&
         scs_ptr->static_config.look_ahead_distance > (uint32_t)0 &&
-#if LAP_ENABLED_VBR
+#if FEATURE_LAP_ENABLED_VBR
         scs_ptr->static_config.look_ahead_distance != (uint32_t)TPL_LAD) {
 #else
         scs_ptr->static_config.look_ahead_distance != (uint32_t)TPL_LAD &&

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2278,7 +2278,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
 #if FEATURE_RE_ENCODE
     if (scs_ptr->static_config.recode_loop > 0 &&
 #if FEATURE_LAP_ENABLED_VBR
-        (!scs_ptr->static_config.rate_control_mode || !scs_ptr->lap_enabled)) {
+        (!scs_ptr->static_config.rate_control_mode || (!scs_ptr->lap_enabled && !use_input_stat(scs_ptr)))) {
         // Only allow re-encoding for 2pass VBR or 1 PASS LAP, otherwise force recode_loop to DISALLOW_RECODE or 0
 #else
         (!use_input_stat(scs_ptr) || scs_ptr->static_config.rate_control_mode != 1)) {
@@ -2611,7 +2611,8 @@ void copy_api_from_app(
     scs_ptr->static_config.recon_enabled = ((EbSvtAv1EncConfiguration*)config_struct)->recon_enabled;
     scs_ptr->static_config.enable_tpl_la = ((EbSvtAv1EncConfiguration*)config_struct)->enable_tpl_la;
 #if FEATURE_LAP_ENABLED_VBR
-    if (scs_ptr->static_config.rate_control_mode && !scs_ptr->lap_enabled && scs_ptr->static_config.enable_tpl_la) {
+    if (scs_ptr->static_config.rate_control_mode && !use_input_stat(scs_ptr) && !use_output_stat(scs_ptr) &&
+        !scs_ptr->lap_enabled && scs_ptr->static_config.enable_tpl_la) {
         SVT_LOG("SVT [Warning]: force enable_tpl_la to be 0. Not supported for 1 PASS RC \n");
         scs_ptr->static_config.enable_tpl_la = 0;
     }


### PR DESCRIPTION
# Description
The first pass encoding is restructured and moved to PictureDecisionProcess. Both ME and Intra are performed on source pixels.
This commit improves the performance of 2 Pass VBR. Also, the support for adding a new 1 Pass VBR is added.

# Issue

# Author(s)
@anaghdin 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x ] other google low res
- [ ] N/A


svt-av1 |   | svt-av1 | AVG PSNR/SSIM/3*yPSNR | Speed Dev
-- | -- | -- | -- | --
2PASS_VBR_NEW_M2 | vs. | 2PASS_VBR_REF_M2 | -0.33% | -1.24%
2PASS_VBR_NEW_M4 | vs. | 2PASS_VBR_REF_M4 | -0.37% | -0.81%
2PASS_VBR_NEW_M6 | vs. | 2PASS_VBR_REF_M6 | -0.18% | 1.04%
2PASS_VBR_NEW_M7 | vs. | 2PASS_VBR_REF_M7 | -0.20% | 3.18%



# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
