### PR TITLE
Fix issue with encoding using user defined prediction structure config

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3236,8 +3236,6 @@ static EbErrorType av1_generate_rps_info_from_user_config(
                 ref_poc = picture_control_set_ptr->picture_number;
             }
 
-            if (picture_control_set_ptr->is_overlay)
-                ref_poc -= pred_position_ptr->ref_list0.reference_list[ref_idx - LAST];
             dpb_list_idx = 0;
             do {
                 if (dpb_list_ptr[dpb_list_idx].is_used == EB_TRUE &&

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3231,7 +3231,7 @@ static EbErrorType av1_generate_rps_info_from_user_config(
         (picture_control_set_ptr->slice_type == B_SLICE)) {
         uint8_t ref_idx = 0;
         for (ref_idx = LAST; ref_idx < LAST + picture_control_set_ptr->ref_list0_count; ++ref_idx) {
-            uint64_t ref_poc = ref_poc = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list0.reference_list[ref_idx-LAST];
+            uint64_t ref_poc = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list0.reference_list[ref_idx-LAST];
             if (picture_control_set_ptr->is_overlay) {
                 ref_poc = picture_control_set_ptr->picture_number;
             }

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3231,7 +3231,11 @@ static EbErrorType av1_generate_rps_info_from_user_config(
         (picture_control_set_ptr->slice_type == B_SLICE)) {
         uint8_t ref_idx = 0;
         for (ref_idx = LAST; ref_idx < LAST + picture_control_set_ptr->ref_list0_count; ++ref_idx) {
-            uint64_t ref_poc = picture_control_set_ptr->picture_number;
+            uint64_t ref_poc = ref_poc = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list0.reference_list[ref_idx-LAST];
+            if (picture_control_set_ptr->is_overlay) {
+                ref_poc = picture_control_set_ptr->picture_number;
+            }
+
             if (picture_control_set_ptr->is_overlay)
                 ref_poc -= pred_position_ptr->ref_list0.reference_list[ref_idx - LAST];
             dpb_list_idx = 0;


### PR DESCRIPTION
# Description
Encoding using user defined custom prediction structure was not working. The small bug fix resolves this issue

The issue seems to have crept in at commit id: a0f233f6ba5d173fc8e258ded045fb0d75074747 
(suggest adding a test for the user defined config to avoid such issues in the future) 

# Issue

Fixes #1567 

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@kedartatwawadi 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
