### PR TITLE
Fix some deadlock issues

### DIFF
--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -44,6 +44,8 @@ extern "C" {
 #define DETAILED_FRAME_OUTPUT   0 // Prints detailed frame output from the library for debugging
 #define TUNE_CHROMA_SSIM        0 // Allows for Chroma and SSIM BDR-based Tuning
 #define FTR_ENABLE_FIXED_QINDEX_OFFSETS 1
+
+#define FIX_DDL                 1 // Fix deadlock issues
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -359,3 +359,56 @@ void atomic_set_u32(AtomicVarU32 *var, uint32_t in) {
     var->obj = in;
     svt_release_mutex(var->mutex);
 }
+/*
+    create condition variable
+
+    Condition variables are synchronization primitives that enable
+    threads to wait until a particular condition occurs.
+    Condition variables enable threads to atomically release
+    a lock(mutex) and enter the sleeping state.
+    it could be seen as a combined: wait and release mutex
+*/
+void svt_create_cond_var(CondVar *cond_var) {
+    cond_var->val = 0;
+#ifdef _WIN32
+    InitializeCriticalSection(&cond_var->cs);
+    InitializeConditionVariable(&cond_var->cv);
+#else
+    pthread_mutex_init(&cond_var->m_mutex, NULL);
+    pthread_cond_init(&cond_var->m_cond, NULL);
+#endif
+}
+/*
+    set a  condition variable to the new value
+*/
+void svt_set_cond_var(CondVar *cond_var, int32_t newval) {
+#ifdef _WIN32
+    EnterCriticalSection(&cond_var->cs);
+    cond_var->val = newval;
+    WakeAllConditionVariable(&cond_var->cv);
+    LeaveCriticalSection(&cond_var->cs);
+#else
+    pthread_mutex_lock(&cond_var->m_mutex);
+    cond_var->val = newval;
+    pthread_cond_broadcast(&cond_var->m_cond);
+    pthread_mutex_unlock(&cond_var->m_mutex);
+#endif
+}
+/*
+    wait until the cond variable changes to a value
+    different than input
+*/
+
+void svt_wait_cond_var(CondVar *cond_var, int32_t input) {
+#ifdef _WIN32
+
+    EnterCriticalSection(&cond_var->cs);
+    while (cond_var->val == input) SleepConditionVariableCS(&cond_var->cv, &cond_var->cs, INFINITE);
+    LeaveCriticalSection(&cond_var->cs);
+
+#else
+    pthread_mutex_lock(&cond_var->m_mutex);
+    while (cond_var->val == input) pthread_cond_wait(&cond_var->m_cond, &cond_var->m_mutex);
+    pthread_mutex_unlock(&cond_var->m_mutex);
+#endif
+}

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -72,7 +72,7 @@ extern uint64_t *        total_lib_memory; // library Memory malloc'd
             SetThreadGroupAffinity(pointer, &group_affinity, NULL);   \
     } while (0)
 
-#elif defined(__linux__)
+#else
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
@@ -81,6 +81,7 @@ extern uint64_t *        total_lib_memory; // library Memory malloc'd
 #endif
 #include <sched.h>
 #include <pthread.h>
+#if defined(__linux__)
 #define EB_CREATE_THREAD(pointer, thread_function, thread_context)                           \
     do {                                                                                     \
         pointer = svt_create_thread(thread_function, thread_context);                        \
@@ -94,7 +95,7 @@ extern uint64_t *        total_lib_memory; // library Memory malloc'd
         EB_ADD_MEM(pointer, 1, EB_THREAD);                            \
     } while (0)
 #endif
-
+#endif
 #define EB_DESTROY_THREAD(pointer)                   \
     do {                                             \
         if (pointer) {                               \

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -120,6 +120,25 @@ extern uint64_t *        total_lib_memory; // library Memory malloc'd
     } while (0)
 
 void atomic_set_u32(AtomicVarU32 *var, uint32_t in);
+
+/*
+ Condition variable
+*/
+typedef struct CondVar {
+    int32_t val;
+#ifdef _WIN32
+    CRITICAL_SECTION   cs;
+    CONDITION_VARIABLE cv;
+#else
+    pthread_mutex_t m_mutex;
+    pthread_cond_t  m_cond;
+#endif
+} CondVar;
+
+void svt_set_cond_var(CondVar *cond_var, int32_t newval);
+void svt_wait_cond_var(CondVar *cond_var, int32_t input);
+void svt_create_cond_var(CondVar *cond_var);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -121,6 +121,7 @@ extern uint64_t *        total_lib_memory; // library Memory malloc'd
 
 void atomic_set_u32(AtomicVarU32 *var, uint32_t in);
 
+#if FIX_DDL
 /*
  Condition variable
 */
@@ -138,6 +139,7 @@ typedef struct CondVar {
 void svt_set_cond_var(CondVar *cond_var, int32_t newval);
 void svt_wait_cond_var(CondVar *cond_var, int32_t input);
 void svt_create_cond_var(CondVar *cond_var);
+#endif
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -384,7 +384,12 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 }
             }
             if (scs_ptr->static_config.enable_tpl_la && scs_ptr->in_loop_me == 0) {
+#if FIX_DDL
                 svt_set_cond_var(&pcs_ptr->me_ready, 1);
+#else
+                svt_post_semaphore(pcs_ptr->pame_done_semaphore);
+                atomic_set_u32(&pcs_ptr->pame_done, 1);
+#endif
             }
             if (scs_ptr->static_config.look_ahead_distance == 0 ||
                 scs_ptr->static_config.enable_tpl_la == 0) {

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -384,8 +384,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 }
             }
             if (scs_ptr->static_config.enable_tpl_la && scs_ptr->in_loop_me == 0) {
-                svt_post_semaphore(pcs_ptr->pame_done_semaphore);
-                atomic_set_u32(&pcs_ptr->pame_done, 1);
+                svt_set_cond_var(&pcs_ptr->me_ready, 1);
             }
             if (scs_ptr->static_config.look_ahead_distance == 0 ||
                 scs_ptr->static_config.enable_tpl_la == 0) {

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -836,7 +836,11 @@ typedef struct PictureParentControlSet {
     uint8_t      tpl_me_segments_row_count;
     uint8_t      tpl_me_done;
     AtomicVarU32 pame_done; //set when PA ME is done.
+#if FIX_DDL
     CondVar me_ready;
+#else
+    EbHandle pame_done_semaphore;
+#endif
     uint8_t      num_tpl_grps;
     uint8_t      num_tpl_processed;
     int16_t      tf_segments_total_count;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -836,7 +836,7 @@ typedef struct PictureParentControlSet {
     uint8_t      tpl_me_segments_row_count;
     uint8_t      tpl_me_done;
     AtomicVarU32 pame_done; //set when PA ME is done.
-    EbHandle     pame_done_semaphore;
+    CondVar me_ready;
     uint8_t      num_tpl_grps;
     uint8_t      num_tpl_processed;
     int16_t      tf_segments_total_count;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -1135,7 +1135,17 @@ EbErrorType tpl_mc_flow(EncodeContext *encode_context_ptr, SequenceControlSet *s
     if (scs_ptr->in_loop_me == 0) {
         //wait for PA ME to be done.
         for (uint32_t i = 1; i < pcs_ptr->tpl_group_size; i++) {
+#if FIX_DDL
             svt_wait_cond_var(&pcs_ptr->tpl_group[i]->me_ready, 0);
+#else
+
+            svt_block_on_mutex(pcs_ptr->tpl_group[i]->pame_done.mutex);
+
+            if (pcs_ptr->tpl_group[i]->pame_done.obj == 0) {
+                svt_block_on_semaphore(pcs_ptr->tpl_group[i]->pame_done_semaphore);
+            }
+            svt_release_mutex(pcs_ptr->tpl_group[i]->pame_done.mutex);
+#endif
         }
     }
 
@@ -7800,7 +7810,11 @@ void *rate_control_kernel(void *input_ptr) {
             }
 #endif
             total_number_of_fb_frames++;
+#if FIX_DDL
 
+#else
+            EB_DESTROY_SEMAPHORE(parentpicture_control_set_ptr->pame_done_semaphore);
+#endif
             // Release the SequenceControlSet
             svt_release_object(parentpicture_control_set_ptr->scs_wrapper_ptr);
             // Release the ParentPictureControlSet

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -1135,12 +1135,7 @@ EbErrorType tpl_mc_flow(EncodeContext *encode_context_ptr, SequenceControlSet *s
     if (scs_ptr->in_loop_me == 0) {
         //wait for PA ME to be done.
         for (uint32_t i = 1; i < pcs_ptr->tpl_group_size; i++) {
-            svt_block_on_mutex(pcs_ptr->tpl_group[i]->pame_done.mutex);
-
-            if (pcs_ptr->tpl_group[i]->pame_done.obj == 0) {
-                svt_block_on_semaphore(pcs_ptr->tpl_group[i]->pame_done_semaphore);
-            }
-            svt_release_mutex(pcs_ptr->tpl_group[i]->pame_done.mutex);
+            svt_wait_cond_var(&pcs_ptr->tpl_group[i]->me_ready, 0);
         }
     }
 
@@ -7805,7 +7800,6 @@ void *rate_control_kernel(void *input_ptr) {
             }
 #endif
             total_number_of_fb_frames++;
-            EB_DESTROY_SEMAPHORE(parentpicture_control_set_ptr->pame_done_semaphore);
 
             // Release the SequenceControlSet
             svt_release_object(parentpicture_control_set_ptr->scs_wrapper_ptr);

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -491,7 +491,7 @@ static EbErrorType reset_pcs_av1(PictureParentControlSet *pcs_ptr) {
     pcs_ptr->max_number_of_pus_per_sb        = SQUARE_PU_COUNT;
 
     atomic_set_u32(&pcs_ptr->pame_done, 0);
-    EB_CREATE_SEMAPHORE(pcs_ptr->pame_done_semaphore, 0, 1);
+    svt_create_cond_var(&pcs_ptr->me_ready);
 
     pcs_ptr->num_tpl_grps      = 0;
     pcs_ptr->num_tpl_processed = 0;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -491,7 +491,12 @@ static EbErrorType reset_pcs_av1(PictureParentControlSet *pcs_ptr) {
     pcs_ptr->max_number_of_pus_per_sb        = SQUARE_PU_COUNT;
 
     atomic_set_u32(&pcs_ptr->pame_done, 0);
+#if FIX_DDL
     svt_create_cond_var(&pcs_ptr->me_ready);
+
+#else
+    EB_CREATE_SEMAPHORE(pcs_ptr->pame_done_semaphore, 0, 1);
+#endif
 
     pcs_ptr->num_tpl_grps      = 0;
     pcs_ptr->num_tpl_processed = 0;


### PR DESCRIPTION
# Description
This PR fixes some deadlocks in the encoder.

Tested on obj-1 fast 8-bit on M4 and M8 and saw no bitstream changes
  | Speed Deviation  | BD-Rate   Deviation | Memory Deviation
-- | -- | -- | --
M4 - 8bit| -0.02% | 0.00% | 0.00%
M8 - 8bit| -0.53% | 0.00% | -0.02%

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@ccccheung 
@Arhuan
@1480c1  

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [x] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
