### PR TITLE
Fix valgrind for "--pass 1"

### DIFF
--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.h
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.h
@@ -24,4 +24,6 @@ EbErrorType initial_rate_control_context_ctor(EbThreadContext *  thread_context_
 
 extern void *initial_rate_control_kernel(void *input_ptr);
 
+void init_zz_cost_info(PictureParentControlSet *pcs_ptr);
+
 #endif // EbInitialRateControl_h

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -31,6 +31,7 @@
 #include "EbPictureDemuxResults.h"
 #include "EbRateControlTasks.h"
 #include "firstpass.h"
+#include "EbInitialRateControlProcess.h"
 /* --32x32-
 |00||01|
 |02||03|
@@ -1108,6 +1109,10 @@ void *motion_estimation_kernel(void *input_ptr) {
         else {
             // ME Kernel Signal(s) derivation
             first_pass_signal_derivation_me_kernel(scs_ptr, pcs_ptr, context_ptr);
+
+            //For first pass compute_decimated_zz_sad() is skipped, and non_moving_index_array[] become uninitialized
+            init_zz_cost_info((PictureParentControlSet *)
+                                  pcs_ptr->previous_picture_control_set_wrapper_ptr->object_ptr);
 
             // first pass start
             context_ptr->me_context_ptr->me_type = ME_FIRST_PASS;


### PR DESCRIPTION
# Description
Fix valgrind error for "--pass 1"
Command line example:
```
valgrind  ./SvtAv1EncApp --lp 1 -i BQSquare_176x144_60.yuv -w 176 -h 144 --preset 3  -n 17 --irefresh-type 2 --pass 1 --stats stat_file.stat

Conditional jump or move depends on uninitialised value(s)
at 0x4A5C7CF: derive_picture_activity_statistics (EbSourceBasedOperationsProcess.c:99)
by 0x4A5C932: source_based_operations_kernel (EbSourceBasedOperationsProcess.c:176)
by 0x5A31608: start_thread (pthread_create.c:477)
by 0x5956292: clone (clone.S:95)
```

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
