### PR TITLE
fix building on non-x86 platforms

### DIFF
--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -245,12 +245,11 @@ CPU_FLAGS get_cpu_flags_to_use() {
 
 
 void setup_common_rtcd_internal(CPU_FLAGS flags) {
-#ifdef ARCH_X86_64
     /* Avoid check that pointer is set double, after first  setup. */
-    static EbBool first_call_setup = EB_TRUE;
-    EbBool check_pointer_was_set = first_call_setup;
-    first_call_setup = EB_FALSE;
-
+    static EbBool first_call_setup      = EB_TRUE;
+    EbBool        check_pointer_was_set = first_call_setup;
+    first_call_setup                    = EB_FALSE;
+#ifdef ARCH_X86_64
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */
     flags &= get_cpu_flags_to_use();

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -75,15 +75,12 @@
 #define SET_AVX2(ptr, c, avx2)                              SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, 0)
 #define SET_AVX2_AVX512(ptr, c, avx2, avx512)               SET_FUNCTIONS(ptr, c, 0, 0, 0, 0, 0, 0, 0, 0, avx2, avx512)
 
-
 void setup_rtcd_internal(CPU_FLAGS flags) {
-
-#ifdef ARCH_X86_64
     /* Avoid check that pointer is set double, after first  setup. */
-    static EbBool first_call_setup = EB_TRUE;
-    EbBool check_pointer_was_set = first_call_setup;
-    first_call_setup = EB_FALSE;
-
+    static EbBool first_call_setup      = EB_TRUE;
+    EbBool        check_pointer_was_set = first_call_setup;
+    first_call_setup                    = EB_FALSE;
+#ifdef ARCH_X86_64
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */
     flags &= get_cpu_flags_to_use();
@@ -390,5 +387,4 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
     SET_AVX2(svt_av1_calc_indices_dim2, svt_av1_calc_indices_dim2_c, svt_av1_calc_indices_dim2_avx2);
     SET_AVX2(variance_highbd, variance_highbd_c, variance_highbd_avx2);
     SET_AVX2(svt_av1_haar_ac_sad_8x8_uint8_input, svt_av1_haar_ac_sad_8x8_uint8_input_c, svt_av1_haar_ac_sad_8x8_uint8_input_avx2);
-
 }


### PR DESCRIPTION
# Description

to confirm locally,
```bash
sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
./Build/linux/build.sh -t https://github.com/m-ab-s/aom/raw/master/build/cmake/toolchains/arm64-linux-gcc.cmake
```

```c
../../../Source/Lib/Common/Codec/common_dsp_rtcd.c: In function ‘setup_common_rtcd_internal’:
../../../Source/Lib/Common/Codec/common_dsp_rtcd.c:221:13: error: ‘check_pointer_was_set’ undeclared (first use in this function)
  221 |         if (check_pointer_was_set && ptr != 0) {                                                                           \
      |             ^~~~~~~~~~~~~~~~~~~~~
```


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
