### PR TITLE
Restore removed kernels:

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.c
@@ -14,6 +14,54 @@
 #include "EbMemory_AVX2.h"
 #include "EbMemory_SSE4_1.h"
 /********************************************************************************************************************************/
+uint64_t svt_compute_mean8x8_avx2_intrin(
+    uint8_t *input_samples, // input parameter, input samples Ptr
+    uint32_t input_stride, // input parameter, input stride
+    uint32_t input_area_width, // input parameter, input area width
+    uint32_t input_area_height) // input parameter, input area height
+{
+    __m256i  sum, sum2, xmm2, xmm1, sum1, xmm0 = _mm256_setzero_si256();
+    uint64_t result;
+    xmm1 = _mm256_sad_epu8(
+        xmm0,
+        _mm256_set_m128i(_mm_loadl_epi64((__m128i *)(input_samples + input_stride)),
+                         _mm_loadl_epi64((__m128i *)(input_samples))));
+    xmm2 = _mm256_sad_epu8(
+        xmm0,
+        _mm256_set_m128i(_mm_loadl_epi64((__m128i *)(input_samples + 3 * input_stride)),
+                         _mm_loadl_epi64((__m128i *)(input_samples + 2 * input_stride))));
+    sum1 = _mm256_add_epi16(xmm1, xmm2);
+
+    input_samples += 4 * input_stride;
+
+    xmm1 = _mm256_sad_epu8(
+        xmm0,
+        _mm256_set_m128i(_mm_loadl_epi64((__m128i *)(input_samples + input_stride)),
+                         _mm_loadl_epi64((__m128i *)(input_samples))));
+    xmm2 = _mm256_sad_epu8(
+        xmm0,
+        _mm256_set_m128i(_mm_loadl_epi64((__m128i *)(input_samples + 3 * input_stride)),
+                         _mm_loadl_epi64((__m128i *)(input_samples + 2 * input_stride))));
+    sum2 = _mm256_add_epi16(xmm1, xmm2);
+
+    sum   = _mm256_add_epi16(sum1, sum2);
+    __m128i upper = _mm256_extractf128_si256(sum, 1); //extract upper 128 bit
+    upper = _mm_add_epi32(upper,
+                          _mm_srli_si128(upper, 8)); // shift 2nd 16 bits to the 1st and sum both
+
+    __m128i lower = _mm256_extractf128_si256(sum, 0); //extract lower 128 bit
+    lower = _mm_add_epi32(lower,
+                          _mm_srli_si128(lower, 8)); // shift 2nd 16 bits to the 1st and sum both
+
+    __m128i mean = _mm_add_epi32(lower, upper);
+
+    (void)input_area_width;
+    (void)input_area_height;
+
+    result = (uint64_t)_mm_cvtsi128_si32(mean) << 2;
+    return result;
+}
+
 void svt_compute_interm_var_four8x8_avx2_intrin(uint8_t *input_samples, uint16_t input_stride,
                                                 uint64_t *mean_of8x8_blocks, // mean of four  8x8
                                                 uint64_t *mean_of_squared8x8_blocks) // meanSquared

--- a/Source/Lib/Encoder/ASM_SSE2/EbComputeMean_Intrinsic_SSE2.c
+++ b/Source/Lib/Encoder/ASM_SSE2/EbComputeMean_Intrinsic_SSE2.c
@@ -122,6 +122,35 @@ uint64_t svt_compute_mean_of_squared_values8x8_sse2_intrin(
 
     return (uint64_t)_mm_cvtsi128_si32(xmm_block_mean) << 10;
 }
+
+uint64_t svt_compute_mean8x8_sse2_intrin(
+    uint8_t *input_samples, // input parameter, input samples Ptr
+    uint32_t input_stride, // input parameter, input stride
+    uint32_t input_area_width, // input parameter, input area width
+    uint32_t input_area_height) // input parameter, input area height
+{
+    __m128i xmm0 = _mm_setzero_si128(), xmm1, xmm2, xmm3, xmm4, xmm_sum1, xmm_sum2;
+
+    xmm1     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples)), xmm0);
+    xmm2     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + input_stride)), xmm0);
+    xmm3     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + 2 * input_stride)), xmm0);
+    xmm4     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + 3 * input_stride)), xmm0);
+    xmm_sum1 = _mm_add_epi16(_mm_add_epi16(xmm1, xmm2), _mm_add_epi16(xmm3, xmm4));
+
+    input_samples += 4 * input_stride;
+    xmm1     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples)), xmm0);
+    xmm2     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + input_stride)), xmm0);
+    xmm3     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + 2 * input_stride)), xmm0);
+    xmm4     = _mm_sad_epu8(_mm_loadl_epi64((__m128i *)(input_samples + 3 * input_stride)), xmm0);
+    xmm_sum2 = _mm_add_epi16(_mm_add_epi16(xmm1, xmm2), _mm_add_epi16(xmm3, xmm4));
+    xmm_sum2 = _mm_add_epi16(xmm_sum1, xmm_sum2);
+
+    (void)input_area_width;
+    (void)input_area_height;
+
+    return (uint64_t)_mm_cvtsi128_si32(xmm_sum2) << 2;
+}
+
 void svt_compute_interm_var_four8x8_helper_sse2(uint8_t *input_samples, uint16_t input_stride,
                                                 uint64_t *mean_of8x8_blocks, // mean of four  8x8
                                                 uint64_t *mean_of_squared8x8_blocks) // meanSquared

--- a/Source/Lib/Encoder/Codec/EbComputeMean.h
+++ b/Source/Lib/Encoder/Codec/EbComputeMean.h
@@ -19,6 +19,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+uint64_t svt_compute_mean_c(uint8_t* input_samples, /**< input parameter, input samples Ptr */
+    uint32_t input_stride, /**< input parameter, input stride */
+    uint32_t input_area_width, /**< input parameter, input area width */
+    uint32_t input_area_height); /**< input parameter, input area height */
+
 uint64_t svt_compute_mean_squared_values_c(
     uint8_t* input_samples, /**< input parameter, input samples Ptr */
     uint32_t input_stride, /**< input parameter, input stride */

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -281,6 +281,29 @@ void calculate_histogram(uint8_t * input_samples, // input parameter, input samp
     return;
 }
 /*******************************************
+ * compute_mean
+ *   returns the mean of a block
+ *******************************************/
+uint64_t svt_compute_mean_c(uint8_t *input_samples, /**< input parameter, input samples Ptr */
+                            uint32_t input_stride, /**< input parameter, input stride */
+                            uint32_t input_area_width, /**< input parameter, input area width */
+                            uint32_t input_area_height) /**< input parameter, input area height */
+{
+    uint32_t hi, vi;
+    uint64_t block_mean = 0;
+    assert(input_area_width > 0);
+    assert(input_area_height > 0);
+
+    for (vi = 0; vi < input_area_height; vi++) {
+        for (hi = 0; hi < input_area_width; hi++) { block_mean += input_samples[hi]; }
+        input_samples += input_stride;
+    }
+
+    block_mean = (block_mean << (VARIANCE_PRECISION >> 1)) / (input_area_width * input_area_height);
+
+    return block_mean;
+}
+/*******************************************
  * svt_compute_mean_squared_values_c
  *   returns the Mean of Squared Values
  *******************************************/
@@ -518,225 +541,225 @@ EbErrorType compute_chroma_block_mean(
     cr_block_index = input_cr_origin_index;
     if (scs_ptr->block_mean_calc_prec == BLOCK_MEAN_PREC_FULL) {
         cb_mean_of_16x16_blocks[0] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[0] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (0,1)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[1] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[1] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (0,2)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[2] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[2] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (0,3)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[3] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[3] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (1,0)
         cb_block_index = input_cb_origin_index + (input_padded_picture_ptr->stride_cb << 3);
         cr_block_index = input_cr_origin_index + (input_padded_picture_ptr->stride_cr << 3);
         cb_mean_of_16x16_blocks[4] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[4] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (1,1)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[5] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[5] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (1,2)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[6] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[6] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (1,3)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[7] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[7] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (2,0)
         cb_block_index = input_cb_origin_index + (input_padded_picture_ptr->stride_cb << 4);
         cr_block_index = input_cr_origin_index + (input_padded_picture_ptr->stride_cr << 4);
         cb_mean_of_16x16_blocks[8] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[8] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (2,1)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[9] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[9] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (2,2)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[10] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[10] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (2,3)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[11] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[11] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (3,0)
         cb_block_index = input_cb_origin_index + (input_padded_picture_ptr->stride_cb * 24);
         cr_block_index = input_cr_origin_index + (input_padded_picture_ptr->stride_cr * 24);
         cb_mean_of_16x16_blocks[12] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[12] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (3,1)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[13] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[13] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (3,2)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[14] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[14] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
 
         // (3,3)
         cb_block_index = cb_block_index + 8;
         cr_block_index = cr_block_index + 8;
         cb_mean_of_16x16_blocks[15] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
-                             input_padded_picture_ptr->stride_cb,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cb[cb_block_index]),
+                                 input_padded_picture_ptr->stride_cb,
+                                 8,
+                                 8);
         cr_mean_of_16x16_blocks[15] =
-            compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
-                             input_padded_picture_ptr->stride_cr,
-                             8,
-                             8);
+            svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_cr[cr_block_index]),
+                                 input_padded_picture_ptr->stride_cr,
+                                 8,
+                                 8);
     } else {
         const uint16_t stride_cb = input_padded_picture_ptr->stride_cb;
         const uint16_t stride_cr = input_padded_picture_ptr->stride_cr;
@@ -1029,10 +1052,10 @@ EbErrorType compute_block_mean_compute_variance(
     // (0,0)
     block_index = input_luma_origin_index;
     if (scs_ptr->block_mean_calc_prec == BLOCK_MEAN_PREC_FULL) {
-        mean_of8x8_blocks[0] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[0] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[0] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1041,10 +1064,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,1)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[1] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[1] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[1] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1053,10 +1076,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,2)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[2] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[2] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[2] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1065,10 +1088,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,3)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[3] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[3] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[3] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1077,10 +1100,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,4)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[4] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[4] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[4] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1089,10 +1112,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,5)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[5] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[5] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[5] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1101,10 +1124,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,6)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[6] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[6] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[6] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1113,10 +1136,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (0,7)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[7] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[7] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[7] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1125,10 +1148,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,0)
         block_index          = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 3);
-        mean_of8x8_blocks[8] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[8] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[8] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1137,10 +1160,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,1)
         block_index          = block_index + 8;
-        mean_of8x8_blocks[9] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                input_padded_picture_ptr->stride_y,
-                                                8,
-                                                8);
+        mean_of8x8_blocks[9] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                    input_padded_picture_ptr->stride_y,
+                                                    8,
+                                                    8);
         mean_of_8x8_squared_values_blocks[9] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1149,10 +1172,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[10] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[10] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[10] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1161,10 +1184,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[11] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[11] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[11] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1173,10 +1196,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[12] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[12] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[12] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1185,10 +1208,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[13] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[13] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[13] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1197,10 +1220,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[14] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[14] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[14] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1209,10 +1232,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (1,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[15] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[15] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[15] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1221,10 +1244,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,0)
         block_index           = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 4);
-        mean_of8x8_blocks[16] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[16] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[16] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1233,10 +1256,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[17] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[17] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[17] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1245,10 +1268,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[18] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[18] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[18] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1257,10 +1280,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[19] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[19] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[19] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1269,10 +1292,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         /// (2,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[20] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[20] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[20] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1281,10 +1304,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[21] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[21] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[21] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1293,10 +1316,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[22] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[22] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[22] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1305,10 +1328,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (2,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[23] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[23] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[23] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1318,10 +1341,10 @@ EbErrorType compute_block_mean_compute_variance(
         // (3,0)
         block_index = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 3) +
                       (input_padded_picture_ptr->stride_y << 4);
-        mean_of8x8_blocks[24] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[24] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[24] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1330,10 +1353,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[25] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[25] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[25] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1342,10 +1365,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[26] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[26] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[26] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1354,10 +1377,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[27] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[27] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[27] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1366,10 +1389,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[28] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[28] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[28] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1378,10 +1401,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[29] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[29] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[29] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1390,10 +1413,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[30] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[30] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[30] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1402,10 +1425,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (3,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[31] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[31] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[31] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1414,10 +1437,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,0)
         block_index           = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 5);
-        mean_of8x8_blocks[32] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[32] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[32] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1426,10 +1449,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[33] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[33] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[33] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1438,10 +1461,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[34] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[34] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[34] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1450,10 +1473,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[35] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[35] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[35] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1462,10 +1485,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[36] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[36] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[36] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1474,10 +1497,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[37] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[37] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[37] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1486,10 +1509,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[38] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[38] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[38] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1498,10 +1521,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (4,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[39] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[39] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[39] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1511,10 +1534,10 @@ EbErrorType compute_block_mean_compute_variance(
         // (5,0)
         block_index = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 3) +
                       (input_padded_picture_ptr->stride_y << 5);
-        mean_of8x8_blocks[40] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[40] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[40] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1523,10 +1546,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[41] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[41] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[41] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1535,10 +1558,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[42] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[42] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[42] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1547,10 +1570,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[43] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[43] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[43] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1559,10 +1582,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[44] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[44] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[44] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1571,10 +1594,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[45] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[45] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[45] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1583,10 +1606,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[46] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[46] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[46] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1595,10 +1618,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (5,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[47] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[47] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[47] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1608,10 +1631,10 @@ EbErrorType compute_block_mean_compute_variance(
         // (6,0)
         block_index = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 4) +
                       (input_padded_picture_ptr->stride_y << 5);
-        mean_of8x8_blocks[48] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[48] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[48] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1620,10 +1643,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[49] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[49] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[49] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1632,10 +1655,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[50] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[50] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[50] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1644,10 +1667,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[51] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[51] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[51] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1656,10 +1679,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[52] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[52] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[52] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1668,10 +1691,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[53] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[53] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[53] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1680,10 +1703,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[54] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[54] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[54] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1692,10 +1715,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (6,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[55] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[55] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[55] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1706,10 +1729,10 @@ EbErrorType compute_block_mean_compute_variance(
         block_index = input_luma_origin_index + (input_padded_picture_ptr->stride_y << 3) +
                       (input_padded_picture_ptr->stride_y << 4) +
                       (input_padded_picture_ptr->stride_y << 5);
-        mean_of8x8_blocks[56] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[56] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[56] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1718,10 +1741,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,1)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[57] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[57] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[57] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1730,10 +1753,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,2)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[58] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[58] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[58] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1742,10 +1765,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,3)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[59] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[59] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[59] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1754,10 +1777,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,4)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[60] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[60] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[60] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1766,10 +1789,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,5)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[61] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[61] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[61] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1778,10 +1801,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,6)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[62] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[62] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[62] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -1790,10 +1813,10 @@ EbErrorType compute_block_mean_compute_variance(
 
         // (7,7)
         block_index           = block_index + 8;
-        mean_of8x8_blocks[63] = compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
-                                                 input_padded_picture_ptr->stride_y,
-                                                 8,
-                                                 8);
+        mean_of8x8_blocks[63] = svt_compute_mean_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
+                                                     input_padded_picture_ptr->stride_y,
+                                                     8,
+                                                     8);
         mean_of_8x8_squared_values_blocks[63] =
             svt_compute_mean_square_values_8x8(&(input_padded_picture_ptr->buffer_y[block_index]),
                                                input_padded_picture_ptr->stride_y,
@@ -3037,7 +3060,7 @@ void calculate_input_average_intensity(SequenceControlSet *     scs_ptr,
                  ++block_index_in_height) {
                 for (block_index_in_width = 0; input_picture_ptr->width >> 3 > block_index_in_width;
                      ++block_index_in_width)
-                    mean += compute_mean_8x8(
+                    mean += svt_compute_mean_8x8(
                         &(input_picture_ptr->buffer_y[(block_index_in_width << 3) +
                                                       (block_index_in_height << 3) *
                                                           input_picture_ptr->stride_y]),

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -371,6 +371,7 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
     SET_SSE2(svt_initialize_buffer_32bits, svt_initialize_buffer_32bits_c, svt_initialize_buffer_32bits_sse2_intrin);
     SET_AVX2(svt_nxm_sad_kernel_sub_sampled, svt_nxm_sad_kernel_helper_c, svt_nxm_sad_kernel_sub_sampled_helper_avx2);
     SET_AVX2(svt_nxm_sad_kernel, svt_nxm_sad_kernel_helper_c, svt_nxm_sad_kernel_helper_avx2);
+    SET_SSE2_AVX2(svt_compute_mean_8x8, svt_compute_mean_c, svt_compute_mean8x8_sse2_intrin, svt_compute_mean8x8_avx2_intrin);
     SET_SSE2(svt_compute_mean_square_values_8x8, svt_compute_mean_squared_values_c, svt_compute_mean_of_squared_values8x8_sse2_intrin);
     SET_SSE2(svt_compute_sub_mean_8x8, svt_compute_sub_mean_8x8_c, svt_compute_sub_mean8x8_sse2_intrin);
     SET_SSE2_AVX2(svt_compute_interm_var_four8x8, svt_compute_interm_var_four8x8_c, svt_compute_interm_var_four8x8_helper_sse2, svt_compute_interm_var_four8x8_avx2_intrin);

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -643,7 +643,7 @@ extern "C" {
     RTCD_EXTERN uint32_t(*svt_nxm_sad_kernel_sub_sampled)(const uint8_t *src, uint32_t src_stride, const uint8_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN uint32_t(*svt_nxm_sad_kernel)(const uint8_t *src, uint32_t src_stride, const uint8_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN uint32_t(*nxm_sad_avg_kernel)(uint8_t *src, uint32_t src_stride, uint8_t *ref1, uint32_t ref1_stride, uint8_t *ref2, uint32_t ref2_stride, uint32_t height, uint32_t width);
-    RTCD_EXTERN uint64_t(*compute_mean_8x8)(uint8_t *input_samples, uint32_t input_stride, uint32_t input_area_width, uint32_t input_area_height);
+    RTCD_EXTERN uint64_t(*svt_compute_mean_8x8)(uint8_t *input_samples, uint32_t input_stride, uint32_t input_area_width, uint32_t input_area_height);
     RTCD_EXTERN uint64_t(*svt_compute_mean_square_values_8x8)(uint8_t *input_samples, uint32_t input_stride, uint32_t input_area_width, uint32_t input_area_height);
     RTCD_EXTERN uint64_t(*svt_compute_sub_mean_8x8)(uint8_t* input_samples, uint16_t input_stride);
     uint64_t svt_compute_sub_mean_8x8_c(uint8_t* input_samples, uint16_t input_stride);
@@ -1211,6 +1211,16 @@ extern "C" {
     uint64_t compute_subd_mean_of_squared_values8x8_sse2_intrin(
         uint8_t* input_samples, // input parameter, input samples Ptr
         uint16_t input_stride);
+    uint64_t svt_compute_mean8x8_sse2_intrin(
+        uint8_t* input_samples, // input parameter, input samples Ptr
+        uint32_t input_stride, // input parameter, input stride
+        uint32_t input_area_width, // input parameter, input area width
+        uint32_t input_area_height); // input parameter, input area height
+    uint64_t svt_compute_mean8x8_avx2_intrin(
+        uint8_t *input_samples, // input parameter, input samples Ptr
+        uint32_t input_stride, // input parameter, input stride
+        uint32_t input_area_width, // input parameter, input area width
+        uint32_t input_area_height);
 
     uint64_t svt_compute_sub_mean8x8_sse2_intrin(uint8_t* input_samples, uint16_t input_stride);
 

--- a/test/compute_mean_test.cc
+++ b/test/compute_mean_test.cc
@@ -80,6 +80,39 @@ static const uint8_t* prepare_data_8x8(uint8_t* data, SVTRandom* rnd) {
     }
     return data;
 }
+
+TEST(ComputeMeanTest, run_compute_mean_test) {
+    SVTRandom rnd[2] = {
+        SVTRandom(8, false),  /**< random generator of normal test vector */
+        SVTRandom(0xE0, 0xFF) /**< random generator of boundary test vector */
+    };
+    uint8_t input_data[block_size];
+
+    for (size_t vi = 0; vi < 2; vi++) {
+        for (int i = 0; i < test_times; i++) {
+            // prepare data
+            prepare_data_8x8(input_data, &rnd[vi]);
+
+            // compute mean
+            uint64_t output_sse2_tst =
+                svt_compute_mean8x8_sse2_intrin(input_data, 8, 8, 8);
+            uint64_t output_avx2_tst =
+                svt_compute_mean8x8_avx2_intrin(input_data, 8, 8, 8);
+            uint64_t output_c_ref = svt_compute_mean_c(input_data, 8, 8, 8);
+
+            // compare results
+            ASSERT_EQ(output_sse2_tst, output_c_ref)
+                << test_name[vi] << "[" << i << "] "
+                << "compute mean with asm SSE2 failed!\n"
+                << print_data(input_data, 8, 8);
+            ASSERT_EQ(output_avx2_tst, output_c_ref)
+                << test_name[vi] << "[" << i << "] "
+                << "compute mean with asm AVX2 failed!\n"
+                << print_data(input_data, 8, 8);
+        }
+    }
+}
+
 TEST(ComputeMeanTest, run_compute_mean_squared_values_test) {
     SVTRandom rnd[2] = {
         SVTRandom(8, false),  /**< random generator of normal test vector */


### PR DESCRIPTION
# Description
Restore removed kernels with assigning function pointer(compute_mean_8x8):
 svt_compute_mean_c
 svt_compute_mean8x8_sse2_intrin
 svt_compute_mean8x8_avx2_intrin

The code was not triggered as block_mean_calc_prec is set by default to BLOCK_MEAN_PREC_SUB but if anyone sets it to BLOCK_MEAN_PREC_FULL the code will crash

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
