### PR TITLE
gitlab: use individual video files 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,8 +193,8 @@ Linux (Thread sanitizer):
   stage: test
   image: registry.gitlab.com/aomediacodec/aom-testing/ubuntu2004
   before_script:
-    - zstd -d /video.tar.zst
-    - tar xf /video.tar
+    - cp /*.zst .
+    - zstd -d *.zst
 
 Valgrind:
   extends: .tests
@@ -454,8 +454,9 @@ Linux (FFmpeg, Static):
     - cmake --build Build --config $CMAKE_BUILD_TYPE
 
 .macos-fetch-testdata: &macos-fetch-testdata |
-  curl -f -L -O --silent "https://gitlab.com/AOMediaCodec/aom-testing/-/raw/master/video.tar.zst"
-  zstd --stdout -d video.tar.zst | tar -xf -
+  for file in $TEST_FILES; do
+    curl -fLs "https://gitlab.com/AOMediaCodec/aom-testing/-/raw/master/test-files/$file.zst" | zstd -d - -o $file
+  done
 
 macOS (Xcode):
   extends: .macos-compiler-base
@@ -520,6 +521,8 @@ macOS Enc Test:
   tags:
     - macos-ci
   stage: test
+  variables:
+    TEST_FILES: akiyo_cif.y4m Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m
   script:
     - *macos-fetch-testdata
     - ./Bin/Release/SvtAv1EncApp --preset 0 -i "$SVT_ENCTEST_FILENAME" -n 3 -b "test-pr-${SVT_ENCTEST_BITNESS}bit-m0.ivf"


### PR DESCRIPTION
# Description

use the individual files for gitlab so we can remove video.tar.zst

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
