### PR TITLE
Task sanitizer fix

### DIFF
--- a/.github/workflows/sanitizers-known-warnings.txt
+++ b/.github/workflows/sanitizers-known-warnings.txt
@@ -33,11 +33,4 @@ race:packetization_kernel
 #encode_context_ptr->terminating_sequence_flag_received = EB_TRUE;
 #Between: picture_decision_kernel and packetization_kernel
 
-#4]
-race:signal_derivation_pre_analysis_oq
-#dlf_kernel() read scs_ptr->seq_header.enable_restoration
-#cdef_kernel() read scs_ptr->seq_header.cdef_level
-#writed in resource_coordination_kernel():signal_derivation_pre_analysis_oq()
-
-
 #End of file

--- a/.github/workflows/sanitizers-known-warnings.txt
+++ b/.github/workflows/sanitizers-known-warnings.txt
@@ -27,10 +27,4 @@ race:picture_manager_kernel
 #picture_manager_kernel() use encode_context_ptr: current_input_poc = encode_context_ptr->current_input_poc; after release
 #written in  picture_decision_kernel():encode_context_ptr->current_input_poc = pcs_ptr->picture_number;
 
-#3]
-race:packetization_kernel
-#Not synchronize access to variable:
-#encode_context_ptr->terminating_sequence_flag_received = EB_TRUE;
-#Between: picture_decision_kernel and packetization_kernel
-
 #End of file

--- a/.github/workflows/sanitizers-known-warnings.txt
+++ b/.github/workflows/sanitizers-known-warnings.txt
@@ -21,10 +21,4 @@ race:mode_decision_kernel
 #        ->average_intensity = pcs_ptr->parent_pcs_ptr->average_intensity[0];
 #}
 
-#2]
-race:picture_decision_kernel
-race:picture_manager_kernel
-#picture_manager_kernel() use encode_context_ptr: current_input_poc = encode_context_ptr->current_input_poc; after release
-#written in  picture_decision_kernel():encode_context_ptr->current_input_poc = pcs_ptr->picture_number;
-
 #End of file

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.c
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.c
@@ -157,7 +157,6 @@ EbErrorType encode_context_ctor(EncodeContext *encode_context_ptr, EbPtr object_
                picture_index);
     }
 
-    encode_context_ptr->current_input_poc = -1;
     encode_context_ptr->initial_picture   = EB_TRUE;
 
     // Sequence Termination Flags

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -142,7 +142,6 @@ typedef struct EncodeContext {
     uint32_t pred_struct_position; // Current position within a prediction structure
     uint32_t elapsed_non_idr_count;
     uint32_t elapsed_non_cra_count;
-    int64_t  current_input_poc;
     EbBool   initial_picture;
     uint64_t last_idr_picture; // the most recently occured IDR picture (in decode order)
 

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -5387,13 +5387,11 @@ void* picture_decision_kernel(void *input_ptr)
                             }
                             else
                                 pcs_ptr->decode_order = pcs_ptr->picture_number_alt;
-                            encode_context_ptr->terminating_sequence_flag_received = (pcs_ptr->end_of_sequence_flag == EB_TRUE) ?
-                                EB_TRUE :
-                                encode_context_ptr->terminating_sequence_flag_received;
 
-                            encode_context_ptr->terminating_picture_number = (pcs_ptr->end_of_sequence_flag == EB_TRUE) ?
-                                pcs_ptr->picture_number_alt :
-                                encode_context_ptr->terminating_picture_number;
+                            if (pcs_ptr->end_of_sequence_flag == EB_TRUE) {
+                                encode_context_ptr->terminating_sequence_flag_received = EB_TRUE;
+                                encode_context_ptr->terminating_picture_number = pcs_ptr->picture_number_alt;
+                            }
 
                             // Find the Reference in the Picture Decision PA Reference Queue
                             input_queue_index = encode_context_ptr->picture_decision_pa_reference_queue_head_index;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -4579,6 +4579,7 @@ void* picture_decision_kernel(void *input_ptr)
     // Dynamic GOP
     uint32_t                           mini_gop_index;
     uint32_t                           out_stride_diff64;
+    int64_t                            current_input_poc = -1;
 
     EbBool                          window_avail, frame_passthrough;
     uint32_t                           window_index;
@@ -4741,8 +4742,7 @@ void* picture_decision_kernel(void *input_ptr)
                 // Setup the PCS & SCS
                 pcs_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[encode_context_ptr->pre_assignment_buffer_count]->object_ptr;
                 // Set the POC Number
-                pcs_ptr->picture_number = (encode_context_ptr->current_input_poc + 1) /*& ((1 << scs_ptr->bits_for_picture_order_count)-1)*/;
-                encode_context_ptr->current_input_poc = pcs_ptr->picture_number;
+                pcs_ptr->picture_number = ++current_input_poc;
 
                 pcs_ptr->pred_structure = scs_ptr->static_config.pred_structure;
 

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -617,7 +617,6 @@ void *picture_manager_kernel(void *input_ptr) {
     PredictionStructureEntry *pred_position_ptr;
     InputQueueEntry *         input_entry_ptr;
     uint32_t                  input_queue_index;
-    uint64_t                  current_input_poc;
     ReferenceQueueEntry *     reference_entry_ptr;
     uint32_t                  reference_queue_index;
     uint64_t                  ref_poc;
@@ -883,31 +882,23 @@ void *picture_manager_kernel(void *input_ptr) {
 
                             reference_entry_ptr = search_ref_in_ref_queue(encode_context_ptr, ref_poc);
 
-                            // Increment the current_input_poc is the case of POC rollover
-                            current_input_poc = encode_context_ptr->current_input_poc;
-                            //current_input_poc += ((current_input_poc < ref_poc) && (input_entry_ptr->list0_ptr->reference_list[ref_idx] > 0)) ?
-                            //    (1 << entry_scs_ptr->bits_for_picture_order_count) :
-                            //    0;
                             if (reference_entry_ptr != NULL){
                             availability_flag =
                                 (availability_flag == EB_FALSE) ? EB_FALSE
-                                                                : // Don't update if already False
-                                    (ref_poc > current_input_poc)
+                                : // Don't update if already False
+                                (scs_ptr->static_config.rate_control_mode &&
+                                entry_pcs_ptr->slice_type != I_SLICE &&
+                                entry_pcs_ptr->temporal_layer_index == 0 &&
+                                !reference_entry_ptr->feedback_arrived &&
+                                !encode_context_ptr->terminating_sequence_flag_received)
+                                ? EB_FALSE
+                                : (entry_pcs_ptr->frame_end_cdf_update_mode &&
+                                    !reference_entry_ptr->frame_context_updated)
                                         ? EB_FALSE
-                                        : // The Reference has not been received as an Input Picture yet, then its availability is false
-                                         (scs_ptr->static_config.rate_control_mode &&
-                                          entry_pcs_ptr->slice_type != I_SLICE &&
-                                          entry_pcs_ptr->temporal_layer_index == 0 &&
-                                          !reference_entry_ptr->feedback_arrived &&
-                                          !encode_context_ptr->terminating_sequence_flag_received)
-                                            ? EB_FALSE
-                                            : (entry_pcs_ptr->frame_end_cdf_update_mode &&
-                                               !reference_entry_ptr->frame_context_updated)
-                                                  ? EB_FALSE
-                                                  : (reference_entry_ptr->reference_available)
-                                                        ? EB_TRUE
-                                                        : // The Reference has been completed
-                                                        EB_FALSE; // The Reference has not been completed
+                                        : (reference_entry_ptr->reference_available)
+                                            ? EB_TRUE
+                                            : // The Reference has been completed
+                                            EB_FALSE; // The Reference has not been completed
                             }else{
                                 availability_flag = EB_FALSE;
                             }
@@ -929,35 +920,25 @@ void *picture_manager_kernel(void *input_ptr) {
 
                                     reference_entry_ptr = search_ref_in_ref_queue(encode_context_ptr, ref_poc);
 
-
-                                    // Increment the current_input_poc is the case of POC rollover
-                                    current_input_poc = encode_context_ptr->current_input_poc;
-                                    //current_input_poc += ((current_input_poc < ref_poc && input_entry_ptr->list1_ptr->reference_list[ref_idx] > 0)) ?
-                                    //    (1 << entry_scs_ptr->bits_for_picture_order_count) :
-                                    //    0;
-
                                     if (reference_entry_ptr != NULL){
                                     availability_flag =
                                         (availability_flag == EB_FALSE)
-                                            ? EB_FALSE
-                                            : // Don't update if already False
-                                            (ref_poc > current_input_poc)
+                                        ? EB_FALSE
+                                        : // Don't update if already False
+                                        (scs_ptr->static_config.rate_control_mode &&
+                                        entry_pcs_ptr->slice_type != I_SLICE &&
+                                        entry_pcs_ptr->temporal_layer_index == 0 &&
+                                        !reference_entry_ptr->feedback_arrived &&
+                                        !encode_context_ptr->terminating_sequence_flag_received)
+                                        ? EB_FALSE
+                                        : (entry_pcs_ptr->frame_end_cdf_update_mode &&
+                                            !reference_entry_ptr->frame_context_updated)
                                                 ? EB_FALSE
-                                                : // The Reference has not been received as an Input Picture yet, then its availability is false
-                                                 (scs_ptr->static_config.rate_control_mode &&
-                                                  entry_pcs_ptr->slice_type != I_SLICE &&
-                                                  entry_pcs_ptr->temporal_layer_index == 0 &&
-                                                  !reference_entry_ptr->feedback_arrived &&
-                                                  !encode_context_ptr->terminating_sequence_flag_received)
-                                                    ? EB_FALSE
-                                                    : (entry_pcs_ptr->frame_end_cdf_update_mode &&
-                                                       !reference_entry_ptr->frame_context_updated)
-                                                          ? EB_FALSE
-                                                          : (reference_entry_ptr
-                                                                 ->reference_available)
-                                                                ? EB_TRUE
-                                                                : // The Reference has been completed
-                                                                EB_FALSE; // The Reference has not been completed
+                                                : (reference_entry_ptr
+                                                        ->reference_available)
+                                                    ? EB_TRUE
+                                                    : // The Reference has been completed
+                                                    EB_FALSE; // The Reference has not been completed
 
                                     }else{
                                         availability_flag = EB_FALSE; }

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -895,11 +895,11 @@ void *picture_manager_kernel(void *input_ptr) {
                                     (ref_poc > current_input_poc)
                                         ? EB_FALSE
                                         : // The Reference has not been received as an Input Picture yet, then its availability is false
-                                        (!encode_context_ptr->terminating_sequence_flag_received &&
                                          (scs_ptr->static_config.rate_control_mode &&
                                           entry_pcs_ptr->slice_type != I_SLICE &&
                                           entry_pcs_ptr->temporal_layer_index == 0 &&
-                                          !reference_entry_ptr->feedback_arrived))
+                                          !reference_entry_ptr->feedback_arrived &&
+                                          !encode_context_ptr->terminating_sequence_flag_received)
                                             ? EB_FALSE
                                             : (entry_pcs_ptr->frame_end_cdf_update_mode &&
                                                !reference_entry_ptr->frame_context_updated)
@@ -944,12 +944,11 @@ void *picture_manager_kernel(void *input_ptr) {
                                             (ref_poc > current_input_poc)
                                                 ? EB_FALSE
                                                 : // The Reference has not been received as an Input Picture yet, then its availability is false
-                                                (!encode_context_ptr
-                                                      ->terminating_sequence_flag_received &&
                                                  (scs_ptr->static_config.rate_control_mode &&
                                                   entry_pcs_ptr->slice_type != I_SLICE &&
                                                   entry_pcs_ptr->temporal_layer_index == 0 &&
-                                                  !reference_entry_ptr->feedback_arrived))
+                                                  !reference_entry_ptr->feedback_arrived &&
+                                                  !encode_context_ptr->terminating_sequence_flag_received)
                                                     ? EB_FALSE
                                                     : (entry_pcs_ptr->frame_end_cdf_update_mode &&
                                                        !reference_entry_ptr->frame_context_updated)

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -466,12 +466,11 @@ void first_pass_frame_end(PictureParentControlSet *pcs_ptr, const int64_t ts_dur
         pcs_ptr, &stats, raw_err_stdev, (const int)pcs_ptr->picture_number, ts_duration);
 }
 /******************************************************
-* Derive Pre-Analysis settings for first pass
+* Derive Pre-Analysis settings for first pass for pcs
 Input   : encoder mode and tune
 Output  : Pre-Analysis signal(s)
 ******************************************************/
-extern EbErrorType first_pass_signal_derivation_pre_analysis(SequenceControlSet *     scs_ptr,
-                                                             PictureParentControlSet *pcs_ptr) {
+extern EbErrorType first_pass_signal_derivation_pre_analysis_pcs(PictureParentControlSet *pcs_ptr) {
     EbErrorType return_error = EB_ErrorNone;
     // Derive HME Flag
     pcs_ptr->enable_hme_flag        = 1;
@@ -485,6 +484,17 @@ extern EbErrorType first_pass_signal_derivation_pre_analysis(SequenceControlSet 
     pcs_ptr->tf_enable_hme_level0_flag             = 0;
     pcs_ptr->tf_enable_hme_level1_flag             = 0;
     pcs_ptr->tf_enable_hme_level2_flag             = 0;
+
+    return return_error;
+}
+
+/******************************************************
+* Derive Pre-Analysis settings for first pass for scs
+Input   : encoder mode and tune
+Output  : Pre-Analysis signal(s)
+******************************************************/
+extern EbErrorType first_pass_signal_derivation_pre_analysis_scs(SequenceControlSet * scs_ptr) {
+    EbErrorType return_error = EB_ErrorNone;
     scs_ptr->seq_header.enable_intra_edge_filter   = 0;
     scs_ptr->seq_header.pic_based_rate_est         = 0;
     scs_ptr->seq_header.enable_restoration         = 0;
@@ -493,6 +503,7 @@ extern EbErrorType first_pass_signal_derivation_pre_analysis(SequenceControlSet 
 
     return return_error;
 }
+
 #define LOW_MOTION_ERROR_THRESH 25
 void set_tf_controls(PictureParentControlSet *pcs_ptr, uint8_t tf_level);
 /******************************************************


### PR DESCRIPTION
# Description
Fix Sanitizer thread issues
1] signal_derivation_pre_analysis_oq()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  Kernel resource_coordination_kernel()                                                                                                                                                                                                                                           update scs_ptr only one time not for any pcs_ptr

2] terminating_sequence_flag_received                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   Update global flag terminating_sequence_flag_received only                                                                                                                                                                                                                      when encoder is terminating, for picture_manager_kernel()                                                                                                                                                                                                                       reordering condition to avoid sanitizer issue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              

3] encode_context_ptr->current_input_poc                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                Kernel picture_manager_kernel() should not use current_input_poc                                                                                                                                                                                                                from picture_decision_kernel(), rollover on picture_number can not happen.           

I am not sure if 3rd fix is safe, commit: 46821c1777971c5e3f31285550be8c44be25e38c                                                                                                                                                                                                                                                                                                                                                                                                                                                                       

# Issue
#1308

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
