### PR TITLE
picture_copy: rename to svt_av1_picture_copy

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureOperators.c
+++ b/Source/Lib/Common/Codec/EbPictureOperators.c
@@ -38,11 +38,12 @@ void pic_copy_kernel_16bit(uint16_t *src, uint32_t src_stride, uint16_t *dst, ui
         svt_memcpy(dst + j * dst_stride, src + j * src_stride, sizeof(uint16_t) * width);
 }
 
-EbErrorType picture_copy(EbPictureBufferDesc *src, uint32_t src_luma_origin_index,
-                         uint32_t src_chroma_origin_index, EbPictureBufferDesc *dst,
-                         uint32_t dst_luma_origin_index, uint32_t dst_chroma_origin_index,
-                         uint32_t area_width, uint32_t area_height, uint32_t chroma_area_width,
-                         uint32_t chroma_area_height, uint32_t component_mask, EbBool hbd) {
+EbErrorType svt_av1_picture_copy(EbPictureBufferDesc *src, uint32_t src_luma_origin_index,
+                                 uint32_t src_chroma_origin_index, EbPictureBufferDesc *dst,
+                                 uint32_t dst_luma_origin_index, uint32_t dst_chroma_origin_index,
+                                 uint32_t area_width, uint32_t area_height,
+                                 uint32_t chroma_area_width, uint32_t chroma_area_height,
+                                 uint32_t component_mask, EbBool hbd) {
     EbErrorType return_error = EB_ErrorNone;
 
     if (hbd) {

--- a/Source/Lib/Common/Codec/EbPictureOperators.h
+++ b/Source/Lib/Common/Codec/EbPictureOperators.h
@@ -82,11 +82,12 @@ void pic_copy_kernel_8bit(EbByte src, uint32_t src_stride, EbByte dst, uint32_t 
 void pic_copy_kernel_16bit(uint16_t *src, uint32_t src_stride, uint16_t *dst, uint32_t dst_stride,
                            uint32_t width, uint32_t height);
 
-EbErrorType picture_copy(EbPictureBufferDesc *src, uint32_t src_luma_origin_index,
-                         uint32_t src_chroma_origin_index, EbPictureBufferDesc *dst,
-                         uint32_t dst_luma_origin_index, uint32_t dst_chroma_origin_index,
-                         uint32_t area_width, uint32_t area_height, uint32_t chroma_area_width,
-                         uint32_t chroma_area_height, uint32_t component_mask, uint8_t hbd);
+EbErrorType svt_av1_picture_copy(EbPictureBufferDesc *src, uint32_t src_luma_origin_index,
+                                 uint32_t src_chroma_origin_index, EbPictureBufferDesc *dst,
+                                 uint32_t dst_luma_origin_index, uint32_t dst_chroma_origin_index,
+                                 uint32_t area_width, uint32_t area_height,
+                                 uint32_t chroma_area_width, uint32_t chroma_area_height,
+                                 uint32_t component_mask, uint8_t hbd);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1722,18 +1722,18 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
                                         PLANE_TYPE_Y,
                                         (uint32_t)candidate_buffer->candidate_ptr->eob[0][txb_itr]);
         } else {
-            picture_copy(candidate_buffer->prediction_ptr,
-                         txb_origin_index,
-                         0,
-                         candidate_buffer->recon_ptr,
-                         txb_origin_index,
-                         0,
-                         context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
-                         context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
-                         0,
-                         0,
-                         PICTURE_BUFFER_DESC_Y_FLAG,
-                         context_ptr->hbd_mode_decision);
+            svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                 txb_origin_index,
+                                 0,
+                                 candidate_buffer->recon_ptr,
+                                 txb_origin_index,
+                                 0,
+                                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+                                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+                                 0,
+                                 0,
+                                 PICTURE_BUFFER_DESC_Y_FLAG,
+                                 context_ptr->hbd_mode_decision);
         }
 
         EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision
@@ -2011,18 +2011,18 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                         PLANE_TYPE_UV,
                         (uint32_t)candidate_buffer->candidate_ptr->eob[1][txb_itr]);
                 else
-                    picture_copy(candidate_buffer->prediction_ptr,
-                                 0,
-                                 tu_cb_origin_index,
-                                 candidate_buffer->recon_ptr,
-                                 0,
-                                 tu_cb_origin_index,
-                                 0,
-                                 0,
-                                 context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
-                                 context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
-                                 PICTURE_BUFFER_DESC_Cb_FLAG,
-                                 context_ptr->hbd_mode_decision);
+                    svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                         0,
+                                         tu_cb_origin_index,
+                                         candidate_buffer->recon_ptr,
+                                         0,
+                                         tu_cb_origin_index,
+                                         0,
+                                         0,
+                                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
+                                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
+                                         PICTURE_BUFFER_DESC_Cb_FLAG,
+                                         context_ptr->hbd_mode_decision);
             }
         }
 
@@ -2098,18 +2098,18 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                         PLANE_TYPE_UV,
                         (uint32_t)candidate_buffer->candidate_ptr->eob[2][txb_itr]);
                 else
-                    picture_copy(candidate_buffer->prediction_ptr,
-                                 0,
-                                 tu_cb_origin_index,
-                                 candidate_buffer->recon_ptr,
-                                 0,
-                                 tu_cb_origin_index,
-                                 0,
-                                 0,
-                                 context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
-                                 context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
-                                 PICTURE_BUFFER_DESC_Cr_FLAG,
-                                 context_ptr->hbd_mode_decision);
+                    svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                         0,
+                                         tu_cb_origin_index,
+                                         candidate_buffer->recon_ptr,
+                                         0,
+                                         tu_cb_origin_index,
+                                         0,
+                                         0,
+                                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
+                                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
+                                         PICTURE_BUFFER_DESC_Cr_FLAG,
+                                         context_ptr->hbd_mode_decision);
             }
         }
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -774,18 +774,18 @@ void av1_perform_inverse_transform_recon(ModeDecisionContext *        context_pt
                                         PLANE_TYPE_Y,
                                         (uint32_t)candidate_buffer->candidate_ptr->eob[0][txb_itr]);
         else
-            picture_copy(candidate_buffer->prediction_ptr,
-                         txb_origin_index,
-                         0, //txb_chroma_origin_index,
-                         candidate_buffer->recon_ptr,
-                         rec_luma_offset,
-                         0, //txb_chroma_origin_index,
-                         txb_width,
-                         txb_height,
-                         0, //chromaTuSize,
-                         0, //chromaTuSize,
-                         PICTURE_BUFFER_DESC_Y_FLAG,
-                         context_ptr->hbd_mode_decision);
+            svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                 txb_origin_index,
+                                 0, //txb_chroma_origin_index,
+                                 candidate_buffer->recon_ptr,
+                                 rec_luma_offset,
+                                 0, //txb_chroma_origin_index,
+                                 txb_width,
+                                 txb_height,
+                                 0, //chromaTuSize,
+                                 0, //chromaTuSize,
+                                 PICTURE_BUFFER_DESC_Y_FLAG,
+                                 context_ptr->hbd_mode_decision);
 
         //CHROMA
         if (tx_depth == 0 || txb_itr == 0) {
@@ -821,18 +821,18 @@ void av1_perform_inverse_transform_recon(ModeDecisionContext *        context_pt
                         PLANE_TYPE_UV,
                         (uint32_t)candidate_buffer->candidate_ptr->eob[1][txb_itr]);
                 else
-                    picture_copy(candidate_buffer->prediction_ptr,
-                                 0,
-                                 cb_tu_chroma_origin_index,
-                                 candidate_buffer->recon_ptr,
-                                 0,
-                                 rec_cb_offset,
-                                 0,
-                                 0,
-                                 chroma_txb_width,
-                                 chroma_txb_height,
-                                 PICTURE_BUFFER_DESC_Cb_FLAG,
-                                 context_ptr->hbd_mode_decision);
+                    svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                         0,
+                                         cb_tu_chroma_origin_index,
+                                         candidate_buffer->recon_ptr,
+                                         0,
+                                         rec_cb_offset,
+                                         0,
+                                         0,
+                                         chroma_txb_width,
+                                         chroma_txb_height,
+                                         PICTURE_BUFFER_DESC_Cb_FLAG,
+                                         context_ptr->hbd_mode_decision);
 
                 if (context_ptr->blk_geom->has_uv &&
                     context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
@@ -852,18 +852,18 @@ void av1_perform_inverse_transform_recon(ModeDecisionContext *        context_pt
                         PLANE_TYPE_UV,
                         (uint32_t)candidate_buffer->candidate_ptr->eob[2][txb_itr]);
                 else
-                    picture_copy(candidate_buffer->prediction_ptr,
-                                 0,
-                                 cr_tu_chroma_origin_index,
-                                 candidate_buffer->recon_ptr,
-                                 0,
-                                 rec_cr_offset,
-                                 0,
-                                 0,
-                                 chroma_txb_width,
-                                 chroma_txb_height,
-                                 PICTURE_BUFFER_DESC_Cr_FLAG,
-                                 context_ptr->hbd_mode_decision);
+                    svt_av1_picture_copy(candidate_buffer->prediction_ptr,
+                                         0,
+                                         cr_tu_chroma_origin_index,
+                                         candidate_buffer->recon_ptr,
+                                         0,
+                                         rec_cr_offset,
+                                         0,
+                                         0,
+                                         chroma_txb_width,
+                                         chroma_txb_height,
+                                         PICTURE_BUFFER_DESC_Cr_FLAG,
+                                         context_ptr->hbd_mode_decision);
 
                 if (context_ptr->blk_geom->has_uv)
                     txb_1d_offset_uv += context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr] *
@@ -4463,7 +4463,7 @@ void tx_type_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr
                     PLANE_TYPE_Y,
                     (uint32_t)eob_txt[tx_type]);
             else
-                picture_copy(
+                svt_av1_picture_copy(
                     candidate_buffer->prediction_ptr,
                     txb_origin_index,
                     0,


### PR DESCRIPTION
# Description

conflicts with vmaf 2.0.0

/cc @kylophone potential cause to look into prefixing/namespacing the symbols in both libraries?

also, @kylophone do you happen to use a .clang-format in vmaf?

# Issue
https://github.com/m-ab-s/media-autobuild_suite/issues/1869#issuecomment-737588744
https://github.com/AOMediaCodec/SVT-AV1/pull/1620
# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
