### PR TITLE
Fix crash in VBR/CVBR RC when lookahead distance is more than intra period

### DIFF
--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -1905,7 +1905,7 @@ void high_level_rc_input_picture_vbr(PictureParentControlSet *pcs_ptr, SequenceC
                 EbBool end_of_sequence_flag = EB_FALSE;
 
                 while (!end_of_sequence_flag &&
-                       queue_entry_index_temp <= queue_entry_index_head_temp +
+                       queue_entry_index_temp < queue_entry_index_head_temp +
                                scs_ptr->static_config.look_ahead_distance) {
                     uint32_t queue_entry_index_temp2 =
                         (queue_entry_index_temp >
@@ -2007,7 +2007,7 @@ void high_level_rc_input_picture_vbr(PictureParentControlSet *pcs_ptr, SequenceC
             while (
                 !end_of_sequence_flag &&
                 //queue_entry_index_temp <= encode_context_ptr->hl_rate_control_historgram_queue_head_index+scs_ptr->static_config.look_ahead_distance){
-                queue_entry_index_temp <=
+                queue_entry_index_temp <
                     queue_entry_index_head_temp + scs_ptr->static_config.look_ahead_distance) {
                 uint32_t queue_entry_index_temp2 =
                     (queue_entry_index_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1)
@@ -3431,7 +3431,7 @@ void high_level_rc_input_picture_cvbr(PictureParentControlSet *pcs_ptr, Sequence
                     EbBool end_of_sequence_flag = EB_FALSE;
 
                     while (!end_of_sequence_flag &&
-                           queue_entry_index_temp <= queue_entry_index_head_temp +
+                           queue_entry_index_temp < queue_entry_index_head_temp +
                                    scs_ptr->static_config.look_ahead_distance) {
                         uint32_t queue_entry_index_temp2 =
                             (queue_entry_index_temp >
@@ -3546,7 +3546,7 @@ void high_level_rc_input_picture_cvbr(PictureParentControlSet *pcs_ptr, Sequence
             while (
                 !end_of_sequence_flag &&
                 //queue_entry_index_temp <= encode_context_ptr->hl_rate_control_historgram_queue_head_index+scs_ptr->static_config.look_ahead_distance){
-                queue_entry_index_temp <=
+                queue_entry_index_temp <
                     queue_entry_index_head_temp + scs_ptr->static_config.look_ahead_distance) {
                 uint32_t queue_entry_index_temp2 =
                     (queue_entry_index_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1)
@@ -3916,7 +3916,7 @@ void frame_level_rc_input_picture_cvbr(PictureControlSet *pcs_ptr, SequenceContr
             while (
                 !end_of_sequence_flag &&
                 //queue_entry_index_temp <= queue_entry_index_head_temp + scs_ptr->static_config.look_ahead_distance) {
-                queue_entry_index_temp <= queue_entry_index_head_temp +
+                queue_entry_index_temp < queue_entry_index_head_temp +
                         encode_context_ptr
                             ->hl_rate_control_historgram_queue[queue_entry_index_head_temp]
                             ->frames_in_sw -


### PR DESCRIPTION
Fix crash in VBR/CVBR RC when lookahead distance is more than intra period

# Description
Changed boundary conditions to prevent an access to uninitialized lookahead data.

# Issue
Fixed #1622

# Author(s)
palexander-14

# Performance impact
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
