### PR TITLE
CMake: fix COVERAGE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,10 +196,6 @@ else()
     if(NATIVE)
         check_both_flags_add(-march=native)
     endif()
-    if(COVERAGE)
-        check_both_flags_add(--coverage)
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-    endif()
     if(MINGW)
         check_both_flags_add(-mxsave -fno-asynchronous-unwind-tables)
     else()
@@ -341,6 +337,10 @@ endif()
 
 if(SANITIZER)
     check_both_flags_add(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+endif()
+
+if(COVERAGE)
+    add_clike_and_ld_flags(--coverage)
 endif()
 
 # Add Subdirectories


### PR DESCRIPTION
# Description

`--coverage` was not being applied because it requires it to be in the linker flags as well

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
