### PR TITLE
Simd expf() implementation

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/CMakeLists.txt
+++ b/Source/Lib/Encoder/ASM_AVX2/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(../../../API
 link_directories(${PROJECT_SOURCE_DIR}/Source/Lib/Encoder/ASM_SSSE3/)
 
 check_both_flags_add(-mavx2)
+check_both_flags_add(-mfma)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
     if(WIN32)

--- a/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbTemporalFiltering_AVX2.c
@@ -127,18 +127,6 @@ static AOM_FORCE_INLINE int32_t xx_mask_and_hadd(__m256i vsum, int i) {
     return _mm_extract_epi32(v128a, 0);
 }
 
-/***************************************************************************************************
-* Visual studio 2019 in Release/RelWithDebInfo is replacing pair of 2 instruction
-* _mm256_mul_ps() and _mm256_add_ps() into one _mm256_fmadd_ps().
-* This instruction is faster but produce different results. There is no equivalent
-* in standard C asm, so we cannot use it. I created test --gtest_filter="*exponent_approximation*"
-* that compare this kernel with its C equivalent expf_c().
-* The only work-aroud is to disable optimization when msvc compiler is used.
-* Before commiting changes in this kernel, please make sure that UT is passing
-***************************************************************************************************/
-#if defined(_MSC_VER)
-#pragma optimize("", off)
-#endif
 __m256 exp_256_ps(__m256 _x) {
     __m256  t, f, p, r;
     __m256i i, j;
@@ -158,26 +146,19 @@ __m256 exp_256_ps(__m256 _x) {
     t = _mm256_mul_ps(_x, l2e); /* t = log2(e) * x */
     r = _mm256_round_ps(t, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC); /* r = rint (t) */
 
-    p = _mm256_mul_ps(r, l2h); /* log(2)_hi * r */
-    f = _mm256_add_ps(_x, p); /* x - log(2)_hi * r */
-    p = _mm256_mul_ps(r, l2l); /* log(2)_lo * r */
-    f = _mm256_add_ps(f, p); /* f = x - log(2)_hi * r - log(2)_lo * r */
+    f = _mm256_fmadd_ps(r, l2h, _x); /* x - log(2)_hi * r */
+    f = _mm256_fmadd_ps(r, l2l, f); /* f = x - log(2)_hi * r - log(2)_lo * r*/
 
     i = _mm256_cvtps_epi32(t); /* i = (int)rint(t) */
 
     /* p ~= exp (f), -log(2)/2 <= f <= log(2)/2 */
     p = c0; /* c0 */
 
-    p = _mm256_mul_ps(p, f); /* c0*f */
-    p = _mm256_add_ps(p, c1); /* c0*f+c1 */
-    p = _mm256_mul_ps(p, f); /* (c0*f+c1)*f */
-    p = _mm256_add_ps(p, c2); /* (c0*f+c1)*f+c2 */
-    p = _mm256_mul_ps(p, f); /* ((c0*f+c1)*f+c2)*f */
-    p = _mm256_add_ps(p, c3); /* ((c0*f+c1)*f+c2)*f+c3 */
-    p = _mm256_mul_ps(p, f); /* (((c0*f+c1)*f+c2)*f+c3)*f */
-    p = _mm256_add_ps(p, c4); /* (((c0*f+c1)*f+c2)*f+c3)*f+c4 ~= exp(f) */
-    p = _mm256_mul_ps(p, f); /* (((c0*f+c1)*f+c2)*f+c3)*f */
-    p = _mm256_add_ps(p, c5); /* (((c0*f+c1)*f+c2)*f+c3)*f+c4 ~= exp(f) */
+    p = _mm256_fmadd_ps(p, f, c1); /* c0*f+c1 */
+    p = _mm256_fmadd_ps(p, f, c2); /* (c0*f+c1)*f+c2 */
+    p = _mm256_fmadd_ps(p, f, c3); /* ((c0*f+c1)*f+c2)*f+c3 */
+    p = _mm256_fmadd_ps(p, f, c4); /* (((c0*f+c1)*f+c2)*f+c3)*f+c4 */
+    p = _mm256_fmadd_ps(p, f, c5); /* ((((c0*f+c1)*f+c2)*f+c3)*f+c4)*f +c5 ~= exp(f) */
 
     /* exp(x) = 2^i * p */
     j = _mm256_slli_epi32(i, 23); /* i << 23 */
@@ -185,9 +166,6 @@ __m256 exp_256_ps(__m256 _x) {
 
     return r;
 }
-#if defined(_MSC_VER)
-#pragma optimize("", on)
-#endif
 
 static void apply_temporal_filter_planewise(struct MeContext *context_ptr, const uint8_t *frame1,
                                             const unsigned int stride, const uint8_t *frame2,

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -644,26 +644,19 @@ float expf_c(float _x) {
     t = _x * l2e; /* t = log2(e) * x */
     r = rintf(t);
 
-    p = r * l2h; /* log(2)_hi * r */
-    f = _x + p; /* x - log(2)_hi * r */
-    p = r * l2l; /* log(2)_lo * r */
-    f = f + p; /* f = x - log(2)_hi * r - log(2)_lo * r */
+    f = (float)((double)(r) * l2h +_x);
+    f = (float)((double)(r) * l2l + f);
 
     i = (int32_t)rint(t);
 
     /* p ~= exp (f), -log(2)/2 <= f <= log(2)/2 */
     p = c0; /* c0 */
 
-    p = p * f; /* c0*f */
-    p = p + c1; /* c0*f+c1 */
-    p = p * f; /* (c0*f+c1)*f */
-    p = p + c2; /* (c0*f+c1)*f+c2 */
-    p = p * f; /* ((c0*f+c1)*f+c2)*f */
-    p = p + c3; /* ((c0*f+c1)*f+c2)*f+c3 */
-    p = p * f; /* (((c0*f+c1)*f+c2)*f+c3)*f */
-    p = p + c4; /* (((c0*f+c1)*f+c2)*f+c3)*f+c4 ~= exp(f) */
-    p = p * f; /* (((c0*f+c1)*f+c2)*f+c3)*f */
-    p = p + c5; /* (((c0*f+c1)*f+c2)*f+c3)*f+c4 ~= exp(f) */
+    p = (float)((double)(p) * f + c1);
+    p = (float)((double)(p) * f + c2);
+    p = (float)((double)(p) * f + c3);
+    p = (float)((double)(p) * f + c4);
+    p = (float)((double)(p) * f + c5);
 
     /* exp(x) = 2^i * p */
     j = i << 23; /* i << 23 */


### PR DESCRIPTION
# Description
Simd expf() implementation for Temporal filter
 
svt_av1_apply_temporal_filter_planewise_avx2() work about 3 times faster
With bd-rate deviation from a maximum gain of -0.03% to a maximum loss of 0.06% and average of 0%.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
