### PR TITLE
gitlab: add macOS FFmpeg test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -450,7 +450,7 @@ Linux (FFmpeg, Static):
     CXXFLAGS: -Werror -Wshadow $EXTRA_CXXFLAGS
   script:
     - export PATH="${VLC_PATH}:${PATH}"
-    - eval cmake -G${CMAKE_GENERATOR:=Ninja} -B Build -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} $EXTRA_CMAKE_FLAGS
+    - eval cmake -G${CMAKE_GENERATOR:=Ninja} -B Build -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR:=/usr/local} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} $EXTRA_CMAKE_FLAGS
     - cmake --build Build --config $CMAKE_BUILD_TYPE
 
 .macos-fetch-testdata: &macos-fetch-testdata |
@@ -473,10 +473,15 @@ macOS (Ninja, Static, Tests):
     EXTRA_CMAKE_FLAGS: -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON
     EXTRA_CFLAGS: -Wno-error -g
     EXTRA_CXXFLAGS: -Wno-error -g
+    PREFIX_DIR: ${CI_PROJECT_DIR}/SVT-Install/
+  after_script:
+    - mkdir -p ${PREFIX_DIR}
+    - cmake --build Build --target install
   artifacts:
     expire_in: 1 day
     paths:
       - Bin/Release/*
+      - ${CI_PROJECT_DIR}/SVT-Install/*
 
 macOS Unit Tests:
   tags:
@@ -535,6 +540,124 @@ macOS Enc Test:
         SVT_ENCTEST_BITNESS: 10
   needs:
     - 'macOS (Ninja, Static, Tests)'
+
+macOS FFmpeg (Static):
+  stage: test
+  tags:
+    - macos-ci
+  variables:
+    PREFIX_DIR: ${CI_PROJECT_DIR}/SVT-Install/
+    PKG_CONFIG_PATH: ${CI_PROJECT_DIR}/SVT-Install/lib/pkgconfig
+    CPPFLAGS: -I${CI_PROJECT_DIR}/SVT-Install/include
+    LDFLAGS: -L${CI_PROJECT_DIR}/SVT-Install/lib
+  script:
+    - git clone https://aomedia.googlesource.com/aom
+    - git clone https://chromium.googlesource.com/webm/libvpx
+    - git clone https://code.videolan.org/videolan/dav1d.git
+    - git clone https://github.com/Netflix/vmaf.git
+    - git clone https://github.com/FFmpeg/FFmpeg.git FFmpeg-src
+
+    # SVT-AV1
+    #- cmake -GNinja -B svtav1-build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_APPS=OFF -DBUILD_DEC=OFF
+    #- cmake --build svtav1-build --config Release --target install
+
+    # aom
+    - cmake -S aom -B aom-build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR} -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DENABLE_TESTDATA=0 -DENABLE_TOOLS=0
+    - cmake --build aom-build --config Release --target install
+
+    # libvpx
+    - mkdir -p vpx-build && cd vpx-build || exit 1
+    - |
+      ../libvpx/configure \
+        --disable-dependency-tracking \
+        --disable-docs \
+        --disable-examples \
+        --disable-libyuv \
+        --disable-postproc \
+        --disable-shared \
+        --disable-tools \
+        --disable-unit-tests \
+        --disable-webm-io \
+        --enable-postproc \
+        --enable-runtime-cpu-detect \
+        --enable-vp8 --enable-vp9 \
+        --enable-vp9-highbitdepth \
+        --enable-vp9-postproc \
+        --prefix=${PREFIX_DIR}
+    - make -j $(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) install
+    - cd -
+
+    # dav1d
+    - |
+      meson setup \
+        --default-library static \
+        --buildtype release \
+        --libdir lib \
+        --prefix ${PREFIX_DIR} \
+        -Denable_tests=false \
+        -Denable_examples=false \
+        -Denable_tools=false \
+        dav1d-build dav1d
+    - meson install -C dav1d-build
+
+    # vmaf
+    - |
+      meson setup \
+        --default-library static \
+        --buildtype release \
+        --libdir lib \
+        --prefix ${PREFIX_DIR} \
+        -Denable_tests=false \
+        -Denable_docs=false \
+        -Dbuilt_in_models=true \
+        -Denable_float=true \
+        vmaf-build vmaf/libvmaf
+    - meson install -C vmaf-build
+
+    # symbol conflict tests
+    # TODO: Fix syntax to work on macOS
+    #- |
+    #  conflicts=$(
+    #    nm -Ag --defined-only /usr/local/lib/lib{SvtAv1Enc,aom,dav1d,vpx,vmaf}.a 2>/dev/null |
+    #    sort -k3 |
+    #    uniq -D -f2 |
+    #    sed '/:$/d;/^$/d'
+    #  )
+    #  if [ -n "$conflicts" ]; then
+    #    printf 'Conflicts Found!\n%s\n' "$conflicts"
+    #    exit 1
+    #  fi
+
+    # FFmpeg
+    # Uses ld=CXX for libvmaf to autolink the stdc++ library
+    - mkdir -p FFmpeg-build && cd FFmpeg-build || exit 1
+    - |
+      ../FFmpeg-src/configure \
+        --arch=x86_64 \
+        --pkg-config-flags="--static" \
+        --cc="${CC:-ccache gcc}" \
+        --cxx="${CXX:-ccache g++}" \
+        --ld="${CXX:-ccache g++}" \
+        --enable-gpl --enable-static \
+        --prefix="${PREFIX_DIR}" \
+        --enable-libaom \
+        --enable-libdav1d \
+        --enable-libsvtav1 \
+        --enable-libvmaf \
+        --enable-libvpx \
+        --disable-shared || {
+          less ffbuild/config.log
+          exit 1
+        }
+    - make -j $(sysctl -n hw.ncpu) install
+    - mv ./ffmpeg $CI_PROJECT_DIR
+  needs:
+    - 'macOS (Ninja, Static, Tests)'
+  artifacts:
+    untracked: false
+    expire_in: 30 days
+    paths:
+      - ffmpeg
 
 #
 # Window CI Jobs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - compile
   - test
 
+variables:
+  CMAKE_GENERATOR: Ninja
+
 #
 # General checks
 #
@@ -20,8 +23,10 @@ Static analysis (cppcheck):
     paths:
       - .cppcheck
     policy: pull-push
+  variables:
+    CMAKE_GENERATOR: Unix Makefiles
   script:
-    - cmake -G"Unix Makefiles" -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - cmake -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - mkdir -p .cppcheck
     - jq '.[]|=with_entries(select(.value | test(".asm|/SVT-AV1/Build/cpuinfo") | not)) | unique' Build/compile_commands.json > compile_commands.json
     - |
@@ -52,7 +57,7 @@ Static analysis (cppcheck):
     policy: pull-push
   script:
     - ccache -s
-    - eval cmake -GNinja -B Build -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} -DBUILD_SHARED_LIBS=OFF $EXTRA_CMAKE_FLAGS
+    - eval cmake -B Build -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} -DBUILD_SHARED_LIBS=OFF $EXTRA_CMAKE_FLAGS
     - cmake --build Build --config $CMAKE_BUILD_TYPE --target install
     - ccache -s
 
@@ -303,7 +308,7 @@ Linux (Gstreamer, Static):
   needs:
     - 'Linux (GCC 10)'
   script:
-    - cmake -GNinja -B Build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_APPS=OFF -DBUILD_DEC=OFF
+    - cmake -B Build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_APPS=OFF -DBUILD_DEC=OFF
     - cmake --build Build --config Release --target install
     - meson setup gstreamer-plugin/build gstreamer-plugin -Dprefix=/usr
     - ninja -C gstreamer-plugin/build install
@@ -346,11 +351,11 @@ Linux (FFmpeg, Static):
     - git clone https://github.com/FFmpeg/FFmpeg.git
 
     # SVT-AV1
-    - cmake -GNinja -B svtav1-build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_APPS=OFF -DBUILD_DEC=OFF
+    - cmake -B svtav1-build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_APPS=OFF -DBUILD_DEC=OFF
     - cmake --build svtav1-build --config Release --target install
 
     # aom
-    - cmake -S aom -B aom-build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DENABLE_TESTDATA=0 -DENABLE_TOOLS=0
+    - cmake -S aom -B aom-build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DENABLE_TESTDATA=0 -DENABLE_TOOLS=0
     - cmake --build aom-build --config Release --target install
 
     # libvpx
@@ -450,7 +455,7 @@ Linux (FFmpeg, Static):
     CXXFLAGS: -Werror -Wshadow $EXTRA_CXXFLAGS
   script:
     - export PATH="${VLC_PATH}:${PATH}"
-    - eval cmake -G${CMAKE_GENERATOR:=Ninja} -B Build -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR:=/usr/local} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} $EXTRA_CMAKE_FLAGS
+    - eval cmake -B Build -DCMAKE_INSTALL_PREFIX=${PREFIX_DIR:=/usr/local} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release} $EXTRA_CMAKE_FLAGS
     - cmake --build Build --config $CMAKE_BUILD_TYPE
 
 .macos-fetch-testdata: &macos-fetch-testdata |
@@ -685,7 +690,6 @@ Win64 (Release, GCC, FFmpeg):
     CXXFLAGS: -pipe -O3
     LDFLAGS: -pipe -O3 -static -static-libgcc -static-libstdc++
     CCACHE_DIR: $CI_PROJECT_DIR/.ccache
-    CMAKE_GENERATOR: Ninja
     GIT_DEPTH: 0
   cache:
     key: ${CI_JOB_NAME}
@@ -794,16 +798,19 @@ Win64 (Release, MSVC, Tests):
   variables:
     CFLAGS: /WX
     CXXFLAGS: /WX
+    CMAKE_GENERATOR: Visual Studio 16 2019
   script:
     - cmake -B Build -DBUILD_TESTING=ON
     - cmake --build Build --config Release
+  after_script:
+    - Move-Item Bin\Release\* .
   artifacts:
     untracked: false
     expire_in: 1 day
     paths:
-      - Bin\Release\*.exe
-      - Bin\Release\*.dll
-      - Bin\Release\*.pdb
+      - "*.exe"
+      - "*.dll"
+      - "*.pdb"
 
 Win64 Unit Tests:
   extends: .windows-ci-common
@@ -818,7 +825,7 @@ Win64 Unit Tests:
       junit: report.xml
   script:
     - $env:GTEST_SHARD_INDEX = $env:CI_NODE_INDEX - 1
-    - '&"Bin\Release\SvtAv1UnitTests.exe" --gtest_filter=-*FFT*'
+    - ./SvtAv1UnitTests.exe --gtest_filter=-*FFT*'
   needs:
     - 'Win64 (Release, MSVC, Tests)'
 
@@ -827,8 +834,8 @@ Win64 Enc Test:
   stage: test
   script:
     - *windows-unpack-testdata
-    - '&"Bin\Release\SvtAv1EncApp.exe" --preset 0 -i "$env:SVT_ENCTEST_FILENAME" -n 3 -b "test-pr-${env:SVT_ENCTEST_BITNESS}bit-m0.ivf"'
-    - '&"Bin\Release\SvtAv1EncApp.exe" --preset 8 -i "$env:SVT_ENCTEST_FILENAME" -n 120 -b "test-pr-${env:SVT_ENCTEST_BITNESS}bit-m8.ivf"'
+    - ./SvtAv1EncApp.exe --preset 0 -i "$env:SVT_ENCTEST_FILENAME" -n 3 -b "test-pr-${env:SVT_ENCTEST_BITNESS}bit-m0.ivf"'
+    - ./SvtAv1EncApp.exe --preset 8 -i "$env:SVT_ENCTEST_FILENAME" -n 120 -b "test-pr-${env:SVT_ENCTEST_BITNESS}bit-m8.ivf"'
   parallel:
     matrix:
       - SVT_ENCTEST_FILENAME: "akiyo_cif.y4m"
@@ -854,6 +861,6 @@ Win64 E2E Tests:
     - cmake -B Build -DBUILD_TESTING=ON
     - cmake --build Build --target TestVectors
     - $env:GTEST_SHARD_INDEX = $env:CI_NODE_INDEX - 1
-    - '&"Bin\Release\SvtAv1E2ETests.exe" --gtest_filter=-*DummySrcTest*'
+    - ./SvtAv1E2ETests.exe --gtest_filter=-*DummySrcTest*'
   needs:
     - 'Win64 (Release, MSVC, Tests)'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -615,18 +615,22 @@ macOS FFmpeg (Static):
     - meson install -C vmaf-build
 
     # symbol conflict tests
-    # TODO: Fix syntax to work on macOS
-    #- |
-    #  conflicts=$(
-    #    nm -Ag --defined-only /usr/local/lib/lib{SvtAv1Enc,aom,dav1d,vpx,vmaf}.a 2>/dev/null |
-    #    sort -k3 |
-    #    uniq -D -f2 |
-    #    sed '/:$/d;/^$/d'
-    #  )
-    #  if [ -n "$conflicts" ]; then
-    #    printf 'Conflicts Found!\n%s\n' "$conflicts"
-    #    exit 1
-    #  fi
+    - |
+      conflicts=$(
+        nm -Ag --defined-only ${PREFIX_DIR}/lib/lib{SvtAv1Enc,aom,dav1d,vpx,vmaf}.a 2>/dev/null |
+        cut -d' ' -f 4 |
+        sort |
+        uniq -d
+      )
+      if [ -n "$conflicts" ]; then
+        printf 'Conflicts Found!\n'
+        for conflict in $conflicts; do
+          nm -Ag --defined-only ${PREFIX_DIR}/lib/lib{SvtAv1Enc,aom,dav1d,vpx,vmaf}.a 2>/dev/null |
+          sort -k3 |
+          grep -- " $conflict$"
+        done
+        exit 1
+      fi
 
     # FFmpeg
     # Uses ld=CXX for libvmaf to autolink the stdc++ library


### PR DESCRIPTION
# Description

This should theoretically be the last CI related job that needs to the added before the move

I am working on trying to combine as many of the ffmpeg jobs as we can so we do not have to update duplicate lines anytime we need to fix something.

https://gitlab.com/1480c1/SVT-AV1/-/pipelines/241438154

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@ePirat 
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
