### PR TITLE
Gitlab: add arm64 and ppc arch compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
           - packages: gcc-9 g++-9
             CC: gcc-9
             CXX: g++-9
+          - packages: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            CC: aarch64-linux-gnu-gcc
+            CXX: aarch64-linux-gnu-g++
+            CMAKE_EFLAGS: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/aarch64-linux-gnu.cmake
           - packages: gcc-10 g++-10
             CC: gcc-10
             CXX: g++-10
@@ -77,6 +81,8 @@ jobs:
           printf '%s\n' "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           sudo apt-get update
           sudo apt-get install -y ${{ env.native_deps }} ${{ matrix.packages }}
+          curl -Ls "https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/toolchains/arm64-linux-gcc.cmake?format=TEXT" |
+            base64 -d > aarch64-linux-gnu.cmake
       - name: Configure SVT-AV1
         run: cmake -S "$GITHUB_WORKSPACE" -B Build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF ${{ matrix.CMAKE_EFLAGS }}
       - name: Build and install SVT-AV1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,6 +112,15 @@ Linux (GCC 9, aarch64):
   before_script:
     - curl -Ls "https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/toolchains/arm64-linux-gcc.cmake?format=TEXT" | base64 -d > aarch64-linux-gnu.cmake
 
+Linux (GCC 9, powerpc64le):
+  extends: .linux-compiler-base
+  variables:
+    CC: powerpc64le-linux-gnu-gcc
+    CXX: powerpc64le-linux-gnu-g++
+    EXTRA_CMAKE_FLAGS: -DCMAKE_TOOLCHAIN_FILE=$CI_PROJECT_DIR/powerpc64le-linux-gnu.cmake -DCROSS=powerpc64le-linux-gnu-
+  before_script:
+    - curl -Ls "https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/toolchains/ppc-linux-gcc.cmake?format=TEXT" | base64 -d > powerpc64le-linux-gnu.cmake
+
 Linux (GCC 10):
   extends: .linux-compiler-base
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,9 @@ Static analysis (cppcheck):
       - .cppcheck
     policy: pull-push
   script:
-    - cmake -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - cmake -G"Unix Makefiles" -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - mkdir -p .cppcheck
-    - jq '.[]|=with_entries(select(.value | test(".asm") | not))' Build/compile_commands.json > compile_commands.json
+    - jq '.[]|=with_entries(select(.value | test(".asm|/SVT-AV1/Build/cpuinfo") | not)) | unique' Build/compile_commands.json > compile_commands.json
     - |
       cppcheck \
         --project=compile_commands.json \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,11 @@ Static analysis (cppcheck):
     policy: pull-push
   script:
     - cmake -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - mkdir -p .cppcheck
+    - jq '.[]|=with_entries(select(.value | test(".asm") | not))' Build/compile_commands.json > compile_commands.json
     - |
-      mkdir -p .cppcheck
       cppcheck \
-        --project=Build/compile_commands.json \
+        --project=compile_commands.json \
         --error-exitcode=1 \
         --enable=all \
         -j 2 \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,6 +102,15 @@ Linux (GCC 9):
     CC: gcc-9
     CXX: g++-9
 
+Linux (GCC 9, aarch64):
+  extends: .linux-compiler-base
+  variables:
+    CC: aarch64-linux-gnu-gcc
+    CXX: aarch64-linux-gnu-g++
+    EXTRA_CMAKE_FLAGS: -DCMAKE_TOOLCHAIN_FILE=$CI_PROJECT_DIR/aarch64-linux-gnu.cmake
+  before_script:
+    - curl -Ls "https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/toolchains/arm64-linux-gcc.cmake?format=TEXT" | base64 -d > aarch64-linux-gnu.cmake
+
 Linux (GCC 10):
   extends: .linux-compiler-base
   variables:


### PR DESCRIPTION
# Description

adds arm64 and pcc compilation to gitlab while also using CMake's external project module to pull cpuinfo at configure time instead of our local copy and build it

# Issue

related to #1614 #1613
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)

@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
