### PR TITLE
CRF: Add --crf option and clarify if running crf or cqp

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -92,7 +92,11 @@ The intra period defines the interval of frames after which you insert an Intra 
 
 `--rc integer` **[Optional]**
 
-This token sets the bitrate control encoding mode [1: Variable Bitrate, 0: Constant QP]. When `--rc` is set to 1, it is best to match the `--lookahead` (lookahead distance described in the next section) parameter to the `--keyint`. When `--rc` is set to 0, a qp value is expected with the use of the `-q` command line option otherwise a default value is assigned (25).
+This token sets the bitrate control encoding mode [1: Variable Bitrate, 0: Constant QP OR Constant Rate Factor]. When `--rc` is set to 1, it is best to match the `--lookahead` (lookahead distance described in the next section) parameter to the `--keyint`.
+
+When `--rc` is set to 0 and `--enable-tpl-la` is set to 0, a qp value is expected with the use of the `-q` or `--qp` command line option.\
+If `--rc` is set to 0 and `--enable-tpl-la` is set to 1, a crf value is expected with the use of the `--crf` command line option.\
+If a qp/crf values is not specified, a default value is assigned (50).
 
 For example, the following command encodes 100 frames of the YUV video sequence into the bin bit stream file. The picture is 1920 luma pixels wide and 1080 pixels high using the `Sample.cfg` configuration. The QP equals 30 and the md5 checksum is not included in the bit stream.
 
@@ -164,9 +168,10 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |
 | --- | --- | --- | --- | --- |
 | **RateControlMode** | --rc | [0 - 2] | 0 | 0 = CQP , 1 = VBR , 2 = CVBR |
-| **QP** | -q | [0 - 63] | 50 | Quantization parameter used when RateControl is set to 0 |
+| **QP** | -q | [0 - 63] | 50 | Quantization parameter used when RateControl is set to 0 and EnableTPLModel is set to 0 |
+| **CRF** | --crf | [0 - 63] | 50 | Rate control parameter used when RateControl is set to 0 and EnableTPLModel is set to 1 |
 | **TargetBitRate** | --tbr | [1 - 4294967] | 7000 | Target bitrate in kilobits per second when RateControlMode is set to 1, or 2 |
-| **UseQpFile** | --use-q-file | [0-1] | 0 | When set to 1, overwrite the picture qp assignment using qp values in QpFile |
+| **UseQpFile** | --use-q-file | [0-1] | 0 | When set to 1, overwrite the picture qp assignment using qp values in QpFile, can be used for initial crf values as well if EnableTPLModel is set to 1, the encoder may still change crf per block |
 | **QpFile** | --qpfile | any string | Null | Path to qp file |
 | **MaxQpAllowed** | --max-qp | [0 - 63] | Null | Maximum (worst) quantizer[0-63] |
 | **MinQpAllowed** | --min-qp | [0 - 63] | Null | Minimum (best) quantizer[0-63] |

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -104,7 +104,7 @@ It should be noted that not all the encoder parameters present in the `Sample.cf
 
 Here are some sample encode command lines
 
-#### 1 pass fixed QP at maximum speed from 24fps yuv 1920x1080 input
+#### 1 pass CRF at maximum speed from 24fps yuv 1920x1080 input
 `SvtAv1EncApp -i input.yuv -w 1920 -h 1080 --fps 24 --rc 0 -q 30 --preset 8 -b output.ivf`
 
 #### 1 pass VBR 10000 Kbps at medium speed from 24fps yuv 1920x1080 input
@@ -328,4 +328,3 @@ Example: 72 core machine:
 18 jobs x --lp 4 --unpin 1
 
 (`-ss`) and (`-unpin 1`) is not a valid combination.(`-unpin`) is overwritten to 0 when (`-ss`) is used.
-

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -219,6 +219,7 @@
 #define HEIGHT_LONG_TOKEN "--height"
 #define NUMBER_OF_PICTURES_LONG_TOKEN "--frames"
 #define QP_LONG_TOKEN "--qp"
+#define CRF_LONG_TOKEN "--crf"
 #define CLASS_12_NEW_TOKEN "--enable-class-12"
 #define LOOP_FILTER_DISABLE_NEW_TOKEN "--disable-dlf"
 #define DISABLE_CFL_NEW_TOKEN "--disable-cfl"
@@ -425,6 +426,11 @@ static void set_cfg_pred_structure(const char *value, EbConfig *cfg) {
 static void set_cfg_qp(const char *value, EbConfig *cfg) {
     cfg->config.qp = strtoul(value, NULL, 0);
 };
+static void set_cfg_crf(const char *value, EbConfig *cfg) {
+    cfg->config.qp = strtoul(value, NULL, 0);
+    cfg->config.rate_control_mode = 0;
+    cfg->config.enable_tpl_la = 1;
+}
 static void set_cfg_use_qp_file(const char *value, EbConfig *cfg) {
     cfg->config.use_qp_file = (EbBool)strtol(value, NULL, 0);
 };
@@ -1000,6 +1006,7 @@ ConfigEntry config_entry_specific[] = {
     {SINGLE_INPUT, TILE_COL_TOKEN, "Number of tile columns to use, log2[0-4]", set_tile_col},
     {SINGLE_INPUT, QP_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
     {SINGLE_INPUT, QP_LONG_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
+    {SINGLE_INPUT, CRF_LONG_TOKEN, "Constant Rate Factor", set_cfg_crf},
 
     {SINGLE_INPUT,
      LOOKAHEAD_NEW_TOKEN,
@@ -1298,6 +1305,7 @@ ConfigEntry config_entry[] = {
      "SceneChangeDetection",
      set_scene_change_detection},
     {SINGLE_INPUT, QP_TOKEN, "QP", set_cfg_qp},
+    {SINGLE_INPUT, CRF_LONG_TOKEN, "CRF", set_cfg_crf},
     {SINGLE_INPUT, USE_QP_FILE_TOKEN, "UseQpFile", set_cfg_use_qp_file},
 #if FTR_ENABLE_FIXED_QINDEX_OFFSETS
     {SINGLE_INPUT, USE_FIXED_QINDEX_OFFSETS_TOKEN, "UseFixedQIndexOffsets", set_cfg_use_fixed_qindex_offsets},
@@ -1511,6 +1519,7 @@ ConfigEntry config_entry[] = {
      "Frame To Be Encoded",
      set_cfg_frames_to_be_encoded},
     {SINGLE_INPUT, QP_LONG_TOKEN, "QP double dash token", set_cfg_qp},
+    {SINGLE_INPUT, CRF_LONG_TOKEN, "CRF double dash token", set_cfg_crf},
     {SINGLE_INPUT, LOOP_FILTER_DISABLE_NEW_TOKEN, "Loop Filter Disable", set_disable_dlf_flag},
 
     {SINGLE_INPUT, DISABLE_CFL_NEW_TOKEN, "Disable CFL", set_disable_cfl_flag},

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -911,7 +911,7 @@ ConfigEntry config_entry_rc[] = {
     // Rate Control
     {SINGLE_INPUT,
      RATE_CONTROL_ENABLE_TOKEN,
-     "Rate control mode(0 = CQP , 1 = VBR , 2 = CVBR)",
+     "Rate control mode(0 = CQP if --enable-tpl-la is set to 0, else CRF , 1 = VBR , 2 = CVBR)",
      set_rate_control_mode},
     {SINGLE_INPUT, TARGET_BIT_RATE_TOKEN, "Target Bitrate (kbps)", set_target_bit_rate},
     {SINGLE_INPUT,
@@ -1006,7 +1006,7 @@ ConfigEntry config_entry_specific[] = {
     {SINGLE_INPUT, TILE_COL_TOKEN, "Number of tile columns to use, log2[0-4]", set_tile_col},
     {SINGLE_INPUT, QP_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
     {SINGLE_INPUT, QP_LONG_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
-    {SINGLE_INPUT, CRF_LONG_TOKEN, "Constant Rate Factor", set_cfg_crf},
+    {SINGLE_INPUT, CRF_LONG_TOKEN, "Constant Rate Factor, equal to --rc 0 --enable-tpl-la 1 --qp x", set_cfg_crf},
 
     {SINGLE_INPUT,
      LOOKAHEAD_NEW_TOKEN,

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -1022,7 +1022,7 @@ void *resource_coordination_kernel(void *input_ptr) {
             if (scs_ptr->static_config.use_qp_file == 1) {
                 pcs_ptr->qp_on_the_fly = EB_TRUE;
                 if (pcs_ptr->input_ptr->qp > MAX_QP_VALUE) {
-                    SVT_LOG("SVT [WARNING]: INPUT QP OUTSIDE OF RANGE\n");
+                    SVT_LOG("SVT [WARNING]: INPUT QP/CRF OUTSIDE OF RANGE\n");
                     pcs_ptr->qp_on_the_fly = EB_FALSE;
                 }
                 pcs_ptr->picture_qp = (uint8_t)pcs_ptr->input_ptr->qp;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3264,7 +3264,7 @@ static void print_lib_params(
     else if (config->rate_control_mode == 2)
         SVT_LOG("\nSVT [config]: RCMode / TargetBitrate (kbps)/ LookaheadDistance / SceneChange\t\t: Constraint VBR / %d / %d / %d ", (int)config->target_bit_rate/1000, config->look_ahead_distance, config->scene_change_detection);
     else
-        SVT_LOG("\nSVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange\t\t\t: CQP / %d / %d / %d ", scs->static_config.qp, config->look_ahead_distance, config->scene_change_detection);
+        SVT_LOG("\nSVT [config]: BRC Mode / %s / LookaheadDistance / SceneChange\t\t\t: %s / %d / %d / %d ", scs->static_config.enable_tpl_la ? "RF" : "QP", scs->static_config.enable_tpl_la ? "CRF" : "CQP", scs->static_config.qp, config->look_ahead_distance, config->scene_change_detection);
 #ifdef DEBUG_BUFFERS
     SVT_LOG("\nSVT [config]: INPUT / OUTPUT \t\t\t\t\t\t\t: %d / %d", scs->input_buffer_fifo_init_count, scs->output_stream_buffer_fifo_init_count);
     SVT_LOG("\nSVT [config]: CPCS / PAREF / REF \t\t\t\t\t\t: %d / %d / %d", scs->picture_control_set_pool_init_count_child, scs->pa_reference_picture_buffer_init_count, scs->reference_picture_buffer_init_count);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2561,7 +2561,7 @@ static EbErrorType verify_settings(
     }
 
     if (config->qp > MAX_QP_VALUE) {
-        SVT_LOG("Error instance %u: QP must be [0 - %d]\n", channel_number + 1, MAX_QP_VALUE);
+        SVT_LOG("Error instance %u: %s must be [0 - %d]\n", channel_number + 1, config->enable_tpl_la ? "CRF" : "QP", MAX_QP_VALUE);
         return_error = EB_ErrorBadParameter;
     }
     if (config->hierarchical_levels > 5) {


### PR DESCRIPTION
# Description

Adds `--crf` option which is equal to `--qp x --rc 0 --enable-tpl-la 1` and update the output shown to show CRF instead of CQP

FFmpeg changes will probably take a bit longer

# Issue
Fixes https://github.com/AOMediaCodec/SVT-AV1/issues/1539
Fixes https://github.com/AOMediaCodec/SVT-AV1/issues/1675
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
