### PR TITLE
gitlab: add gstreamer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,6 +283,36 @@ Linux E2E Tests:
     - mv test/vectors/* .
     - ./Bin/Release/SvtAv1E2ETests --gtest_filter=-*DummySrcTest*
 
+Linux (Gstreamer, Static):
+  extends: .tests
+  variables:
+    CC: gcc-10
+    CXX: g++-10
+    CFLAGS: -pipe -O3
+    CXXFLAGS: -pipe -O3
+    LDFLAGS: -pipe
+    CCACHE_DIR: $CI_PROJECT_DIR/.ccache
+    PKG_CONFIG_PATH: /usr/local/lib/pkgconfig
+    GIT_DEPTH: 0
+  cache:
+    key: ${CI_JOB_NAME}
+    paths:
+      - .ccache
+    policy: pull-push
+  needs:
+    - 'Linux (GCC 10)'
+  script:
+    - cmake -GNinja -B Build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_APPS=OFF -DBUILD_DEC=OFF
+    - cmake --build Build --config Release --target install
+    - meson setup gstreamer-plugin/build gstreamer-plugin -Dprefix=/usr
+    - ninja -C gstreamer-plugin/build install
+    - |
+      gst-launch-1.0 -v filesrc location=akiyo_cif.y4m \
+        ! y4mdec \
+        ! svtav1enc \
+        ! webmmux \
+        ! filesink location=akiyo.mkv
+
 Linux (FFmpeg, Static):
   extends: .tests
   variables:


### PR DESCRIPTION
# Description

adds gstreamer testing to gitlab

# Issue
https://gitlab.com/AOMediaCodec/aom-testing/-/merge_requests/14
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
