### PR TITLE
CMake: only apply fortify source if optimization is applied and not 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ else()
     if(MINGW)
         list(APPEND flags_to_test -mxsave -fno-asynchronous-unwind-tables)
     else()
-        list(APPEND flags_to_test -fstack-protector-strong -D_FORTIFY_SOURCE=2)
+        list(APPEND flags_to_test -fstack-protector-strong)
     endif()
 endif()
 
@@ -176,6 +176,10 @@ endif()
 
 if(CMAKE_CXX_FLAGS MATCHES ".*-march=native.*")
     string(APPEND CMAKE_CXX_FLAGS " -mno-avx")
+endif()
+
+if(CMAKE_C_FLAGS MATCHES "-O" AND NOT CMAKE_C_FLAGS MATCHES "-O0" AND NOT MINGW)
+    string(APPEND CMAKE_C_FLAGS " -D_FORTIFY_SOURCE=2")
 endif()
 
 if(CMAKE_ASM_NASM_OBJECT_FORMAT MATCHES "win")


### PR DESCRIPTION

# Description

cmake on centos errors out with `-Werror` since their header contains an error if `-O*` is not specified and fortify source is set

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
