### PR TITLE
ci: remove merged vmaf patch

### DIFF
--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -103,7 +103,7 @@ jobs:
           path: vmaf
       - name: Configure libvmaf
         run: |
-          sudo -E meson setup --buildtype release --libdir lib -Denable_{tests,docs}=false -Dbuilt_in_models=false vmaf-build vmaf/libvmaf
+          sudo -E meson setup --buildtype release --libdir lib -Denable_{tests,docs}=false -Dbuilt_in_models=true vmaf-build vmaf/libvmaf
           sudo -E meson install -C vmaf-build
 
       - name: Check for symbol conflicts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -356,7 +356,6 @@ Linux (FFmpeg, Static):
     - meson install -C dav1d-build
 
     # vmaf
-    - curl -Ls "https://github.com/Netflix/vmaf/pull/768.patch" | git -C vmaf apply -3
     - |
       meson setup \
         --default-library static \


### PR DESCRIPTION
# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
