### PR TITLE
CMake: add -mno-avx if -march=native is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,14 @@ foreach(flag ${flags_to_test};${release_flags_to_test};${debug_flags_to_test})
     endif()
 endforeach()
 
+if(CMAKE_C_FLAGS MATCHES ".*-march=native.*")
+    string(APPEND CMAKE_C_FLAGS " -mno-avx")
+endif()
+
+if(CMAKE_CXX_FLAGS MATCHES ".*-march=native.*")
+    string(APPEND CMAKE_CXX_FLAGS " -mno-avx")
+endif()
+
 if(CMAKE_ASM_NASM_OBJECT_FORMAT MATCHES "win")
     set(CMAKE_ASM_NASM_FLAGS_DEBUG "${CMAKE_ASM_NASM_FLAGS_DEBUG} -gcv8")
 elseif(CMAKE_ASM_NASM_COMPILER MATCHES "nasm")


### PR DESCRIPTION
# Description

-march=native can activate -mavx on certain archs that can cause segfaults
on random lines of code

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
