### PR TITLE
CMake: add -mno-avx if supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,9 +205,6 @@ else()
     else()
         check_both_flags_add(-fstack-protector-strong)
     endif()
-endif()
-
-if(CMAKE_C_FLAGS MATCHES ".*-march=native.*" OR CMAKE_CXX_FLAGS MATCHES ".*-march=native.*")
     check_both_flags_add(-mno-avx)
 endif()
 


### PR DESCRIPTION


# Description

`-mavx` implies `-msse2avx` which converts sse to avx which can cause seg faults

moves `-mno-avx` from being only applied on march to being applied generally

# Issue
Fixes  https://github.com/AOMediaCodec/SVT-AV1/issues/1668
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
