### PR TITLE
fix build requiring cmd /c to let terminal survive failures

### DIFF
--- a/Build/windows/build.bat
+++ b/Build/windows/build.bat
@@ -24,6 +24,7 @@ set "GENERATOR="
 :: Default is not building unit tests
 set "unittest=OFF"
 if NOT -%1-==-- call :args %*
+if %errorlevel%==1 exit /b 1
 if exist CMakeCache.txt del /f /s /q CMakeCache.txt 1>nul
 if exist CMakeFiles rmdir /s /q CMakeFiles 1>nul
 if NOT "%GENERATOR%"=="" set GENERATOR=-G"%GENERATOR%"
@@ -41,9 +42,9 @@ if "%shared%"=="ON" (
 if "%unittest%"=="ON" echo Building unit tests
 
 if "%vs%"=="2019" (
-    cmake ../.. %GENERATOR% -A x64 -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders -DBUILD_SHARED_LIBS=%shared% -DBUILD_TESTING=%unittest% %cmake_eflags% || exit 1
+    cmake ../.. %GENERATOR% -A x64 -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders -DBUILD_SHARED_LIBS=%shared% -DBUILD_TESTING=%unittest% %cmake_eflags% || exit /b 1
 ) else (
-    cmake ../.. %GENERATOR% -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders -DBUILD_SHARED_LIBS=%shared% -DBUILD_TESTING=%unittest% %cmake_eflags% || exit 1
+    cmake ../.. %GENERATOR% -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders -DBUILD_SHARED_LIBS=%shared% -DBUILD_TESTING=%unittest% %cmake_eflags% || exit /b 1
 )
 
 if "%build%"=="y" cmake --build . --config %buildtype%
@@ -63,7 +64,7 @@ if -%1-==-- (
         del /f /s /q "%%~i" 1>nul
         rmdir /s /q "%%~i" 1>nul
     )
-    exit
+    exit /b
 ) else if /I "%1"=="2019" (
     echo Generating Visual Studio 2019 solution
     set "GENERATOR=Visual Studio 16 2019"
@@ -150,11 +151,12 @@ if -%1-==-- (
 )  else (
     echo Unknown argument "%1"
     call :help
+    goto :EOF
 )
 goto :args
 
 :help
     echo Batch file to build SVT-AV1 on Windows
     echo Usage: build.bat [2019^|2017^|2015^|clean] [release^|debug] [nobuild] [test] [shared^|static] [c-only] [avx512]
-    exit
+    exit /b 1
 goto :EOF


### PR DESCRIPTION
build.bat causes terminal to terminate during failures. use `exit /b exit_code` instead of exit exit_code` where applicable.