### PR TITLE
svt_spatial_full_distortion_kernel_avx512: fix Wshadow warning

### DIFF
--- a/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
@@ -350,7 +350,7 @@ uint64_t svt_spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t inpu
                     leftover_sum64, _mm256_unpackhi_epi32(sum, _mm256_setzero_si256()));
                 sum       = _mm256_add_epi64(sum_L, sum_H);
                 sum       = _mm256_add_epi64(sum, leftover_sum64);
-                __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum),
+                s = _mm_add_epi64(_mm256_castsi256_si128(sum),
                                           _mm256_extracti128_si256(sum, 1));
                 return _mm_extract_epi64(s, 0) + _mm_extract_epi64(s, 1);
             }


### PR DESCRIPTION
# Description

```c
FAILED: Source/Lib/Common/ASM_AVX512/CMakeFiles/COMMON_ASM_AVX512.dir/EbPictureOperators_Intrinsic_AVX512.c.o 
/usr/lib/ccache/gcc-10 -DARCH_X86_64=1 -DEN_AVX512_SUPPORT=1 -DSAFECLIB_STR_NULL_SLACK=1 -I../. -I../Source/API -I../Source/Lib/Common/Codec -I../Source/Lib/Common/C_DEFAULT -I../Source/Lib/Common/ASM_SSE2 -I../Source/Lib/Common/ASM_SSSE3 -I../Source/Lib/Common/ASM_SSE4_1 -I../Source/Lib/Common/ASM_AVX2 -I../Source/Lib/Common/ASM_AVX512 -Wall -Wextra -Wformat -Wformat-security -Werror -Wshadow -fstack-protector-strong -mavx2 -mavx512f -mavx512bw -mavx512dq -mavx512vl -O3 -DNDEBUG -fPIC -fvisibility=hidden -std=gnu99 -MD -MT Source/Lib/Common/ASM_AVX512/CMakeFiles/COMMON_ASM_AVX512.dir/EbPictureOperators_Intrinsic_AVX512.c.o -MF Source/Lib/Common/ASM_AVX512/CMakeFiles/COMMON_ASM_AVX512.dir/EbPictureOperators_Intrinsic_AVX512.c.o.d -o Source/Lib/Common/ASM_AVX512/CMakeFiles/COMMON_ASM_AVX512.dir/EbPictureOperators_Intrinsic_AVX512.c.o -c ../Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
../Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c: In function 'svt_spatial_full_distortion_kernel_avx512':
../Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c:353:25: error: declaration of 's' shadows a previous local [-Werror=shadow]
  353 |                 __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum),
      |                         ^
../Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c:201:34: note: shadowed declaration is here
  201 |     __m128i        sum_l, sum_h, s;
      |                                  ^
```

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
