### PR TITLE
Fix issue with hang-up on VBR encoding with specific conditions

### DIFF
--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -1953,15 +1953,16 @@ void high_level_rc_input_picture_vbr(PictureParentControlSet *pcs_ptr, SequenceC
                     queue_entry_index_temp++;
                 }
 
-                if (min_la_bit_distance >=
-                    (uint64_t)ABS((int64_t)high_level_rate_control_ptr
-                                      ->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                                  (int64_t)bit_constraint_per_sw)) {
-                    min_la_bit_distance = (uint64_t)ABS(
-                        (int64_t)
-                            high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                        (int64_t)bit_constraint_per_sw);
-                    selected_ref_qp = ref_qp_index;
+                const uint64_t la_bit_distance_temp = (uint64_t)ABS(
+                    (int64_t)high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
+                    (int64_t)bit_constraint_per_sw);
+                if (min_la_bit_distance >= la_bit_distance_temp) {
+                    if (min_la_bit_distance == la_bit_distance_temp &&
+                        ref_qp_index < selected_ref_qp) {
+                        best_qp_found = EB_TRUE;
+                    }
+                    min_la_bit_distance = la_bit_distance_temp;
+                    selected_ref_qp     = ref_qp_index;
                 } else
                     best_qp_found = EB_TRUE;
                 const int32_t qp_step = ref_qp_table_index == previous_selected_ref_qp
@@ -1970,7 +1971,7 @@ void high_level_rc_input_picture_vbr(PictureParentControlSet *pcs_ptr, SequenceC
                         ? +1
                         : -1
                     : 1;
-                ref_qp_table_index    = (uint32_t)(ref_qp_table_index + qp_step);
+                ref_qp_table_index = (uint32_t)(ref_qp_table_index + qp_step);
             }
         }
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -1958,9 +1958,8 @@ void high_level_rc_input_picture_vbr(PictureParentControlSet *pcs_ptr, SequenceC
                     (int64_t)bit_constraint_per_sw);
                 if (min_la_bit_distance >= la_bit_distance_temp) {
                     if (min_la_bit_distance == la_bit_distance_temp &&
-                        ref_qp_index < selected_ref_qp) {
+                        ref_qp_index < selected_ref_qp)
                         best_qp_found = EB_TRUE;
-                    }
                     min_la_bit_distance = la_bit_distance_temp;
                     selected_ref_qp     = ref_qp_index;
                 } else
@@ -3482,15 +3481,15 @@ void high_level_rc_input_picture_cvbr(PictureParentControlSet *pcs_ptr, Sequence
                         queue_entry_index_temp++;
                     }
 
-                    if (min_la_bit_distance >=
-                        (uint64_t)ABS((int64_t)high_level_rate_control_ptr
-                                          ->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                                      (int64_t)bit_constraint_per_sw)) {
-                        min_la_bit_distance = (uint64_t)ABS(
-                            (int64_t)
-                                high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                            (int64_t)bit_constraint_per_sw);
-                        selected_ref_qp = ref_qp_index;
+                    const uint64_t la_bit_distance_temp = (uint64_t)ABS(
+                        (int64_t)high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
+                        (int64_t)bit_constraint_per_sw);
+                    if (min_la_bit_distance >= la_bit_distance_temp) {
+                        if (min_la_bit_distance == la_bit_distance_temp &&
+                            ref_qp_index < selected_ref_qp)
+                            best_qp_found = EB_TRUE;
+                        min_la_bit_distance = la_bit_distance_temp;
+                        selected_ref_qp     = ref_qp_index;
                     } else
                         best_qp_found = EB_TRUE;
                     const int32_t qp_step = ref_qp_table_index != previous_selected_ref_qp ? 1
@@ -3966,22 +3965,24 @@ void frame_level_rc_input_picture_cvbr(PictureControlSet *pcs_ptr, SequenceContr
                 queue_entry_index_temp++;
             }
 
-            if (min_la_bit_distance >=
-                (uint64_t)ABS(
-                    (int64_t)high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                    (int64_t)bit_constraint_per_sw)) {
-                min_la_bit_distance = (uint64_t)ABS(
-                    (int64_t)high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
-                    (int64_t)bit_constraint_per_sw);
-                selected_ref_qp = ref_qp_index;
+            const uint64_t la_bit_distance_temp = (uint64_t)ABS(
+                (int64_t)high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] -
+                (int64_t)bit_constraint_per_sw);
+            if (min_la_bit_distance >= la_bit_distance_temp) {
+                if (min_la_bit_distance == la_bit_distance_temp &&
+                    ref_qp_index < selected_ref_qp)
+                    best_qp_found = EB_TRUE;
+                min_la_bit_distance = la_bit_distance_temp;
+                selected_ref_qp     = ref_qp_index;
             } else
                 best_qp_found = EB_TRUE;
-            const int32_t qp_step = ref_qp_table_index != previous_selected_ref_qp ? 1
+            const int32_t qp_step = ref_qp_table_index != previous_selected_ref_qp
+                ? 1
                 : high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] >
-                    bit_constraint_per_sw
-                ? +1
-                : -1;
-            ref_qp_table_index    = (uint32_t)(ref_qp_table_index + qp_step);
+                        bit_constraint_per_sw
+                    ? +1
+                    : -1;
+            ref_qp_table_index = (uint32_t)(ref_qp_table_index + qp_step);
         }
 
         int delta_qp = 0;


### PR DESCRIPTION
# Description
Fix allows VBR RC to pick lower of two qp candidates when lookahead returns the same bits prediction for two adjacent qp values

# Issue
Fix #1499 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
palexander-14

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
