### PR TITLE
patches: add libvmaf to ffmpeg builds

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-          install: mingw-w64-x86_64-ccache mingw-w64-x86_64-yasm mingw-w64-x86_64-nasm mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-dav1d make diffutils
+          install: mingw-w64-x86_64-ccache mingw-w64-x86_64-yasm mingw-w64-x86_64-nasm mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-dav1d mingw-w64-x86_64-meson make diffutils vim
           update: true
 
       - name: Set ccache dir
@@ -73,13 +73,27 @@ jobs:
         shell: msys2 {0}
         run: |
           mkdir -p vpx-build && cd vpx-build || exit 1
-          ../libvpx/configure  --prefix=/mingw64 --disable-{examples,webm-io,libyuv,postproc,shared,unit-tests,docs,install-bins} --enable-{vp9-postproc,vp9-highbitdepth}
+          ../libvpx/configure --prefix=/mingw64 --disable-{examples,webm-io,libyuv,postproc,shared,unit-tests,docs,install-bins} --enable-{vp9-postproc,vp9-highbitdepth}
           make -j $(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) install
+
+      - name: Clone libvmaf
+        uses: actions/checkout@v2
+        with:
+          repository: Netflix/vmaf
+          path: vmaf
+      - name: Configure libvmaf
+        shell: msys2 {0}
+        run: |
+          # additional folder under vmaf/libvmaf needed for builtin models
+          # https://github.com/Netflix/vmaf/issues/752
+          meson setup --prefix /mingw64 --buildtype release --libdir lib -Denable_{tests,docs}=false -Dbuilt_in_models=true vmaf/libvmaf/vmaf-build vmaf/libvmaf
+          meson install -C vmaf/libvmaf/vmaf-build
+          sed -i 's;Libs.private.*;& -lstdc++;' /mingw64/lib/pkgconfig/libvmaf.pc
 
       - name: Configure FFmpeg
         shell: msys2 {0}
         run: |
-          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1,dav1d}  --disable-shared || {
+          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1,dav1d,vmaf}  --disable-shared || {
             cat ffbuild/config.log
             exit 1
           }

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -51,22 +51,26 @@ jobs:
         if: matrix.os == 'ubuntu-18.04'
         run: |
           sudo apt-get update &&
-          sudo apt-get install -y yasm nasm cmake ccache ninja-build
+          sudo apt-get install -y yasm nasm cmake ccache ninja-build python3-pip python3-setuptools
+          sudo -E pip3 install meson
       - name: Install dependencies (mac)
         if: matrix.os == 'macos-10.15'
         run: |
           {
             brew update || brew update-reset
-            brew upgrade yasm nasm ccache pkg-config ninja || brew install -q yasm nasm ccache pkg-config ninja
+            brew upgrade yasm nasm ccache pkg-config ninja meson || brew install -q yasm nasm ccache pkg-config ninja meson
           } || brew update-reset
       - name: Check dependencies
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          printf '%s\n' "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           $CC --version
           yasm --version
           cmake --version
+          meson --version
           ccache --version
+          printf '%s\n' \
+            "CCACHE_DIR=$HOME/.ccache" \
+            "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
 
       - name: Clone SVT-AV1
         uses: actions/checkout@v2
@@ -92,11 +96,24 @@ jobs:
           sudo -E ../libvpx/configure --disable-{examples,webm-io,libyuv,postproc,shared,unit-tests,docs,install-bins} --enable-{vp9-postproc,vp9-highbitdepth}
           sudo -E make -j $(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) install
 
+      - name: Clone libvmaf
+        uses: actions/checkout@v2
+        with:
+          repository: Netflix/vmaf
+          path: vmaf
+      - name: Configure libvmaf
+        run: |
+          sudo -E meson setup --buildtype release --libdir lib -Denable_{tests,docs}=false -Dbuilt_in_models=false vmaf-build vmaf/libvmaf
+          sudo -E meson install -C vmaf-build
+
       - name: Check for symbol conflicts
         if: matrix.os == 'ubuntu-18.04'
         run: |
           conflicts=$(
-              nm -CAg --defined-only /usr/local/lib/lib{SvtAv1Enc,aom,vpx}.a | cut -d' ' -f3 | sort | uniq -d
+            nm -Ag --defined-only /usr/local/lib/lib{SvtAv1Enc,aom,vpx,vmaf}.a 2>/dev/null |
+            cut -d' ' -f3- |
+            sort |
+            uniq -d
           )
           if [[ -n $conflicts ]]; then
             printf 'Conflicts Found!\n'
@@ -107,7 +124,7 @@ jobs:
       - name: Configure FFmpeg
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1} --disable-shared || {
+          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1,vmaf} --disable-shared || {
             less ffbuild/config.log
             exit 1
           }


### PR DESCRIPTION

# Description

adds libvmaf to the list of tested libraries

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
