### PR TITLE
cppcheck: suppress unused functions and extra messages

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -33,4 +33,5 @@ jobs:
             --enable=all \
             -j $(nproc) \
             --template="::error file={file},line={line},col={column}::{severity}: {message} ({id})\n{file}:{line}" \
-            -ithird_party
+            -ithird_party \
+            --suppress=unusedFunction > /dev/null

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,8 @@ Static analysis (cppcheck):
         -j 2 \
         -rp=$PWD \
         -ithird_party \
-        --cppcheck-build-dir=.cppcheck
+        --cppcheck-build-dir=.cppcheck \
+        --suppress=unusedFunction > /dev/null
 
 #
 # Linux CI Jobs


### PR DESCRIPTION
# Description

This limits the messages shown on the cppcheck jobs to just errros

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
