### PR TITLE
gitlab: add avx512 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,6 +152,13 @@ Linux (GCC 10, Tests, Static):
       - Bin/Release/SvtAv1ApiTests
       - Bin/Release/SvtAv1E2ETests
 
+Linux (GCC 10, AVX512):
+  extends: .linux-compiler-base
+  variables:
+    CC: gcc-10
+    CXX: g++-10
+    EXTRA_CMAKE_FLAGS: -DENABLE_AVX512=ON
+
 .sanitizer compile:
   extends: .linux-compiler-base
   variables:

--- a/Build/windows/build.bat
+++ b/Build/windows/build.bat
@@ -144,6 +144,9 @@ if -%1-==-- (
 ) else if /I "%1"=="c-only" (
     set "cmake_eflags=%cmake_eflags% -DCOMPILE_C_ONLY=ON"
     shift
+) else if /I "%1"=="avx512" (
+    set "cmake_eflags=%cmake_eflags% -DENABLE_AVX512=ON"
+    shift
 )  else (
     echo Unknown argument "%1"
     call :help
@@ -152,6 +155,6 @@ goto :args
 
 :help
     echo Batch file to build SVT-AV1 on Windows
-    echo Usage: build.bat [2019^|2017^|2015^|clean] [release^|debug] [nobuild] [test] [shared^|static] [c-only]
+    echo Usage: build.bat [2019^|2017^|2015^|clean] [release^|debug] [nobuild] [test] [shared^|static] [c-only] [avx512]
     exit
 goto :EOF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,9 +228,17 @@ elseif(CMAKE_ASM_NASM_COMPILER MATCHES "yasm")
 endif()
 
 include(CheckSymbolExists)
+
 check_symbol_exists("_mm512_extracti64x4_epi64" "immintrin.h" HAS_AVX512)
-if(NOT HAS_AVX512)
-    add_definitions(-DNON_AVX512_SUPPORT)
+if(HAS_AVX512)
+    option(ENABLE_AVX512 "Enable building avx512 code" OFF)
+else()
+    set(ENABLE_AVX512 OFF CACHE INTERNAL "Enable building avx512 code")
+endif()
+if(ENABLE_AVX512)
+    add_definitions(-DEN_AVX512_SUPPORT=1)
+else()
+    add_definitions(-DEN_AVX512_SUPPORT=0)
 endif()
 
 # ASM compiler macro

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -33,11 +33,6 @@
 extern "C" {
 #endif // __cplusplus
 
-// undefining this macro would allow the AVX512 optimization to be enabled by default
-#ifndef NON_AVX512_SUPPORT
-#define NON_AVX512_SUPPORT
-#endif
-
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC               0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 #define DEBUG_TPL               0 // Prints to debug TPL

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <immintrin.h>
 #include "EbHighbdIntraPrediction_SSE2.h"
 #include "common_dsp_rtcd.h"

--- a/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
@@ -10,7 +10,7 @@
 */
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h>
 #include "EbPictureOperators_Inline_AVX2.h"
@@ -365,4 +365,4 @@ uint64_t svt_spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t inpu
     return hadd32_avx2_intrin(sum);
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/cdef_block_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/cdef_block_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <immintrin.h>
 #include "common_dsp_rtcd.h"
 #include "EbBitstreamUnit.h"
@@ -214,4 +214,4 @@ void svt_cdef_filter_block_8x8_16_avx512(const uint16_t *const in, const int32_t
     }
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include "EbMemory_SSE4_1.h"
 #include "common_dsp_rtcd.h"
@@ -1206,4 +1206,4 @@ void svt_av1_convolve_2d_copy_sr_avx512(const uint8_t *src, int32_t src_stride, 
     }
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/convolve_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h>
 #include "common_dsp_rtcd.h"
@@ -1443,4 +1443,4 @@ void svt_av1_convolve_x_sr_avx512(const uint8_t *src, int32_t src_stride, uint8_
     }
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
+++ b/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
@@ -21,7 +21,7 @@
 #include "synonyms_avx2.h"
 #include "synonyms_avx512.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 static INLINE __m512i svt_mm512_broadcast_i64x2(const __m128i v) {
 #ifdef _WIN32
@@ -1103,6 +1103,6 @@ static INLINE void jnt_no_avg_round_store_64_avx512(const __m512i res[2], const 
     jnt_no_avg_store_64_avx512(d[0], d[1], dst);
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT
 
 #endif // AOM_DSP_X86_CONVOLVE_AVX512_H_

--- a/Source/Lib/Common/ASM_AVX512/highbd_inv_txfm_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_inv_txfm_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <assert.h>
 #include <immintrin.h>

--- a/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <immintrin.h>
 #include "common_dsp_rtcd.h"
 #include "convolve.h"
@@ -2134,4 +2134,4 @@ void svt_av1_jnt_convolve_2d_avx512(const uint8_t *src, int32_t src_stride, uint
         im_block, w, h, filter_params_y, subpel_y_q4, conv_params, dst8, dst8_stride);
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/jnt_convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/jnt_convolve_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <immintrin.h>
 #include "common_dsp_rtcd.h"
 #include "convolve.h"
@@ -4003,4 +4003,4 @@ void svt_av1_jnt_convolve_x_avx512(const uint8_t *src, int32_t src_stride, uint8
     jnt_convolve_x_tap_func_table[tap_x](
         src, src_stride, dst8, dst8_stride, w, h, filter_params_x, subpel_x_q4, conv_params);
 }
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/synonyms_avx512.h
+++ b/Source/Lib/Common/ASM_AVX512/synonyms_avx512.h
@@ -15,7 +15,7 @@
 #include <immintrin.h>
 #include "synonyms.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 /**
   * Various reusable shorthands for x86 SIMD intrinsics.
@@ -49,6 +49,6 @@ static INLINE void zz_storeu_512(void *const a, const __m512i v) {
     _mm512_storeu_si512((__m512i *)a, v);
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT
 
 #endif // AOM_DSP_X86_SYNONYMS_AVX512_H_

--- a/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
@@ -10,7 +10,7 @@
  */
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <assert.h>
 #include <immintrin.h>
 
@@ -1161,4 +1161,4 @@ void svt_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrd
     }
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -101,7 +101,7 @@ CPU_FLAGS get_cpu_flags() {
 
 CPU_FLAGS get_cpu_flags_to_use() {
     CPU_FLAGS flags = get_cpu_flags();
-#ifdef NON_AVX512_SUPPORT
+#if !EN_AVX512_SUPPORT
     /* Remove AVX512 flags. */
     flags &= (CPU_FLAGS_AVX512F - 1);
 #endif
@@ -110,12 +110,12 @@ CPU_FLAGS get_cpu_flags_to_use() {
 #endif /*ARCH_X86_64*/
 
 #ifdef ARCH_X86_64
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #define SET_FUNCTIONS_AVX512(ptr, avx512)                                                         \
     if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;
-#else /* NON_AVX512_SUPPORT */
+#else /* EN_AVX512_SUPPORT */
 #define SET_FUNCTIONS_AVX512(ptr, avx512)
-#endif /* NON_AVX512_SUPPORT */
+#endif /* EN_AVX512_SUPPORT */
 
 #define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     if (((uintptr_t)NULL != (uintptr_t)mmx)    && (flags & HAS_MMX))    ptr = mmx;                \
@@ -511,7 +511,7 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     /* No C version, use only internal in kerneal: svt_cdef_filter_block_avx2() */
 #ifdef ARCH_X86_64
     if (flags & HAS_AVX2)    svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx2;
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     if (flags & HAS_AVX512F) svt_cdef_filter_block_8x8_16 = svt_cdef_filter_block_8x8_16_avx512;
 #endif
 #endif

--- a/Source/Lib/Encoder/ASM_AVX512/EbCdef_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbCdef_AVX512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h>
 #include "aom_dsp_rtcd.h"
@@ -79,4 +79,4 @@ uint64_t svt_search_one_dual_avx512(int *lev0, int *lev1, int nb_strengths,
     return best_tot_mse;
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Encoder/ASM_AVX512/EbCombinedAveragingSAD_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbCombinedAveragingSAD_AVX512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h>
 #include "EbCombinedAveragingSAD_Inline_AVX2.h"
@@ -166,4 +166,4 @@ uint32_t combined_averaging_ssd_avx512(uint8_t *src, ptrdiff_t src_stride, uint8
     return _mm_cvtsi128_si32(sum_128);
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <assert.h>
 #include "EbComputeSAD_AVX2.h"
 #include <immintrin.h>
@@ -4930,4 +4930,4 @@ void svt_sad_loop_kernel_avx512_intrin(
     *x_search_center = (int16_t)best_x;
     *y_search_center = (int16_t)best_y;
 }
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Encoder/ASM_AVX512/encodetxb_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/encodetxb_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h> /* AVX2 */
 #include "synonyms.h"
@@ -147,4 +147,4 @@ void svt_av1_txb_init_levels_avx512(const TranLow *const coeff, const int32_t wi
         xx_storeu_128(ls + 2 * 64, x_zeros);
     }
 }
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Encoder/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #include <assert.h>
 #include "aom_dsp_rtcd.h"
 #include "EbTransforms.h"

--- a/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
@@ -11,7 +11,7 @@
 
 #include "EbDefinitions.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 #include <immintrin.h> // AVX2
 #include "synonyms.h"
@@ -3523,4 +3523,4 @@ int64_t svt_av1_lowbd_pixel_proj_error_avx512(const uint8_t *src8, int32_t width
     return err + _mm_cvtsi128_si64(hadd_64_avx2(sum_256));
 }
 
-#endif // !NON_AVX512_SUPPORT
+#endif // EN_AVX512_SUPPORT

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -27,12 +27,12 @@
  **************************************/
 
 #ifdef ARCH_X86_64
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 #define SET_FUNCTIONS_AVX512(ptr, avx512)                                                         \
     if (((uintptr_t)NULL != (uintptr_t)avx512) && (flags & HAS_AVX512F)) ptr = avx512;
-#else /* NON_AVX512_SUPPORT */
+#else /* EN_AVX512_SUPPORT */
 #define SET_FUNCTIONS_AVX512(ptr, avx512)
-#endif /* NON_AVX512_SUPPORT */
+#endif /* EN_AVX512_SUPPORT */
 
 #define SET_FUNCTIONS_X86(ptr, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512) \
     if (((uintptr_t)NULL != (uintptr_t)mmx)    && (flags & HAS_MMX))    ptr = mmx;                \

--- a/test/CdefTest.cc
+++ b/test/CdefTest.cc
@@ -54,7 +54,7 @@ typedef void (*svt_cdef_filter_block_8x8_16_func)(
 static const svt_cdef_filter_block_8x8_16_func
     svt_cdef_filter_block_8x8_16_func_table[] = {
         svt_cdef_filter_block_8x8_16_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
         svt_cdef_filter_block_8x8_16_avx512
 #endif
 };
@@ -684,7 +684,7 @@ typedef uint64_t (*svt_search_one_dual_func)(int *lev0, int *lev1,
 
 static const svt_search_one_dual_func search_one_dual_func_table[] = {
     svt_search_one_dual_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_search_one_dual_avx512
 #endif
 };

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -19,7 +19,7 @@
 #include "random.h"
 #include "util.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 using namespace std;
 int bitdepth[] = { 8, 10, 12 };
 

--- a/test/EbHighbdIntraPredictionTests.h
+++ b/test/EbHighbdIntraPredictionTests.h
@@ -15,7 +15,7 @@
 
 #include "aom_dsp_rtcd.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 typedef void(*aom_highbd_dc_top_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
 static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_opt[7] = {

--- a/test/EncodeTxbAsmTest.cc
+++ b/test/EncodeTxbAsmTest.cc
@@ -305,7 +305,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(::testing::Values(&svt_av1_txb_init_levels_avx2),
                        ::testing::Range(0, static_cast<int>(TX_SIZES_ALL), 1)));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(
     EntropyAVX512, EncodeTxbInitLevelTest,
     ::testing::Combine(::testing::Values(&svt_av1_txb_init_levels_avx512),

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -15,7 +15,7 @@
 #include "EbUnitTestUtility.h"
 #include "EbUnitTest.h"
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 typedef void(*svt_av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
 svt_av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[9] = { svt_av1_fwd_txfm2d_16x16_avx2, svt_av1_fwd_txfm2d_32x32_avx2 , svt_av1_fwd_txfm2d_64x64_avx2 , svt_av1_fwd_txfm2d_16x64_avx2, svt_av1_fwd_txfm2d_64x16_avx2 , svt_av1_fwd_txfm2d_32x64_avx2 , svt_av1_fwd_txfm2d_64x32_avx2 , svt_av1_fwd_txfm2d_16x32_avx2 , svt_av1_fwd_txfm2d_32x16_avx2 };

--- a/test/FwdTxfm2dAsmTest.cc
+++ b/test/FwdTxfm2dAsmTest.cc
@@ -113,7 +113,7 @@ static const FwdTxfm2dFunc fwd_txfm_2d_N4_c_func[TX_SIZES_ALL] = {
     svt_av1_fwd_txfm2d_64x16_N4_c,
 };
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 static const FwdTxfm2dFunc fwd_txfm_2d_N2_asm512_func[TX_SIZES_ALL] = {
     NULL,
     NULL,
@@ -221,7 +221,7 @@ class FwdTxfm2dAsmTest : public ::testing::TestWithParam<FwdTxfm2dAsmParam> {
             "ASM AND N4 ", fwd_txfm_2d_N4_asm_func[tx_size_], test_func);
     }
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     void run_match_test_N2_512() {
         FwdTxfm2dFunc test_func_asm = fwd_txfm_2d_N2_asm512_func[tx_size_];
         FwdTxfm2dFunc ref_func = fwd_txfm_2d_c_func[tx_size_];
@@ -426,7 +426,7 @@ TEST_P(FwdTxfm2dAsmTest, DISABLED_speed_test) {
     speed_test();
 }
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 TEST_P(FwdTxfm2dAsmTest, match_test_N2_512) {
     if (CPU_FLAGS_AVX512F & get_cpu_flags_to_use()) {
         run_match_test_N2_512();

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -118,7 +118,7 @@ static const InvSqrTxfmFuncPair inv_txfm_c_sse4_1_func_pairs[TX_64X64 + 1] = {
     SQR_FUNC_PAIRS(svt_av1_inv_txfm2d_add_64x64, sse4_1, is_tx_type_imp_64x64_sse4),
 };
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 static const InvSqrTxfmFuncPair inv_txfm_c_avx512_func_pairs[TX_64X64 + 1] = {
     EMPTY_FUNC_PAIRS(svt_av1_inv_txfm2d_add_4x4),
     EMPTY_FUNC_PAIRS(svt_av1_inv_txfm2d_add_8x8),
@@ -151,7 +151,7 @@ static const InvRectTxfm2dType1Func rect_type1_ref_funcs_c[TX_SIZES_ALL] = {
     svt_av1_inv_txfm2d_add_16x64_c,
     svt_av1_inv_txfm2d_add_64x16_c};
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 static const InvRectTxfm2dType1Func rect_type1_ref_funcs_avx512[TX_SIZES_ALL] = {
     nullptr,
     nullptr,
@@ -259,7 +259,7 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
         const int height = tx_size_high[tx_size];
         InvSqrTxfmFuncPair pair = (is_asm_kernel == 0)
                                       ? inv_txfm_c_avx2_func_pairs[tx_size]
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
                                       : (is_asm_kernel == 2)
                                       ? inv_txfm_c_avx512_func_pairs[tx_size]
 #endif
@@ -693,7 +693,7 @@ TEST_P(InvTxfm2dAsmTest, sqr_txfm_match_test) {
         const TxSize tx_size = static_cast<TxSize>(i);
         run_sqr_txfm_match_test(tx_size, 0);
         run_sqr_txfm_match_test(tx_size, 1);
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
         if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F)
             run_sqr_txfm_match_test(tx_size, 2);
 #endif
@@ -706,7 +706,7 @@ TEST_P(InvTxfm2dAsmTest, rect_type1_txfm_match_test) {
         run_rect_type1_txfm_match_test(tx_size,rect_type1_ref_funcs_c);
     }
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
         for (int i = TX_4X8; i < TX_SIZES_ALL; i++) {
             const TxSize tx_size = static_cast<TxSize>(i);

--- a/test/MotionEstimationTest.cc
+++ b/test/MotionEstimationTest.cc
@@ -293,7 +293,7 @@ TEST(MotionEstimation_avx2, DISABLED_sadMxNx4d_speed) {
     sadMxNx4d_speed_test(aom_sad_4d_avx2_func_ptr_array);
 }
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 
 //NULL means not implemented
 AomSadFn aom_sad_avx512_func_ptr_array[num_sad] = {
@@ -333,4 +333,4 @@ TEST(MotionEstimation_avx512, DISABLED_sadMxNx4d_speed) {
     sadMxNx4d_speed_test(aom_sad_4d_avx512_func_ptr_array);
 }
 
-#endif  // !NON_AVX512_SUPPORT
+#endif  // EN_AVX512_SUPPORT

--- a/test/ResidualTest.cc
+++ b/test/ResidualTest.cc
@@ -129,7 +129,7 @@ typedef void (*svt_residual_kernel8bit_func)(uint8_t *input, uint32_t input_stri
 
 static const svt_residual_kernel8bit_func residual_kernel8bit_func_table[] = {
     svt_residual_kernel8bit_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_residual_kernel8bit_avx512
 #endif
 };

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -233,7 +233,7 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN,
                                          WIENER_WIN_3TAP)));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(
     AV1_COMPUTE_STATS_AVX512, av1_compute_stats_test,
     ::testing::Combine(::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
@@ -481,7 +481,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN, WIENER_WIN_3TAP),
         ::testing::Values(AOM_BITS_8, AOM_BITS_10, AOM_BITS_12)));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(
     AV1_COMPUTE_STATS_HBD_AVX512, av1_compute_stats_test_hbd,
     ::testing::Combine(

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -570,7 +570,7 @@ typedef std::tuple<Ebsad_LoopKernelNxMType, Ebsad_LoopKernelNxMType> FuncPair;
 FuncPair TEST_FUNC_PAIRS[] = {
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_sse4_1_intrin),
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_avx2_intrin),
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_avx512_intrin),
 #endif
 };
@@ -578,7 +578,7 @@ FuncPair TEST_FUNC_PAIRS[] = {
 FuncPair TEST_FUNC_PAIRS_SMALL[] = {
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_sse4_1_intrin),
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_avx2_intrin),
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     FuncPair(svt_sad_loop_kernel_c, svt_sad_loop_kernel_avx512_intrin),
 #endif
 };

--- a/test/SelfGuidedUtilTest.cc
+++ b/test/SelfGuidedUtilTest.cc
@@ -331,7 +331,7 @@ TEST_P(PixelProjErrorLbdTest, DISABLED_SpeedTest) {
 static const PixelProjErrorTestParam lbd_test_vector[] = {
     make_tuple(svt_av1_lowbd_pixel_proj_error_avx2,
                svt_av1_lowbd_pixel_proj_error_c),
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     make_tuple(svt_av1_lowbd_pixel_proj_error_avx512,
                svt_av1_lowbd_pixel_proj_error_c)
 #endif

--- a/test/SpatialFullDistortionTest.cc
+++ b/test/SpatialFullDistortionTest.cc
@@ -185,7 +185,7 @@ TEST_P(SpatialFullDistortionTest, DISABLED_Speed) {
 INSTANTIATE_TEST_CASE_P(AVX2, SpatialFullDistortionTest,
     ::testing::Values(svt_spatial_full_distortion_kernel_avx2));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(
     AVX512, SpatialFullDistortionTest,
     ::testing::Values(svt_spatial_full_distortion_kernel_avx512));
@@ -360,7 +360,7 @@ void SpatialFullDistortionKernelFuncTest::RunCheckOutput() {
 TEST_P(SpatialFullDistortionKernelFuncTest, SpatialKernelFuncTest) {
     RunCheckOutput();
 }
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(
     SpatialKernelFunc, SpatialFullDistortionKernelFuncTest,
     ::testing::Combine(

--- a/test/convolve_2d_test.cc
+++ b/test/convolve_2d_test.cc
@@ -67,56 +67,56 @@ using lowbd_convolve_func = void (*)(const uint8_t *src, int src_stride,
 
 static const lowbd_convolve_func lowbd_convolve_2d_sr_func_table[] = {
     svt_av1_convolve_2d_sr_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_convolve_2d_sr_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_convolve_x_sr_func_table[] = {
     svt_av1_convolve_x_sr_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_convolve_x_sr_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_convolve_y_sr_func_table[] = {
     svt_av1_convolve_y_sr_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_convolve_y_sr_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_convolve_copy_sr_func_table[] = {
     svt_av1_convolve_2d_copy_sr_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_convolve_2d_copy_sr_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_jnt_convolve_2d_func_table[] = {
     svt_av1_jnt_convolve_2d_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_jnt_convolve_2d_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_jnt_convolve_x_func_table[] = {
     svt_av1_jnt_convolve_x_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_jnt_convolve_x_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_jnt_convolve_y_func_table[] = {
     svt_av1_jnt_convolve_y_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_jnt_convolve_y_avx512
 #endif
 };
 
 static const lowbd_convolve_func lowbd_jnt_convolve_copy_func_table[] = {
     svt_av1_jnt_convolve_2d_copy_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_jnt_convolve_2d_copy_avx512
 #endif
 };
@@ -799,7 +799,7 @@ INSTANTIATE_TEST_CASE_P(ConvolveTestY, AV1LbdJntConvolve2DTest,
 INSTANTIATE_TEST_CASE_P(ConvolveTest2D, AV1LbdJntConvolve2DTest,
                         BuildParams(1, 1, 0, 0));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(ConvolveTestCOPY_AVX512, AV1LbdJntConvolve2DTest,
                         BuildParams(0, 0, 1, 0));
 INSTANTIATE_TEST_CASE_P(ConvolveTestX_AVX512, AV1LbdJntConvolve2DTest,
@@ -849,7 +849,7 @@ INSTANTIATE_TEST_CASE_P(ConvolveTestY, AV1LbdSrConvolve2DTest,
 INSTANTIATE_TEST_CASE_P(ConvolveTest2D, AV1LbdSrConvolve2DTest,
                         BuildParams(1, 1, 0, 0));
 
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
 INSTANTIATE_TEST_CASE_P(ConvolveTestCopy_AVX512, AV1LbdSrConvolve2DTest,
                         BuildParams(0, 0, 1, 0));
 INSTANTIATE_TEST_CASE_P(ConvolveTestX_AVX512, AV1LbdSrConvolve2DTest,

--- a/test/wiener_convolve_test.cc
+++ b/test/wiener_convolve_test.cc
@@ -107,7 +107,7 @@ static const int test_tap_table[] = {7, 5, 3};
 
 static const WienerConvolveFunc wiener_convolve_func_table[] = {
     svt_av1_wiener_convolve_add_src_avx2,
-#ifndef NON_AVX512_SUPPORT
+#if EN_AVX512_SUPPORT
     svt_av1_wiener_convolve_add_src_avx512
 #endif
 };


### PR DESCRIPTION
# Description

Changes avx512 macro to `EN_AVX512_SUPPORT`

Activatable by adding `-DENABLE_AVX512=ON` on the cmake line or through `./Build/linux/build.sh --enable-avx512` or `./Build/windows/build.bat avx512`


# Issue

https://github.com/AOMediaCodec/SVT-AV1/pull/1650
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
