### PR TITLE
gitlab: use centos 7 for gcc4.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,10 +63,7 @@ clang 10:
 
 gcc 4:
   extends: .linux-compiler-base
-  image: registry.gitlab.com/aomediacodec/aom-testing/ubuntu1804
-  variables:
-    CC: gcc-4.8
-    CXX: g++-4.8
+  image: registry.gitlab.com/aomediacodec/aom-testing/centos7
 
 valgrind compile:
   extends: .linux-compiler-base


### PR DESCRIPTION

# Description

switch to centos to closer match what people who are actually using gcc 4.8.5 might use

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
